### PR TITLE
Return action if it already exists

### DIFF
--- a/app/services/manage_action.rb
+++ b/app/services/manage_action.rb
@@ -1,18 +1,4 @@
-class Action < ActiveRecord::Base
-  belongs_to :campaign_page
-  belongs_to :action_user
-
-
-  class << self
-    def create_action(params)
-      ManageAction.new(params).create
-    end
-  end
-end
-
-
 class ManageAction
-
   def initialize(params)
     @params = params
   end
@@ -37,3 +23,4 @@ class ManageAction
     @campaign_page ||= CampaignPage.find(@params[:campaign_page_id])
   end
 end
+

--- a/spec/factories/action_users.rb
+++ b/spec/factories/action_users.rb
@@ -1,13 +1,5 @@
 FactoryGirl.define do
   factory :action_user do
-    first_name   { Faker::Name.first_name             }
-    last_name    { Faker::Name.last_name              }
-    email        { Faker::Internet.email              }
-    country      { Faker::Address.country             }
-    city         { Faker::Address.city                }
-    postal_code  { Faker::Address.zip_code            }
-    title        { Faker::Address.prefix              }
-    address1     { Faker::Address.street_address      }
-    address2     { Faker::Address.secondary_address   }
+    email { Faker::Internet.email }
   end
 end

--- a/spec/services/manage_action_spec.rb
+++ b/spec/services/manage_action_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe ManageAction do
+  let(:campaign) { create(:campaign_page) }
+  let(:data) { { email: 'bob@example.com', campaign_page_id: campaign.id } }
+
+  describe '#create' do
+    subject { ManageAction.new(data).create }
+
+    it 'creates an action' do
+      expect(subject).to be_a Action
+    end
+
+    it 'creates an action user' do
+      expect(subject.action_user.email).to eq('bob@example.com')
+    end
+
+    it 'uses existing user if present' do
+      create(:action_user, email: 'bob@example.com')
+
+      expect{ subject }.to_not change{ ActionUser.count }.from(1)
+    end
+
+    it 'returns existing action if present' do
+       action = ManageAction.new(data).create
+
+       expect(subject.id).to eq(action.id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes JS bug (found by @Tuuleh) where an action was returning `null` when a user signed the same petition more than once.