### PR TITLE
Thermometer

### DIFF
--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -43,6 +43,12 @@ module TemplatesHelper
         'call_in_form' => {},
         'letter_sent_form' => {},
         'form_button_text' => 'Add your voice!'
+      },
+      thermometer: {
+        'goal' => 10000,
+        'count' => 0,
+        'autoincrement' => true,
+        'linked_actions' => [1, 2, 3]
       }
     }
     

--- a/app/models/campaign_pages_widget.rb
+++ b/app/models/campaign_pages_widget.rb
@@ -5,8 +5,6 @@ class CampaignPagesWidget < ActiveRecord::Base
   has_one :actionkit_page
 
   validates_presence_of :content, :page_display_order, :campaign_page_id, :widget_type_id
-  # validates that there are not two widgets with exactly same content on the same campaign page
-  validates_uniqueness_of :content, scope: :campaign_page_id
   # validates that the page display order integer is unique across the widgets with that campaign page id
-  validates_uniqueness_of :page_display_order, scope: :campaign_page_id
+  validates_uniqueness_of  :page_display_order, :scope => :campaign_page_id
 end

--- a/app/views/campaign_pages/_form.slim
+++ b/app/views/campaign_pages/_form.slim
@@ -14,7 +14,6 @@
     => f.select(:language,
                 options_from_collection_for_select(Language.all,'language_code', 'language_name'))
 
-
   #widget_location.form-group
 
   div.form-group

--- a/app/views/widgets/thermometer/_display.slim
+++ b/app/views/widgets/thermometer/_display.slim
@@ -1,6 +1,5 @@
-div.progress
-  / get a percentile value of width for the progress bar from count and goal
+div#thermometer_widget.progress
+  / get a percentile value of display width for the progress bar from count and goal
   - @width = 100 * options['count'].to_f / options['goal'].to_f
-  div.progress-bar role="progressbar" aria-valuenow=options['count'] aria-valuemin="0" aria-valuemax=options['goal'] style="width: #{@width}%"
+  div.progress-bar role="progressbar" aria-valuenow=options['count'].to_f aria-valuemin="0" aria-valuemax=options['goal'].to_f style="width: #{@width}%"
     = options['count']
-    

--- a/app/views/widgets/thermometer/_display.slim
+++ b/app/views/widgets/thermometer/_display.slim
@@ -3,3 +3,4 @@ div.progress
   - @width = 100 * options['count'].to_f / options['goal'].to_f
   div.progress-bar role="progressbar" aria-valuenow=options['count'] aria-valuemin="0" aria-valuemax=options['goal'] style="width: #{@width}%"
     = options['count']
+    

--- a/app/views/widgets/thermometer/_display.slim
+++ b/app/views/widgets/thermometer/_display.slim
@@ -1,0 +1,5 @@
+div.progress
+  / get a percentile value of width for the progress bar from count and goal
+  - @width = 100 * options['count'].to_f / options['goal'].to_f
+  div.progress-bar role="progressbar" aria-valuenow=options['count'] aria-valuemin="0" aria-valuemax=options['goal'] style="width: #{@width}%"
+    = options['count']

--- a/app/views/widgets/thermometer/_form.slim
+++ b/app/views/widgets/thermometer/_form.slim
@@ -1,0 +1,12 @@
+#thermometer_widget
+  div.form-group
+    label for='widgets[thermometer][goal]' Goal: 
+    input type='number' name='widgets[thermometer][goal]' value=10000
+  div.form-group
+    label for='widgets[thermometer][goal]' Starting count: 
+    input type='number' name='widgets[thermometer][count]' value=10000
+  div.form-group
+    label for='widgets[thermometer][autoincrement]' Autoincrement goal?
+    input type='checkbox' name='widgets[thermometer][autoincrement]'
+  = hidden_field_tag 'widgets[thermometer][widget_type]', widget_type_id.to_s
+


### PR DESCRIPTION
Adding a pull request for the cherry-picked thermometer widget commits separate from the campaign-pages-to-campaigns branch. Note that on that branch, there are some changes to how the widget forms or displays are constructed, including changes to the thermometer widget. This is a slightly older version of the widget, consistent with the development branch, because there are some changes to the widgets on campaign-pages-to-campaigns that haven't made it to development yet (and so the updated thermometer form wouldn't work on development).