### PR TITLE
update Readme instructions after setting up dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,20 @@ Champaign is a digital campaigning platform built by SumOfUs. It is under develo
   * If you're using a Linux system, you can install Docker natively via: `sudo apt-get install docker` or
   similar for RH-based systems.
 2. Install Docker-Compose (previously fig) [here](http://docs.docker.com/compose/install/)
+3. Install VirtualBox [here](https://www.virtualbox.org/wiki/Downloads)
+  * to check if you already have it, you can type `VBoxManage` at the command line.
 3. Clone the project to your local system using git
-4. Set up and run the project:
+4. Set up the docker VM
+  * run `boot2docker init` then `boot2docker up`. Add the bash variables output by `boot2docker up` to your `~/.bash_profile` or `~/.bash_rc` and reload the terminal.
+  * create a file to hold the web enviroment by running `touch .env.web`.
+5. Setup and start Rails
   * `docker-compose build` This will take a few minutes to download the relevant containers and install
   ruby gems.
-  * Create the database by issuing `docker-compose run web db:create` and do initial database migrations by issuing `docker-compose run web db:migrate`
+  * Copy `secrets.yml` to the `config` directory.
+  * Create the database by issuing `docker-compose run web rake db:create` and load the tables by issuing `docker-compose run web rake db:schema:load`
   * `docker-compose up` This will start the application running in the docker container.
+6. Check that it's running
   * If you are on Linux, you can check that the application is running by visiting localhost with the specified port (at this time,`http://localhost:3000`).
   * If you are on OS X, you will need to retrieve the IP of your Docker vm by running `boot2docker ip`
   on the command line. (On most machines, this seems to be `192.168.59.103`).
-  * On OS X, visit `http://boot2docker_ip:port` (or the equivalent result of `boot2docker ip` with port 3000) in your
-  browser to see the application running.
+  * On OS X, visit `http://boot2docker_ip:port` (or the equivalent result of `boot2docker ip` with port 3000) in your browser to see the application running.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ Champaign is a digital campaigning platform built by SumOfUs. It is under develo
   * If you are on OS X, you will need to retrieve the IP of your Docker vm by running `boot2docker ip`
   on the command line. (On most machines, this seems to be `192.168.59.103`).
   * On OS X, visit `http://boot2docker_ip:port` (or the equivalent result of `boot2docker ip` with port 3000) in your browser to see the application running.
+7. Run the tests
+  * `docker-compose run web rspec spec`


### PR DESCRIPTION
The instructions for setting up the development environment were out of date. This adds some missing steps and fixes some typos.