### PR TITLE
Moves feature spec to its rightful place

### DIFF
--- a/spec/features/campaign_pages_spec.rb
+++ b/spec/features/campaign_pages_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CampaignPagesController, type: :feature do
+describe CampaignPagesController do
   scenario 'Redirect after a user signs the petition' do
     cam_page = create_petition_page
     visit "/campaign_pages/#{cam_page.id}"


### PR DESCRIPTION
Simply moving a feature spec from `specs/controllers` to `spec/features`