### PR TITLE
Toggle feature and refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'paper_trail'
 
 gem 'rmagick' # rmagick for image processing
 gem 'paperclip'
-
+gem 'action_parameter'
 # We need to use render inside a model in order to compile HTML for display
 # in champaign-flute.
 gem 'render_anywhere', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,6 @@ gem 'jquery-rails'
 gem 'bootstrap-sass', '~> 3.3.5'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
-gem 'react-rails'
-gem 'browserify-rails'
 gem 'select2-rails'
 gem 'dropzonejs-rails'
 gem 'codemirror-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -37,10 +37,6 @@ gem 'rails_admin'
 # Use Paper Trail for containing a full history of our edits.
 gem 'paper_trail'
 
-# Use ActionParameter as a way to extract model-based mass-assignment into
-# a class that Does One Thing (in this case, filter mass assignments) in the
-# Rails 4 style. https://github.com/edelpero/action_parameter
-gem 'action_parameter'
 gem 'rmagick' # rmagick for image processing
 gem 'paperclip'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,6 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    action_parameter (0.0.3)
-      actionpack (>= 3.0.0)
-      activesupport (>= 3.0.0)
     actionmailer (4.2.3)
       actionpack (= 4.2.3)
       actionview (= 4.2.3)
@@ -301,7 +298,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  action_parameter
   aws-sdk (~> 2)
   bootstrap-sass (~> 3.3.5)
   browser

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    action_parameter (0.0.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     actionmailer (4.2.3)
       actionpack (= 4.2.3)
       actionview (= 4.2.3)
@@ -298,6 +301,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  action_parameter
   aws-sdk (~> 2)
   bootstrap-sass (~> 3.3.5)
   browser

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,10 +50,6 @@ GEM
       jmespath (~> 1.0)
     aws-sdk-resources (2.1.8)
       aws-sdk-core (= 2.1.8)
-    babel-source (5.8.0)
-    babel-transpiler (0.7.0)
-      babel-source (>= 4.0, < 6)
-      execjs (~> 2.0)
     bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -61,9 +57,6 @@ GEM
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
     browser (0.9.1)
-    browserify-rails (1.2.0)
-      railties (>= 4.0.0, < 5.0)
-      sprockets (> 3.0.2)
     builder (3.2.2)
     bunny (1.7.0)
       amq-protocol (>= 1.9.2)
@@ -89,7 +82,6 @@ GEM
       execjs
     coffee-script-source (1.9.1.1)
     columnize (0.9.0)
-    connection_pool (2.2.0)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
     devise (3.5.1)
@@ -230,13 +222,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
-    react-rails (1.1.0)
-      babel-transpiler (>= 0.7.0)
-      coffee-script-source (~> 1.8)
-      connection_pool
-      execjs
-      rails (>= 3.2)
-      tilt
     remotipart (1.2.1)
     render_anywhere (0.0.11)
       rails (>= 3.0.7)
@@ -320,7 +305,6 @@ DEPENDENCIES
   aws-sdk (~> 2)
   bootstrap-sass (~> 3.3.5)
   browser
-  browserify-rails
   bunny
   byebug
   capybara
@@ -342,7 +326,6 @@ DEPENDENCIES
   pg
   rails (= 4.2.3)
   rails_admin
-  react-rails
   render_anywhere
   rmagick
   rspec-rails (~> 3.3)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,6 @@
 //= require jquery_ujs
 //= require pub_sub
 
-//= require components
 //= require bootstrap-sprockets
 //= require select2
 //= require dropzone

--- a/app/assets/javascripts/campaign_page.js
+++ b/app/assets/javascripts/campaign_page.js
@@ -47,9 +47,34 @@
   }
 
   var configureToggle = function() {
-    console.log("toggle");
+    var $stateInput = $('.plugin-active-field');
 
-  }
+    var handleClick = function(e){
+      e.preventDefault();
+      $('form.plugin-toggle').submit();
+      $('.toggle-button').removeClass('btn-success');
+      $(this).addClass('btn-success');
+    };
+
+    var handleSuccess = function(e,data){
+      console.log('succes', data);
+    };
+
+    var handleError = function(xhr, status, error){
+      console.log('error', status, error);
+    };
+
+    var updateState = function(){
+      var state = !JSON.parse($stateInput.val());
+      $stateInput.val(state);
+    };
+
+    $('.toggle-button').on('click', handleClick);
+
+    $('form.plugin-toggle').on('ajax:before', updateState);
+    $('form.plugin-toggle').on('ajax:success', handleSuccess);
+    $('form.plugin-toggle').on('ajax:error', handleError);
+  };
 
   var configureSelect2 = function(){
     $('.select2-container').select2({});

--- a/app/assets/javascripts/campaign_page.js
+++ b/app/assets/javascripts/campaign_page.js
@@ -42,6 +42,11 @@
     $('form.edit_campaign_page').on('ajax:before', updateContentBeforeSave);
   }
 
+  var configureToggle = function() {
+    console.log("toggle");
+
+  }
+
   var configureSelect2 = function(){
     $('.select2-container').select2({});
   }
@@ -50,6 +55,7 @@
     configureDropZone();
     configureQuillEditor();
     configureSelect2();
+    configureToggle();
   };
 
   $.subscribe("campaign_page:has_loaded", initialize);

--- a/app/assets/javascripts/campaign_page.js
+++ b/app/assets/javascripts/campaign_page.js
@@ -21,6 +21,10 @@
   }
 
   var configureQuillEditor = function() {
+    if($('#editor').length === 0){
+      return false;
+    }
+
     var quillConfig = {
       theme: 'snow',
       modules: {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,10 +6,10 @@
 @import "interactive";
 @import "widget";
 @import "common";
+@import "campaign_pages";
 @import "dropzone";
 @import "codemirror";
 @import "codemirror/themes/3024-night";
-
 
 /* Decide what's needed below, and organise with files */
 #petition_form {

--- a/app/assets/stylesheets/campaign_pages.scss
+++ b/app/assets/stylesheets/campaign_pages.scss
@@ -1,0 +1,13 @@
+.page-header.campaign-pages {
+  margin-top: 10px;
+
+  h2 {
+    margin-top: 10px;
+  }
+}
+
+.campaign-pages {
+  .nav-tabs {
+    margin-bottom: 20px;
+  }
+}

--- a/app/controllers/plugins/actions_controller.rb
+++ b/app/controllers/plugins/actions_controller.rb
@@ -15,6 +15,6 @@ class Plugins::ActionsController < ApplicationController
 
   def permitted_params
     params.require(:plugins_action).
-      permit(:form_id, :description)
+      permit(:form_id, :description, :active)
   end
 end

--- a/app/controllers/plugins/actions_controller.rb
+++ b/app/controllers/plugins/actions_controller.rb
@@ -4,13 +4,18 @@ class Plugins::ActionsController < ApplicationController
   def update
     action = Plugins::Action.find(params[:id])
     action.update_attributes(permitted_params)
-    render json: 'ok'
+
+    respond_to do |format|
+      format.json { render json: action, status: :ok }
+    end
   end
 
   private
 
   def find_form
-    @form ||= Form.find params[:plugins_action][:form_id]
+    if params[:plugins_action][:form_id]
+      Form.find params[:plugins_action][:form_id]
+    end
   end
 
   def permitted_params

--- a/app/controllers/plugins/thermometers_controller.rb
+++ b/app/controllers/plugins/thermometers_controller.rb
@@ -16,6 +16,6 @@ class Plugins::ThermometersController < ApplicationController
 
   def permitted_params
     params.require(:plugins_thermometer).
-      permit(:title, :offset, :goal)
+      permit(:title, :offset, :goal, :active)
   end
 end

--- a/app/controllers/plugins_controller.rb
+++ b/app/controllers/plugins_controller.rb
@@ -1,0 +1,13 @@
+class PluginsController < ApplicationController
+  before_filter :find_campaign_page
+
+  def show
+    @plugin = Plugins.find_for(@campaign_page.id, params[:id])
+  end
+
+  private
+
+  def find_campaign_page
+    @campaign_page = CampaignPage.find params[:campaign_page_id]
+  end
+end

--- a/app/helpers/campaign_pages_helper.rb
+++ b/app/helpers/campaign_pages_helper.rb
@@ -6,4 +6,11 @@ module CampaignPagesHelper
       link_to text, path
     end
   end
+
+  def toggle_switch(state, active, label)
+    klass = (active == state ? 'btn-success' : '')
+    klass += " btn toggle-button btn-default"
+
+    content_tag :a, label, class: klass
+  end
 end

--- a/app/helpers/campaign_pages_helper.rb
+++ b/app/helpers/campaign_pages_helper.rb
@@ -1,2 +1,9 @@
 module CampaignPagesHelper
+  def campaign_page_nav_item(text, path)
+    klass = current_page?(path) ? 'active' : nil
+
+    content_tag :li, class: klass do
+      link_to text, path
+    end
+  end
 end

--- a/app/models/plugins.rb
+++ b/app/models/plugins.rb
@@ -27,5 +27,13 @@ module Plugins
 
       { 'plugins' => plugins_data }
     end
+
+    def names
+      registered.map{|plugin| plugin.to_s.underscore.split('/').last }
+    end
+
+    def find_for(campaign_page_id, plugin_name)
+      Plugins.const_get(plugin_name.camelize).find_by(campaign_page_id: campaign_page_id)
+    end
   end
 end

--- a/app/views/campaign_pages/_header.html.slim
+++ b/app/views/campaign_pages/_header.html.slim
@@ -1,0 +1,17 @@
+- content_for :page_header do
+  .page-header.campaign-pages
+    .container
+      .row
+        .col-md-12
+          h2 #{link_to 'Campaign Pages', campaign_pages_path} / #{ link_to('foo', '#')}
+
+.row.campaign-pages
+  .col-md-12
+
+    ul.nav.nav-tabs
+      = campaign_page_nav_item('Content', edit_campaign_page_path(@campaign_page) )
+      = campaign_page_nav_item('Plugins', campaign_page_plugin_path(@campaign_page, 'action') )
+      li = link_to 'Actions', '#'
+      li = link_to 'Stats', '#'
+
+

--- a/app/views/campaign_pages/_header.html.slim
+++ b/app/views/campaign_pages/_header.html.slim
@@ -3,7 +3,7 @@
     .container
       .row
         .col-md-12
-          h2 #{link_to 'Campaign Pages', campaign_pages_path} / #{ link_to('foo', '#')}
+          h2 #{link_to 'Campaign Pages', campaign_pages_path} / #{ link_to(@campaign_page.title, '#')}
 
 .row.campaign-pages
   .col-md-12

--- a/app/views/campaign_pages/edit.slim
+++ b/app/views/campaign_pages/edit.slim
@@ -1,49 +1,63 @@
-= form_for @campaign_page, remote: true do |f|
-  = f.hidden_field :content
+= render 'campaign_pages/header'
 
-  = render 'shared/error_messages', target: @campaign_page
+.row
+  .col-md-12
+    = form_for @campaign_page, remote: true do |f|
+      = f.hidden_field :content
 
-  .page-title.form-group
-    = f.text_field :title
+      = render 'shared/error_messages', target: @campaign_page
 
-  .form-group
-    = render 'shared/quill_editor'
+      .page-title.form-group
+        = f.text_field :title
 
-  .form-group
-    = f.label :liquid_layout_id, t('.layout_select')
-    = f.select :liquid_layout_id,
-      LiquidLayout.all.map{|ll| [ll.title, ll.id] },
-        { include_blank: 'Default' },
-        class: "space-left form-control"
+      .form-group
+        = render 'shared/quill_editor'
 
-  .form-group
-    = f.label  :tag_ids, t('.tags')
-    = f.select :tag_ids, options_from_collection_for_select(Tag.all, 'id', 'tag_name', @campaign_page.tag_ids), {}, html_options= {class: 'form-control select2-container', multiple: true}
+      .form-group
+        = f.label :liquid_layout_id, t('.layout_select')
+        = f.select :liquid_layout_id,
+          LiquidLayout.all.map{|ll| [ll.title, ll.id] },
+            { include_blank: 'Default' },
+            class: "space-left form-control"
 
-  .btn-toolbar
-    = submit_tag t('common.save'), class: 'btn btn-default', 'data-disable-with' => t('common.saving')
-    = link_to t('.view'), @campaign_page, class: 'btn btn-info', target: '_blank'
+      .form-group
+        = f.label  :tag_ids, t('.tags')
+        = f.select :tag_ids, options_from_collection_for_select(Tag.all, 'id', 'tag_name', @campaign_page.tag_ids), {}, html_options= {class: 'form-control select2-container', multiple: true}
 
-section
-  h3 = t('.photos')
-  - if @campaign_page.images.any?
-    .component.campaign-images
-      - @campaign_page.images.each do |image|
-        = render partial: 'images/thumbnail', locals: { image: image }
+      .btn-toolbar
+        = submit_tag t('common.save'), class: 'btn btn-default', 'data-disable-with' => t('common.saving')
+        = link_to t('.view'), @campaign_page, class: 'btn btn-info', target: '_blank'
 
-  .component
-    = form_tag campaign_page_images_url(@campaign_page), id: 'dropzone', class: 'dropzone' do
+    section
+      h3 = t('.photos')
+      - if @campaign_page.images.any?
+        .component.campaign-images
+          - @campaign_page.images.each do |image|
+            = render partial: 'images/thumbnail', locals: { image: image }
 
-section
-  h3 = t('.extras')
+      .component
+        = form_tag campaign_page_images_url(@campaign_page), id: 'dropzone', class: 'dropzone' do
 
-  - Plugins.registered.each do |plugin|
-    - plugin_record = plugin.find_by_campaign_page_id(@campaign_page.id)
+    h3 = t('.extras')
 
-    - if plugin_record
-      div.component.main
-        h4 = plugin_record.name
-        = render partial: "#{plugin.to_s.underscore.pluralize}/form", locals: { plugin: plugin_record, page: @campaign_page }
+.row
+  .col-md-3
+    .navbar-default.sidebar
+    ul.nav.nav-stacked
+      - Plugins.registered.each do |plugin|
+        - plugin_record = plugin.find_by_campaign_page_id(@campaign_page.id)
+        li = link_to plugin_record.name, '#'
+
+
+
+  .col-md-9
+    - Plugins.registered.each do |plugin|
+      - plugin_record = plugin.find_by_campaign_page_id(@campaign_page.id)
+
+      - if plugin_record
+        div.component.main style="display:nones;"
+          h4 Settings for #{plugin_record.name}
+          = render partial: "#{plugin.to_s.underscore.pluralize}/form", locals: { plugin: plugin_record, page: @campaign_page }
 
 
 

--- a/app/views/campaign_pages/edit.slim
+++ b/app/views/campaign_pages/edit.slim
@@ -38,29 +38,6 @@
       .component
         = form_tag campaign_page_images_url(@campaign_page), id: 'dropzone', class: 'dropzone' do
 
-    h3 = t('.extras')
-
-.row
-  .col-md-3
-    .navbar-default.sidebar
-    ul.nav.nav-stacked
-      - Plugins.registered.each do |plugin|
-        - plugin_record = plugin.find_by_campaign_page_id(@campaign_page.id)
-        li = link_to plugin_record.name, '#'
-
-
-
-  .col-md-9
-    - Plugins.registered.each do |plugin|
-      - plugin_record = plugin.find_by_campaign_page_id(@campaign_page.id)
-
-      - if plugin_record
-        div.component.main style="display:nones;"
-          h4 Settings for #{plugin_record.name}
-          = render partial: "#{plugin.to_s.underscore.pluralize}/form", locals: { plugin: plugin_record, page: @campaign_page }
-
-
-
 javascript:
   $.publish("campaign_page:has_loaded");
 

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -34,6 +34,9 @@ html
                 li= link_to t('menu.login'), new_user_session_path
                 li= link_to t('menu.sign_up'), new_user_registration_path
                 li= link_to t('menu.sign_google'), user_omniauth_authorize_path(:google_oauth2)
+
+    = yield :page_header
+
     .container
       #trum
       - if flash[:error]

--- a/app/views/plugins/actions/_form.slim
+++ b/app/views/plugins/actions/_form.slim
@@ -1,8 +1,4 @@
-= form_for plugin, url: plugins_action_path(plugin), remote: true, html: { class: 'plugin-toggle' }  do |f|
-  .form-group.plugin-toggle
-    .btn-group
-      a.toggle-button.btn.btn-default data-state=1 On
-      a.toggle-button.btn.btn-default data-state=0 Off
+= render partial: 'plugins/shared/toggle_form', locals: { plugin: plugin, path: plugins_action_path(plugin) }
 
 = form_for plugin, url: plugins_action_path(plugin), remote: true  do |f|
   .form-group

--- a/app/views/plugins/actions/_form.slim
+++ b/app/views/plugins/actions/_form.slim
@@ -1,15 +1,20 @@
-= form_for plugin, url: plugins_action_path(plugin), remote: true  do |f|
 
-  div.form-group
+= form_for plugin, url: plugins_action_page(plugin), remote: true, html: { class: 'plugin-toggle }  do |f|
+  .form-group.plugin-toggle
+    .btn-group
+      a.toggle-button.btn.btn-default data-state=1 On
+      a.toggle-button.btn.btn-default data-state=0 Off
+
+= form_for plugin, url: plugins_action_path(plugin), remote: true  do |f|
+  .form-group
     = f.label :form, "Choose a form"
     = f.select :form_id, Form.all.map{ |form| [form.title, form.id] }, {include_blank: true}, {class: 'form-control'}
 
 
-  div.form-group
+  .form-group
     = f.label :description, "Description"
     = f.text_area :description, class: 'form-control'
 
-  div.form-group
+  .form-group
     = submit_tag t('common.save'), class: 'btn btn-default', 'data-disable-with' => t('common.saving')
-
 

--- a/app/views/plugins/actions/_form.slim
+++ b/app/views/plugins/actions/_form.slim
@@ -1,5 +1,5 @@
 
-= form_for plugin, url: plugins_action_page(plugin), remote: true, html: { class: 'plugin-toggle }  do |f|
+= form_for plugin, url: plugins_action_path(plugin), remote: true, html: { class: 'plugin-toggle' }  do |f|
   .form-group.plugin-toggle
     .btn-group
       a.toggle-button.btn.btn-default data-state=1 On

--- a/app/views/plugins/actions/_form.slim
+++ b/app/views/plugins/actions/_form.slim
@@ -1,4 +1,3 @@
-
 = form_for plugin, url: plugins_action_path(plugin), remote: true, html: { class: 'plugin-toggle' }  do |f|
   .form-group.plugin-toggle
     .btn-group

--- a/app/views/plugins/shared/_toggle_form.html.slim
+++ b/app/views/plugins/shared/_toggle_form.html.slim
@@ -1,0 +1,8 @@
+= form_for plugin, url: path, remote: true, html: { class: 'plugin-toggle' }  do |f|
+  = f.hidden_field :active, class: 'plugin-active-field'
+  .form-group.plugin-toggle
+    .btn-group
+      = toggle_switch true, plugin.active?, 'On'
+      = toggle_switch false, plugin.active?, 'Off'
+
+

--- a/app/views/plugins/show.html.slim
+++ b/app/views/plugins/show.html.slim
@@ -2,9 +2,9 @@
 
 .row
   .col-md-2
-    ul.nav.nav-stacked
+    ul.nav.nav-pills.nav-stacked
       - Plugins.names.each do |plugin|
-        li = link_to plugin.capitalize, campaign_page_plugin_path(@campaign_page, plugin)
+        = campaign_page_nav_item(plugin.capitalize,  campaign_page_plugin_path(@campaign_page, plugin))
 
 
   .col-md-10

--- a/app/views/plugins/show.html.slim
+++ b/app/views/plugins/show.html.slim
@@ -1,0 +1,17 @@
+= render 'campaign_pages/header'
+
+.row
+  .col-md-2
+    ul.nav.nav-stacked
+      - Plugins.names.each do |plugin|
+        li = link_to plugin.capitalize, campaign_page_plugin_path(@campaign_page, plugin)
+
+
+  .col-md-10
+    h4 Settings for #{@plugin.name}
+    = render partial: "#{@plugin.class.to_s.underscore.pluralize}/form", locals: { plugin: @plugin, page: @campaign_page }
+
+javascript:
+  $.publish("campaign_page:has_loaded");
+
+

--- a/app/views/plugins/templates/main.liquid
+++ b/app/views/plugins/templates/main.liquid
@@ -12,7 +12,9 @@
          {% include 'photos' %}
         </div>
 
-        {% include 'thermometer' %}
+        {% if plugins.thermometer.active %}
+          {% include 'thermometer' %}
+        {% endif %}
 
         <!-- DO NOT INSERT COMPONENTS BEYOND HERE -->
         <!-- MAIN CONTENT HERE -->
@@ -22,7 +24,10 @@
     </div>
 
     <div class="col-md-4">
+      {% if plugins.action.active %}
         {% include 'action' %}
+      {% endif %}
     </div>
   </div>
 </div>
+

--- a/app/views/plugins/thermometers/_form.slim
+++ b/app/views/plugins/thermometers/_form.slim
@@ -18,4 +18,3 @@
   .form-group
     = submit_tag t('common.save'), class: 'btn btn-default', 'data-disable-with' => t('common.saving')
 
-

--- a/app/views/plugins/thermometers/_form.slim
+++ b/app/views/plugins/thermometers/_form.slim
@@ -1,19 +1,21 @@
+= render partial: 'plugins/shared/toggle_form', locals: { plugin: plugin, path: plugins_thermometer_path(plugin) }
+
 = form_for plugin, url: plugins_thermometer_path(plugin), remote: true, html: {class: 'plugin-settings'} do |f|
   = render "shared/error_messages", target: plugin
   = render "shared/success_message", success: (defined?(success) || false)
 
-  div.form-group
+  .form-group
     = f.label :title, "Title"
     = f.text_field :title, class: 'form-control'
-  div.form-group
+  .form-group
     = f.label :offset, "Offset"
     = f.text_field(:offset, class: 'form-control')
-  div.form-group
+  .form-group
     = f.label :goal, "Goal"
     = f.text_field(:goal, class: 'form-control')
 
 
-  div.form-group
+  .form-group
     = submit_tag t('common.save'), class: 'btn btn-default', 'data-disable-with' => t('common.saving')
 
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,9 +34,6 @@ module Champaign
     # a console while you're accessing the site from a host on Docker.
     config.web_console.whiny_requests = false
 
-    # to get browserify to handle react JSX
-    config.browserify_rails.commandline_options = "--transform babelify --extension=\".js.jsx\""
-
     # We're using Redis as our cache. Configure that here.
     # we use 'redis' as the host name because that's configured by docker
     # during our setup as the host where our redis instance is stored.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
 
   resources :campaign_pages do
     resources :images
+    resources :plugins
   end
 
   resources :forms do
@@ -30,6 +31,7 @@ Rails.application.routes.draw do
     resources :actions
     resources :thermometers
   end
+
 
   resources :liquid_partials
   resources :liquid_layouts

--- a/lib/tasks/champaign.rake
+++ b/lib/tasks/champaign.rake
@@ -1,6 +1,17 @@
 require './lib/liquid_markup_seeder'
 
 namespace :champaign do
+  desc "Set plugins to active"
+  task activate_plugins: :environment do
+    puts "Starting update..."
+
+    Plugins.registered.each do |plugin|
+      plugin.all.each{|pl| pl.update({active: true}) }
+    end
+
+    puts "Update is done."
+  end
+
   desc "Seed database with liquid markup for partials and templates"
   task seed_liquid: :environment do
     puts "Starting Liquid Markup Seeder..."

--- a/spec/controllers/plugins_controller_spec.rb
+++ b/spec/controllers/plugins_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe PluginsController do
+  let(:plugin) { instance_double('Plugins::Action') }
+  let(:page)   { instance_double('CampaignPage', id: 5) }
+
+  before do
+    allow(Plugins).to receive(:find_for){ plugin }
+    allow(CampaignPage).to receive(:find){ page }
+    get :show, id: '1', campaign_page_id: '2'
+  end
+
+  describe 'GET #show' do
+    it 'renders show' do
+      expect(response).to render_template('show')
+    end
+
+    it 'finds campaign page' do
+      expect(CampaignPage).to have_received(:find).with('2')
+    end
+
+    it 'finds plugin' do
+      expect(Plugins).to have_received(:find_for).with(5, '1')
+    end
+  end
+end

--- a/spec/helpers/campaign_pages_helper_spec.rb
+++ b/spec/helpers/campaign_pages_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe CampaignPagesHelper do
+  describe "#campaign_page_nav_item" do
+    it "returns li element with link" do
+      actual = helper.campaign_page_nav_item('foo', '/bar')
+      expect(actual).to eq("<li><a href=\"/bar\">foo</a></li>")
+    end
+  end
+
+  describe "#toggle_switch" do
+    it "returns link when active" do
+      actual = helper.toggle_switch(true, true, 'foo')
+      expect(actual).to eq(
+        "<a class=\"btn-success btn toggle-button btn-default\">foo</a>"
+      )
+    end
+
+    it "returns link when inactive" do
+      actual = helper.toggle_switch(true, false, 'foo')
+      expect(actual).to eq(
+        "<a class=\" btn toggle-button btn-default\">foo</a>"
+      )
+    end
+  end
+end

--- a/spec/lib/champaign_queue/clients/sqs_spec.rb
+++ b/spec/lib/champaign_queue/clients/sqs_spec.rb
@@ -5,7 +5,7 @@ describe ChampaignQueue::Clients::Sqs do
     it "delivers payload to AWS SQS Queue" do
 
       expected_arguments = {
-        queue_url: "http://example.com",
+        queue_url: ENV['SQS_QUEUE_URL'],
         message_body: {foo: :bar}.to_json
       }
 


### PR DESCRIPTION
Mainly DRYing up view code (using partials and helpers), but also returns the original toggle feature allowing campaigners to switch plugins on and off.

![toggle](https://cloud.githubusercontent.com/assets/12949/9358281/1389d316-4683-11e5-986c-d66e83729d26.gif)

With toggling no changes are required on the template side, so you could have a template that handles all possible plugins, but gracefully deals with those that are switched off. I imagine we'll have a master template like this. For more custom templates @NealJMD's solution would then kick in.

Also, I've moved plugin settings from the main campaign page edit view. As plugin options grew, this page would have become a campaigner's nightmare. Now plugins exist in their own tab.

NOTE: This PR requires two rake tasks to be run:

`rake champaign:activate_plugins`
`rake champaign:seed_liquid`