### PR TITLE
Validation messages, template picker

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -103,3 +103,7 @@ form.template-form {
   background: #f3f3f3;
   cursor: pointer;
 }
+
+.space-left {
+  margin-left: 10px;
+}

--- a/app/controllers/campaign_pages_controller.rb
+++ b/app/controllers/campaign_pages_controller.rb
@@ -103,6 +103,7 @@ class CampaignPagesController < ApplicationController
       :template_id,
       :campaign_id,
       :language_id,
+      :liquid_layout_id,
       {:tag_ids => []} )
   end
 end

--- a/app/controllers/campaign_pages_controller.rb
+++ b/app/controllers/campaign_pages_controller.rb
@@ -72,9 +72,12 @@ class CampaignPagesController < ApplicationController
 
   def update
     respond_to do |format|
-      format.json do
-        @campaign_page.update( permitted_params )
-        render json: @campaign_page
+      if @campaign_page.update(permitted_params)
+        format.html { redirect_to edit_campaign_page_path(@campaign_page), notice: 'Page was successfully updated.' }
+        format.json { render json: @campaign_page, status: :ok }
+      else
+        format.html { render :edit }
+        format.json { render json: @liquid_layout.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/plugins/thermometers_controller.rb
+++ b/app/controllers/plugins/thermometers_controller.rb
@@ -5,9 +5,9 @@ class Plugins::ThermometersController < ApplicationController
 
     respond_to do |format|
       if plugin.update(permitted_params)
-        format.html { render partial: 'form', locals: {plugin: plugin, success: true } }
+        format.html { render partial: 'form', locals: { plugin: plugin, success: true } }
       else
-        format.html { render partial: 'form', locals: {plugin: plugin}, status: :unprocessable_entity  }
+        format.html { render partial: 'form', locals: { plugin: plugin}, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/plugins/thermometers_controller.rb
+++ b/app/controllers/plugins/thermometers_controller.rb
@@ -5,7 +5,7 @@ class Plugins::ThermometersController < ApplicationController
 
     respond_to do |format|
       if plugin.update(permitted_params)
-        format.html { render partial: 'form', locals: {plugin: plugin} }
+        format.html { render partial: 'form', locals: {plugin: plugin, success: true } }
       else
         format.html { render partial: 'form', locals: {plugin: plugin}, status: :unprocessable_entity  }
       end

--- a/app/models/plugins/thermometer.rb
+++ b/app/models/plugins/thermometer.rb
@@ -4,7 +4,7 @@ class Plugins::Thermometer < ActiveRecord::Base
   DEFAULTS = { offset: 0, goal: 1000 }
 
   validates :goal, :offset, presence: true
-  validates :goal, :offset, numericality: true
+  validates :goal, :offset, numericality: { greater_than_or_equal_to: 0 }
 
   def get_current
     count = campaign_page.actions.count

--- a/app/views/campaign_pages/edit.slim
+++ b/app/views/campaign_pages/edit.slim
@@ -1,5 +1,7 @@
-= form_for @campaign_page, remote: true do |f|
+= form_for @campaign_page do |f|
   = f.hidden_field :content
+
+  = render 'shared/error_messages', target: @campaign_page
 
   .page-title.form-group
     = f.text_field :title

--- a/app/views/campaign_pages/edit.slim
+++ b/app/views/campaign_pages/edit.slim
@@ -10,6 +10,12 @@
   .form-group
     = render 'shared/quill_editor'
 
+  .form-group
+    = f.label :liquid_layout_id, t('.layout_select')
+    = f.select :liquid_layout_id,
+      LiquidLayout.all.map{|ll| [ll.title, ll.id] },
+      {include_blank: 'Default'},
+      class: "space-left"
 
   .form-group
     = submit_tag(t('common.save'), class: 'btn btn-default btn-primary')

--- a/app/views/campaign_pages/edit.slim
+++ b/app/views/campaign_pages/edit.slim
@@ -12,7 +12,8 @@
 
 
   .form-group
-    = submit_tag(t('common.save'), class: 'btn btn-default')
+    = submit_tag(t('common.save'), class: 'btn btn-default btn-primary')
+    = link_to t('.view'), @campaign_page, class: 'btn btn-default space-left'
 
 - if @campaign_page.images.any?
   .component.campaign-images

--- a/app/views/campaign_pages/index.slim
+++ b/app/views/campaign_pages/index.slim
@@ -12,7 +12,7 @@
       tbody
         - @campaign_pages.each do |page|
           tr
-            td = page.title
+            td = link_to page.title, page
             td
               span class=(page.featured? ? 'tick' : 'cross')
             td

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -37,7 +37,7 @@ html
     .container
       #trum
       - if flash[:error]
-        div.alert.alert-dismissible.alert-error
+        div.alert.alert-dismissible.alert-danger
           button type='button' class='close' data-dismiss='alert' x
           strong #{flash[:error]}
       - if flash[:notice]

--- a/app/views/plugins/thermometers/_form.slim
+++ b/app/views/plugins/thermometers/_form.slim
@@ -1,12 +1,6 @@
 = form_for plugin, url: plugins_thermometer_path(plugin), remote: true, html: {class: 'plugin-settings'} do |f|
-  - if plugin.errors.any?
-    .errors-description
-      h3 = pluralize(plugin.errors.count, "error")
-         prohibited this plugin from being saved:
-
-      ul
-        - plugin.errors.full_messages.each do |message|
-          li = message
+  = render "shared/error_messages", target: plugin
+  = render "shared/success_message", success: (defined?(success) || false)
 
   div.form-group
     = f.label :title, "Title"

--- a/app/views/shared/_error_messages.slim
+++ b/app/views/shared/_error_messages.slim
@@ -1,6 +1,8 @@
 - if target.errors.any?
-  div.has-error.help-block
-    | We couldn't save your submission because of the following errors:
-    ul
-      - target.errors.full_messages.each do |msg|
-        li= msg
+  div.alert.alert-dismissible.alert-danger
+    button type='button' class='close' data-dismiss='alert' x
+    strong 
+      | We couldn't save your submission because of the following #{pluralize(target.errors.count, "error")}:
+      ul
+        - target.errors.full_messages.each do |msg|
+          li= msg

--- a/app/views/shared/_success_message.slim
+++ b/app/views/shared/_success_message.slim
@@ -1,0 +1,5 @@
+- if success
+  - message ||= t('common.successful_update')
+  div.alert.alert-dismissible.alert-success
+    button type='button' class='close' data-dismiss='alert' x
+    strong #{message}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
     edit: 'Edit'
     save: 'Save'
     lets_go: "Let's Go!"
+    successful_update: "Your changes have been saved!"
 
   menu:
     campaign_pages: 'Campaign Pages'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,9 @@ en:
     new:
       title: "Let's Get Started!"
       sub:   "First, give your Campaign Page a unique and catchy title"
+    edit:
+      layout_select: "Pick the Layout"
+      show: "View the page"
 
   campaigns:
     index:

--- a/db/migrate/20150812172556_remove_language_id_null_constraint.rb
+++ b/db/migrate/20150812172556_remove_language_id_null_constraint.rb
@@ -1,0 +1,5 @@
+class RemoveLanguageIdNullConstraint < ActiveRecord::Migration
+  def change
+    change_column :campaign_pages, :language_id, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150812131853) do
+ActiveRecord::Schema.define(version: 20150812172556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,7 +53,7 @@ ActiveRecord::Schema.define(version: 20150812131853) do
   add_index "actions", ["campaign_page_id"], name: "index_actions_on_campaign_page_id", using: :btree
 
   create_table "campaign_pages", force: :cascade do |t|
-    t.integer  "language_id",                          null: false
+    t.integer  "language_id"
     t.integer  "campaign_id"
     t.string   "title",                                null: false
     t.string   "slug",                                 null: false


### PR DESCRIPTION
does
- show validation errors on campaign page and thermometer plugin
- show success messages for campaign page and thermometer plugin
- adds a dropdown to pick the template for the page
- adds some view links to make clicking around easier

does not 
- show validation errors / success on action plugin