### PR TITLE
allow template switching on campaign page form

### DIFF
--- a/app/controllers/campaign_pages_controller.rb
+++ b/app/controllers/campaign_pages_controller.rb
@@ -15,8 +15,9 @@ class CampaignPagesController < ApplicationController
 
   def create
     @campaign_page = CampaignPage.new(@page_params)
-    @campaign_page.compile_html
+    return switch_template(@campaign_page, :new) if params[:switch_template]
     if @campaign_page.save
+      @campaign_page.compile_html
       redirect_to @campaign_page, notice: 'Campaign page updated!'
     else
       @options = create_form_options(@page_params)
@@ -35,7 +36,9 @@ class CampaignPagesController < ApplicationController
   end
 
   def update
-    if @campaign_page.update_attributes @page_params
+    @campaign_page.attributes = @page_params
+    return switch_template(@campaign_page, :edit) if params[:switch_template]
+    if @campaign_page.save
       @campaign_page.compile_html
       redirect_to @campaign_page, notice: 'Campaign page updated!'
     else
@@ -50,6 +53,13 @@ class CampaignPagesController < ApplicationController
   end
 
   private
+
+  def switch_template page, view
+    templater = PageTemplater.new(params[:template])
+    templater.convert @campaign_page
+    @options = create_form_options(@page_params)
+    render view
+  end
 
   def get_campaign_page
     @campaign_page = CampaignPage.find(params[:id])

--- a/app/services/campaign_page_builder.rb
+++ b/app/services/campaign_page_builder.rb
@@ -1,0 +1,27 @@
+class CampaignPageBuilder
+
+  def initialize(page, page_params, params)
+    @page = page
+    @page.attributes = page_params
+    @params = params
+    switch_template if switched_template?
+  end
+
+  def switched_template?
+    @params[:switch_template].present?
+  end
+
+  def switch_template
+    templater = PageTemplater.new(@params[:template])
+    templater.convert @page
+  end
+
+  def save
+    @page.save
+  end
+
+  def campaign_page
+    @page
+  end
+
+end

--- a/app/services/page_templater.rb
+++ b/app/services/page_templater.rb
@@ -1,0 +1,28 @@
+class PageTemplater
+
+  def initialize(template)
+    @template = Template.find(template)
+  end
+
+  def convert page
+    new_widgets = @template.widgets.map{ |w| w.dup }
+    page.widgets = merge_widgets new_widgets, page.widgets
+  end
+
+  private
+
+  def merge_widgets template_widgets, page_widgets
+    # most simple solution: mark old widgets for destruction so that 
+    # they still show up in the form, but as "deleted". The next level
+    # is to rather than replace all page widgets, re-use those that
+    # match the type of those in the template
+    page_widgets.each{ |w| w.mark_for_destruction }
+    return template_widgets + page_widgets
+  end
+
+end
+
+# use cases
+# - on new page, no template selected, empty widgetless form, select a template
+# - on new page, have some widgets (maybe from template), want to switch to a new template
+# - on edit page, have some widgets (maybe from template), want to switch to a new template

--- a/app/services/page_templater.rb
+++ b/app/services/page_templater.rb
@@ -4,7 +4,7 @@ class PageTemplater
     @template = Template.find(template)
   end
 
-  def convert page
+  def convert(page)
     new_widgets = @template.widgets.map{ |w| w.dup }
     page.widgets = merge_widgets new_widgets, page.widgets
   end
@@ -21,8 +21,3 @@ class PageTemplater
   end
 
 end
-
-# use cases
-# - on new page, no template selected, empty widgetless form, select a template
-# - on new page, have some widgets (maybe from template), want to switch to a new template
-# - on edit page, have some widgets (maybe from template), want to switch to a new template

--- a/app/views/campaign_pages/_form.slim
+++ b/app/views/campaign_pages/_form.slim
@@ -1,6 +1,7 @@
 = form_for(@campaign_page, class: 'form-horizontal', html: {multipart: true}) do |f|
   = render 'shared/error_messages', target: @campaign_page
   fieldset
+    = render 'shared/template_picker', builder: f, templates: @options[:templates]
     legend Basic page information
     .form-group
       = f.label :featured, class: 'control-label col-lg-2'

--- a/app/views/shared/_template_picker.slim
+++ b/app/views/shared/_template_picker.slim
@@ -1,0 +1,2 @@
+= select_tag :template, options_for_select(templates.map{|t| [t.template_name, t.id] })
+= builder.submit 'Apply template', name: 'switch_template'

--- a/app/views/shared/_widget_fields.slim
+++ b/app/views/shared/_widget_fields.slim
@@ -1,5 +1,5 @@
 .widget-fields class=widget.snake_type
-  fieldset
+  fieldset class=(builder.object.marked_for_destruction? ? 'hidden-deleted' : '')
     h4
       = widget.class.name.titleize
       div.btn.btn-sm.delete-widget.pull-right Remove Widget
@@ -7,8 +7,9 @@
     .col-lg-2
       = builder.text_field :page_display_order, class: 'form-control'
     = builder.hidden_field :type
-    = builder.hidden_field :_destroy, value: false, class: 'destroy-field'
+    = builder.hidden_field :_destroy, class: 'destroy-field', value: builder.object.marked_for_destruction?
     = builder.fields_for :content do |content_builder|
       = render widget.class.fields, builder: content_builder, widget: widget
 
-  .deleted-info.hidden-irrelevant You have removed a #{widget.class.name.titleize}. This change will be saved when you submit this form. #{link_to 'Click here', '#', class: 'undelete-widget'} to restore the widget.
+  .deleted-info class=(builder.object.marked_for_destruction? ? '' : 'hidden-irrelevant')
+    | You have removed a #{widget.class.name.titleize}. This change will be saved when you submit this form. #{link_to 'Click here', '#', class: 'undelete-widget'} to restore the widget.


### PR DESCRIPTION
Campaigners should be able to apply templates at any point to a page, whether existing or brand new, and have the page figure out how to reuse as many widgets as possible. 