### PR TITLE
Search by widget type

### DIFF
--- a/app/services/search/page_searcher.rb
+++ b/app/services/search/page_searcher.rb
@@ -5,24 +5,6 @@ class Search::PageSearcher
         where("campaign_pages.title ILIKE ? OR widgets.content #>> '{text_body_html}' ILIKE ?", "%#{string}%", "%#{string}%")
   end
 
-  def get_pages_by_widgets(collection, widgets_collection)
-    # get campaign page ids from your collection of widgets
-    page_ids = widgets_collection.pluck(:page_id)
-    # get an intersection of page ids and original ids in the collection
-    array_to_relation(CampaignPage, collection.find(page_ids))
-  end
-
-  def combine_collections(collection1, collection2)
-    # get union of unique values in collection1 and collection2
-    arr = (collection1 | collection2).uniq
-    # map from array back to AR collection
-    array_to_relation(CampaignPage, arr)
-  end
-
-  def array_to_relation(model, arr)
-    model.where(id: arr.map(&:id))
-  end
-
   def initialize(params)
     @queries = params[:search]
     @collection = CampaignPage.all
@@ -47,6 +29,24 @@ class Search::PageSearcher
   end
 
   private
+
+  def get_pages_by_widgets(collection, widgets_collection)
+    # get campaign page ids from your collection of widgets
+    page_ids = widgets_collection.pluck(:page_id)
+    # get an intersection of page ids and original ids in the collection
+    array_to_relation(CampaignPage, collection.find(page_ids))
+  end
+
+  def combine_collections(collection1, collection2)
+    # get union of unique values in collection1 and collection2
+    arr = (collection1 | collection2).uniq
+    # map from array back to AR collection
+    array_to_relation(CampaignPage, arr)
+  end
+
+  def array_to_relation(model, arr)
+    model.where(id: arr.map(&:id))
+  end
 
   def search_by_title(query)
     @collection = Search.full_text_search(@collection, 'title', query)

--- a/app/services/search/page_searcher.rb
+++ b/app/services/search/page_searcher.rb
@@ -29,6 +29,7 @@ class Search::PageSearcher
   end
 
   def search
+    pp 'in search, queries are ', [*@queries].inspect
     [*@queries].each do |search_type, query|
       case search_type
         when 'content_search'
@@ -52,6 +53,7 @@ class Search::PageSearcher
 
   def search_by_text(query)
     text_body_matches = get_pages_by_widgets(@collection, Search::WidgetSearcher.text_widget_search(query))
+    pp 'text body matches', text_body_matches.inspect, text_body_matches.class
     @collection = combine_collections(search_by_title(query), text_body_matches)
   end
 

--- a/app/services/search/page_searcher.rb
+++ b/app/services/search/page_searcher.rb
@@ -29,9 +29,8 @@ class Search::PageSearcher
   end
 
   def search
-    pp 'in search, queries are ', @queries.inspect, @queries.class
-    @queries.each do |search_type, query|
-      case search_type
+    [*@queries].each do |search_type, query|
+      case search_type.to_s
         when 'content_search'
           search_by_text(query)
         when 'tags'
@@ -42,12 +41,12 @@ class Search::PageSearcher
           search_by_campaign(query)
         when 'widget_type'
           search_by_widget_type(query)
-        else
-          pp 'did not match any case in switch'
       end
     end
     @collection
   end
+
+  private
 
   def search_by_title(query)
     @collection = Search.full_text_search(@collection, 'title', query)
@@ -55,7 +54,6 @@ class Search::PageSearcher
 
   def search_by_text(query)
     text_body_matches = get_pages_by_widgets(@collection, Search::WidgetSearcher.text_widget_search(query))
-    pp 'text body matches', text_body_matches.inspect, text_body_matches.class
     @collection = combine_collections(search_by_title(query), text_body_matches)
   end
 

--- a/app/services/search/page_searcher.rb
+++ b/app/services/search/page_searcher.rb
@@ -29,8 +29,8 @@ class Search::PageSearcher
   end
 
   def search
-    pp 'in search, queries are ', [*@queries].inspect
-    [*@queries].each do |search_type, query|
+    pp 'in search, queries are ', @queries.inspect, @queries.class
+    @queries.each do |search_type, query|
       case search_type
         when 'content_search'
           search_by_text(query)
@@ -42,6 +42,8 @@ class Search::PageSearcher
           search_by_campaign(query)
         when 'widget_type'
           search_by_widget_type(query)
+        else
+          pp 'did not match any case in switch'
       end
     end
     @collection

--- a/app/services/search/widget_searcher.rb
+++ b/app/services/search/widget_searcher.rb
@@ -5,4 +5,8 @@ class Search::WidgetSearcher
     Search.full_text_search(TextBodyWidget.all, "content ->> 'text_body_html'", query)
   end
 
+  def self.widget_type_search(query)
+    Widget.where({type: query})
+  end
+
 end

--- a/app/views/campaign_pages/index.slim
+++ b/app/views/campaign_pages/index.slim
@@ -32,16 +32,21 @@
         = label_tag 'search[campaign]', 'Search by campaigns:', class: 'control-label col-lg-2'
         .col-lg-10
           = select_tag 'search[campaign]', options_from_collection_for_select(Campaign.all, 'id', 'campaign_name'),
-                         html_options= {class: 'form-control select2-container', multiple: true}
+                       html_options= {class: 'form-control select2-container', multiple: true}
 
-        = label_tag 'search[language_search]', 'Search by language: ', class: 'control-label col-lg-2'
+        = label_tag 'search[language]', 'Search by language: ', class: 'control-label col-lg-2'
         .col-lg-10
-          = select_tag 'search[language_search]', options_from_collection_for_select(Language.all, 'id', 'language_name'),
+          = select_tag 'search[language]', options_from_collection_for_select(Language.all, 'id', 'language_name'),
                        html_options= {:class => 'form-control select2-container', multiple: true}
 
         = label_tag 'search[tags]', 'Search by tags:', class: 'control-label col-lg-2'
         .col-lg-10
           = select_tag 'search[tags]', options_from_collection_for_select(Tag.all, 'id', 'tag_name'),
+                       html_options= {class: 'form-control select2-container', multiple: true}
+
+        = label_tag 'search[widget_type]', 'Contains widget types:', class: 'control-label col-lg-2'
+        .col-lg-10
+          = select_tag 'search[widget_type]', options_for_select(Widget.classes.map{ |wc| [wc.title, wc.name] }),
                        html_options= {class: 'form-control select2-container', multiple: true}
 
         .col-md-12

--- a/spec/service_objects/search_spec.rb
+++ b/spec/service_objects/search_spec.rb
@@ -2,9 +2,6 @@ require 'rails_helper'
 
 describe 'Search ::' do
 
-  #TODO TOMORROW: I think :params are not specified correctly, and when calling page_searcher.search,
-  #the switch doesn't work properly because it fails to match against the params hash.
-
   let(:test_text) { 'a spectacular test string' }
   let(:language) { build(:language) }
   let!(:matching_widget) { create(:text_body_widget, text_body_html: test_text) }

--- a/spec/service_objects/search_spec.rb
+++ b/spec/service_objects/search_spec.rb
@@ -109,7 +109,7 @@ describe 'Search ::' do
             content_search: test_text,
             tags: [tag.id],
             widget_type: ['PetitionWidget'],
-            language: language
+            language: language.id
           }
         }
       }

--- a/spec/service_objects/search_spec.rb
+++ b/spec/service_objects/search_spec.rb
@@ -2,8 +2,11 @@ require 'rails_helper'
 
 describe 'Search ::' do
 
-  let(:params) { {search: {content_search: test_text} } }
+  #TODO TOMORROW: I think :params are not specified correctly, and when calling page_searcher.search,
+  #the switch doesn't work properly because it fails to match against the params hash.
+
   let(:test_text) { 'a spectacular test string' }
+  let(:params) { {search: {content_search: test_text} } }
   let(:language) { build(:language) }
   let!(:matching_widget) { create(:text_body_widget, text_body_html: test_text) }
   let!(:nonmatching_widget) { create(:text_body_widget, text_body_html: 'a non-matching text body') }

--- a/spec/service_objects/search_spec.rb
+++ b/spec/service_objects/search_spec.rb
@@ -6,7 +6,6 @@ describe 'Search ::' do
   #the switch doesn't work properly because it fails to match against the params hash.
 
   let(:test_text) { 'a spectacular test string' }
-  let(:params) { {search: {content_search: test_text} } }
   let(:language) { build(:language) }
   let!(:matching_widget) { create(:text_body_widget, text_body_html: test_text) }
   let!(:nonmatching_widget) { create(:text_body_widget, text_body_html: 'a non-matching text body') }
@@ -39,8 +38,6 @@ describe 'Search ::' do
       )
     }
 
-    let(:page_searcher) { Search::PageSearcher.new(params) }
-
     subject { Search::PageSearcher }
 
     describe '._search' do
@@ -50,47 +47,37 @@ describe 'Search ::' do
     end
 
     context 'search by text content' do
+      let(:text_searcher) { Search::PageSearcher.new({search: {content_search: test_text} }) }
       it 'gets pages that match by title or by text body if the text search method is called' do
-        expect(page_searcher.search).to match_array([title_match_page, body_match_page])
-      end
-
-      it 'only gets pages that match by title if only title match method is called' do
-        expect(page_searcher.search_by_title(test_text)).to eq([title_match_page])
+        expect(text_searcher.search).to match_array([title_match_page, body_match_page])
       end
     end
 
     context 'search by tag' do
+      let(:tag_searcher) { Search::PageSearcher.new({search: {tags: [tag.id]} }) }
       it 'searches for a page based on the tags on that page' do
-        expect(page_searcher.search_by_tags(tag.id)).to eq([body_match_page])
-      end
-
-      it 'returns an empty collection when no page with the existing tags exists' do
-        expect(page_searcher.search_by_tags(tag.id+1)).to eq([])
+        expect(tag_searcher.search).to eq([body_match_page])
       end
     end
 
     context 'search by campaign' do
+      let(:search_by_campaign) { Search::PageSearcher.new({search: {campaign: [campaign.id]} }) }
       it 'searches for a page based on the campaign it belongs to' do
-        expect(page_searcher.search_by_campaign(campaign.id)).to eq([title_match_page])
-      end
-
-      it 'returns an empty collection when no pages belong to that campaign' do
-        expect(page_searcher.search_by_campaign(campaign.id+999)).to eq([])
+        expect(search_by_campaign.search).to eq([title_match_page])
       end
     end
 
     context 'search by language' do
+      let(:language_searcher) { Search::PageSearcher.new({search: {language: [language.id]} }) }
       it 'finds only the page that corresponds to the specified language' do
-        expect(page_searcher.search_by_language(language.id)).to eq([title_match_page])
-      end
-      it 'returns an empty collection when no pages correspond to the language' do
-        expect(page_searcher.search_by_language(language.id+999)).to eq([])
+        expect(language_searcher.search).to eq([title_match_page])
       end
     end
 
     context 'search by widget' do
+      let(:search_by_widget) { Search::PageSearcher.new({search: {widget_type: ['PetitionWidget']} }) }
       it 'finds the page that corresponds to the desired widget type' do
-        expect(page_searcher.search_by_widget_type(['PetitionWidget'])).to eq([petition_page])
+        expect(search_by_widget.search).to eq([petition_page])
       end
     end
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -34,6 +34,18 @@ FactoryGirl.define do
     type "PetitionWidget"
   end
 
+  factory :thermometer_widget do
+    content {
+      {
+        goal: 10000,
+        count: 100,
+        autoincrement: true
+      }
+    }
+    page_display_order
+    type "ThermometerWidget"
+  end
+
   factory :user do
     email
     password { Faker::Internet.password }


### PR DESCRIPTION
Functionality to search by widget type works fine in development. Specs fail, though, assumingly due to the fact that i'm passing params wrong and when I call page_searcher.search with the params, the switch just goes through because it fails to match the cases with the search parameters.