### PR TITLE
Devise disable signup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN bundle install
 EXPOSE 3000
 ADD . /myapp
 
-CMD bundle exec rails s -b 0.0.0.0
+CMD bundle exec unicorn -l 0.0.0.0:3000

--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,9 @@ gem 'browser'
 
 gem 'share_progress', '>=0.1.1', require: false
 
+gem 'newrelic_rpm'
+gem 'unicorn'
+
 group :development, :test do
   gem 'byebug'
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    kgio (2.10.0)
     liquid (3.0.3)
     logger (1.2.8)
     loofah (2.0.2)
@@ -153,6 +154,7 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nested_form (0.3.2)
+    newrelic_rpm (3.13.0.299)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oauth2 (1.0.0)
@@ -226,6 +228,7 @@ GEM
       activesupport (= 4.2.3)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    raindrops (0.15.0)
     rake (10.4.2)
     rdoc (4.2.0)
     remotipart (1.2.1)
@@ -293,6 +296,10 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unicorn (4.9.0)
+      kgio (~> 2.6)
+      rack
+      raindrops (~> 0.7)
     warden (1.2.3)
       rack (>= 1.0)
     web-console (2.2.1)
@@ -330,6 +337,7 @@ DEPENDENCIES
   jquery-rails
   liquid
   logger
+  newrelic_rpm
   omniauth-google-oauth2
   paper_trail
   paperclip
@@ -348,6 +356,7 @@ DEPENDENCIES
   spring
   timecop
   uglifier (>= 1.3.0)
+  unicorn
   web-console (~> 2.0)
   webmock
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,21 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
+  <% end -%>
+<% end -%>

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -41,7 +41,6 @@ html
                   ul.dropdown-menu
                     li= link_to t('menu.sign_google'), user_omniauth_authorize_path(:google_oauth2)
                     li= link_to t('menu.login'), new_user_session_path
-                    li= link_to t('menu.sign_up'), new_user_registration_path
 
 
     = yield :page_header

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,49 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python and Node applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated September 17, 2015
+# 
+# This configuration file is custom generated for SumOfUs
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: <%= ENV['NEWRELIC_LICENSE_KEY'] %>
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: Champaign
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: My Application (Development)
+
+  # NOTE: There is substantial overhead when running in developer mode.
+  # Do not use for production or load testing.
+  developer_mode: true
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: My Application (Staging)
+
+production:
+  <<: *default_settings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
-  devise_for :users, :controllers => { :omniauth_callbacks => "omniauth_callbacks" }
+
+  # We remove the sign_up path name so as not to allow users to sign in with username and password.
+  devise_for :users, :controllers => { :omniauth_callbacks => "omniauth_callbacks" }, path_names: { sign_up: ''}
+  
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ web:
   environment:
     PG_USERNAME: postgres
     PG_HOST: db
+  command: bundle exec unicorn -l 0.0.0.0:3000
 
 db:
   image: postgres


### PR DESCRIPTION
This removes the ability to sign up with a username and password from our site.

There’s one catch I’m seeing, which is that the password login page still has a sign up link on it (which will now return a 404) - I’m not sure where that page is designed/modified, so I’m not sure how to remove that link.