### PR TITLE
Aws deploy

### DIFF
--- a/.ebextensions/03_container_commands.config
+++ b/.ebextensions/03_container_commands.config
@@ -7,7 +7,7 @@ files:
       #!/bin/bash
       docker run -e RDS_DB_NAME=$RDS_DB_NAME -e RDS_USERNAME=$RDS_USERNAME -e RDS_PASSWORD=$RDS_PASSWORD \
       -e RDS_HOSTNAME=$RDS_HOSTNAME -e RDS_PORT=5432 -e RAILS_ENV=production -e DEVISE_SECRET_KEY=$DEVISE_SECRET_KEY \
-      aws_beanstalk/current-app:latest rake db:migrate champaign:seed_liquid
+      aws_beanstalk/staging-app:latest rake db:migrate champaign:seed_liquid
   "/home/ec2-user/precompile-assets.sh":
     mode: "000755"
     owner: root
@@ -18,7 +18,7 @@ files:
       -e DEVISE_SECRET_KEY=$DEVISE_SECRET_KEY -e RAILS_ENV=production -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
       -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e SECRET_KEY_BASE=$SECRET_KEY_BASE \
       -e ASSET_SYNC_GZIP_COMPRESSION=$ASSET_SYNC_GZIP_COMPRESSION \
-      aws_beanstalk/current-app:latest rake assets:precompile
+      aws_beanstalk/staging-app:latest rake assets:precompile
   "/home/ec2-user/docker-housekeeping.sh":
     mode: "000755"
     owner: root

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-production'
   staging:
-    branch: aws-deploy
+    branch: development
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-production'
   staging:
-    branch: development
+    branch: aws-deploy
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web


### PR DESCRIPTION
This changes the container our rake tasks are issued at deploy time. Staging app is the container AWS spins up to set up your new application, so it contains the files from our application. Running the rake tasks there will perform migrations that are up-to-date with the migration requirements of our new deploy, and upload static assets that'll match the fingerprints on the requests for them.