### PR TITLE
Share progress validation

### DIFF
--- a/app/controllers/share/shares_controller.rb
+++ b/app/controllers/share/shares_controller.rb
@@ -28,7 +28,7 @@ class Share::SharesController < ApplicationController
     })
 
     respond_to do |format|
-      if @share.valid?
+      if @share.errors.empty?
         format.html { redirect_to index_path }
       else
         format.html { render 'share/edit' }
@@ -44,7 +44,7 @@ class Share::SharesController < ApplicationController
     })
 
     respond_to do |format|
-      if @share.valid?
+      if @share.errors.empty?
         format.html { redirect_to index_path }
       else
         format.html { render 'share/new' }

--- a/app/models/share/email.rb
+++ b/app/models/share/email.rb
@@ -1,6 +1,5 @@
 class Share::Email < ActiveRecord::Base
-  belongs_to :page
-  belongs_to :button
+  include Share::Variant
 
   validates :subject, :body, presence: true
   validate :has_link

--- a/app/models/share/facebook.rb
+++ b/app/models/share/facebook.rb
@@ -1,6 +1,5 @@
 class Share::Facebook < ActiveRecord::Base
-  belongs_to :button
-  belongs_to :page
+  include Share::Variant
 
   validates :description, :title, presence: true
 

--- a/app/models/share/twitter.rb
+++ b/app/models/share/twitter.rb
@@ -1,10 +1,11 @@
 class Share::Twitter < ActiveRecord::Base
-  belongs_to :page
+  include Share::Variant
+
   validates :description, presence: true
   validate :has_link
 
   def has_link
     errors.add(:description, "does not contain {LINK}") unless description =~ /\{LINK\}/
   end
-end
 
+end

--- a/app/models/share/variant.rb
+++ b/app/models/share/variant.rb
@@ -7,7 +7,6 @@ module Share::Variant
   end
 
   def add_errors(errors_to_add)
-    puts "got errors_to_add #{errors_to_add}"
     errors_to_add.each do |error|
       errors.add(:base, error)
     end

--- a/app/models/share/variant.rb
+++ b/app/models/share/variant.rb
@@ -1,0 +1,15 @@
+module Share::Variant
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :button
+    belongs_to :page
+  end
+
+  def add_errors(errors_to_add)
+    puts "got errors_to_add #{errors_to_add}"
+    errors_to_add.each do |error|
+      errors.add(:base, error)
+    end
+  end
+end

--- a/app/services/share_progress_variant_builder.rb
+++ b/app/services/share_progress_variant_builder.rb
@@ -40,16 +40,12 @@ class ShareProgressVariantBuilder
 
     return variant unless variant.valid?
 
-    button = Share::Button.where(sp_type: @variant_type, page_id: @page.id).first
-    button = Share::Button.new(sp_type: @variant_type, page_id: @page.id) if button.blank?
-
+    button = Share::Button.find_or_initialize_by(sp_type: @variant_type, page_id: @page.id)
     sp_button = ShareProgress::Button.new( share_progress_button_params(variant, button) )
 
     if sp_button.save
       button.update(sp_id: sp_button.id, sp_button_html: sp_button.share_button_html) unless button.sp_id
       variant.update(sp_id:  sp_button.variants[@variant_type].last[:id])
-      variant.save
-      button.save
     else
       add_sp_errors_to_variant(sp_button, variant)
     end

--- a/app/services/share_progress_variant_builder.rb
+++ b/app/services/share_progress_variant_builder.rb
@@ -59,12 +59,17 @@ class ShareProgressVariantBuilder
   private
 
   def add_sp_errors_to_variant(sp_button, variant)
-    if sp_button.errors.has_key? "variants"
-      variant.add_errors(sp_button.errors['variants'][0])
-    else
-      sp_button.errors.each_value do |val|
-        variant.add_errors(val[0])
+    begin
+      if sp_button.errors.has_key? 'variants'
+        variant.add_errors(sp_button.errors['variants'][0])
+      else
+        sp_button.errors.each_value do |val|
+          variant.add_errors(val[0])
+        end
       end
+    rescue NoMethodError
+      # in case SP just starts returning something wonky and the array access raises NoMethodError
+      variant.add_errors([sp_button.errors.to_s])
     end
   end
 

--- a/spec/controllers/share/shared_examples.rb
+++ b/spec/controllers/share/shared_examples.rb
@@ -1,5 +1,5 @@
 shared_examples "shares" do |share_class, service|
-  let(:share){ instance_double(share_class, valid?: true) }
+  let(:share){ instance_double(share_class, valid?: true, errors: {}) }
   let(:page)  { instance_double('Page', title: 'Foo', content: 'Bar', id: '1', to_param: '1' ) }
 
   before do

--- a/spec/controllers/share/shared_examples.rb
+++ b/spec/controllers/share/shared_examples.rb
@@ -98,6 +98,10 @@ shared_examples "shares" do |share_class, service|
     it 'redirects to share index path' do
       expect( response ).to redirect_to("/pages/1/share/#{service.to_s.pluralize}")
     end
+
+    it 'needs negative test cases' do
+      expect(false).to equal true
+    end
   end
 
   describe 'POST#create' do
@@ -123,6 +127,11 @@ shared_examples "shares" do |share_class, service|
     it 'redirects to share index path' do
       expect( response ).to redirect_to("/pages/1/share/#{service.pluralize}")
     end
+
+    it 'needs negative test cases' do
+      expect(false).to equal true
+    end
+
   end
 end
 

--- a/spec/controllers/share/shared_examples.rb
+++ b/spec/controllers/share/shared_examples.rb
@@ -1,5 +1,6 @@
 shared_examples "shares" do |share_class, service|
   let(:share){ instance_double(share_class, valid?: true, errors: {}) }
+  let(:failed_share){ instance_double(share_class, valid?: true, errors: {base: ['email_body needs {LINK}']}) }
   let(:page)  { instance_double('Page', title: 'Foo', content: 'Bar', id: '1', to_param: '1' ) }
 
   before do
@@ -75,61 +76,89 @@ shared_examples "shares" do |share_class, service|
   end
 
   describe 'PUT#update' do
-    before do
-      allow(ShareProgressVariantBuilder).to receive(:update){ share }
 
-      put :update, page_id: 1, id: 2, "share_#{service}": params
+    describe 'success' do
+      before do
+        allow(ShareProgressVariantBuilder).to receive(:update){ share }
+
+        put :update, page_id: 1, id: 2, "share_#{service}": params
+      end
+
+      it 'finds campaign page' do
+        expect(Page).to have_received(:find).with('1')
+      end
+
+      it 'updates' do
+        expect(ShareProgressVariantBuilder).to have_received(:update).
+          with(params, {
+          variant_type: service.to_sym,
+          page: page,
+          url: "http://test.host/pages/1",
+          id: '2'
+        })
+      end
+
+      it 'redirects to share index path' do
+        expect( response ).to redirect_to("/pages/1/share/#{service.to_s.pluralize}")
+      end
     end
 
-    it 'finds campaign page' do
-      expect(Page).to have_received(:find).with('1')
-    end
+    describe 'failure' do
+      before do
+        allow(ShareProgressVariantBuilder).to receive(:update){ failed_share }
+        put :update, page_id: 1, id: 2, "share_#{service}": params
+      end
 
-    it 'updates' do
-      expect(ShareProgressVariantBuilder).to have_received(:update).
-        with(params, {
-        variant_type: service.to_sym,
-        page: page,
-        url: "http://test.host/pages/1",
-        id: '2'
-      })
-    end
+      it 'renders share/edit' do
+        expect( response ).to render_template('share/edit')
+      end
 
-    it 'redirects to share index path' do
-      expect( response ).to redirect_to("/pages/1/share/#{service.to_s.pluralize}")
-    end
-
-    it 'needs negative test cases' do
-      expect(false).to equal true
+      it 'does not call valid? on the variant' do
+        expect(share).not_to have_received(:valid?)
+      end
     end
   end
 
   describe 'POST#create' do
-    before do
-      allow(ShareProgressVariantBuilder).to receive(:create){ share }
 
-      post :create, page_id: 1, "share_#{service}": params
+    describe 'success' do
+      before do
+        allow(ShareProgressVariantBuilder).to receive(:create){ share }
+
+        post :create, page_id: 1, "share_#{service}": params
+      end
+
+      it 'finds campaign page' do
+        expect(Page).to have_received(:find).with('1')
+      end
+
+      it 'creates' do
+        expect(ShareProgressVariantBuilder).to have_received(:create).
+          with(params, {
+          variant_type: service.to_sym,
+          page: page,
+          url: "http://test.host/pages/1"
+        })
+      end
+
+      it 'redirects to share index path' do
+        expect( response ).to redirect_to("/pages/1/share/#{service.pluralize}")
+      end
     end
 
-    it 'finds campaign page' do
-      expect(Page).to have_received(:find).with('1')
-    end
+    describe 'success' do
+      before do
+        allow(ShareProgressVariantBuilder).to receive(:create){ failed_share }
+        post :create, page_id: 1, "share_#{service}": params
+      end
 
-    it 'creates' do
-      expect(ShareProgressVariantBuilder).to have_received(:create).
-        with(params, {
-        variant_type: service.to_sym,
-        page: page,
-        url: "http://test.host/pages/1"
-      })
-    end
+      it 'renders share/edit' do
+        expect( response ).to render_template('share/new')
+      end
 
-    it 'redirects to share index path' do
-      expect( response ).to redirect_to("/pages/1/share/#{service.pluralize}")
-    end
-
-    it 'needs negative test cases' do
-      expect(false).to equal true
+      it 'does not call valid? on the variant' do
+        expect(share).not_to have_received(:valid?)
+      end
     end
 
   end

--- a/spec/services/share_progress_variant_builder_spec.rb
+++ b/spec/services/share_progress_variant_builder_spec.rb
@@ -54,6 +54,10 @@ describe ShareProgressVariantBuilder do
       expect(button.sp_id).to eq("1")
       expect(button.sp_button_html).to eq("<div />")
     end
+
+    it 'needs validation test cases' do
+      expect(false).to equal true
+    end
   end
 
   describe '.update' do
@@ -84,6 +88,10 @@ describe ShareProgressVariantBuilder do
       expect(ShareProgress::Button).to receive(:new)
       expect(sp_button).to receive(:save)
       update_variant
+    end
+
+    it 'needs validation test cases' do
+      expect(false).to equal true
     end
   end
 end

--- a/spec/services/share_progress_variant_builder_spec.rb
+++ b/spec/services/share_progress_variant_builder_spec.rb
@@ -85,17 +85,45 @@ describe ShareProgressVariantBuilder do
       end
     end
 
+    describe 'reporting unexpected error messages' do
+      before do
+        allow(ShareProgress::Button).to receive(:new){ failure_sp_button }
+      end
 
-    it 'persists button locally' do
-      create_variant
+      it 'reports with a string error' do
+        allow(failure_sp_button).to receive(:errors){ "Something went wrong" }
+        variant = create_variant # if it raises an error, it'll fail here
+        expect(variant.errors.size).to eq 1
+        expect(variant.errors[:base]).to eq ['Something went wrong']
+      end
 
-      button = Share::Button.first
-      expect(button.sp_id).to eq("1")
-      expect(button.sp_button_html).to eq("<div />")
-    end
+      it 'reports with an array error' do
+        allow(failure_sp_button).to receive(:errors){ ["Dude wheres my car?"] }
+        variant = create_variant # if it raises an error, it'll fail here
+        expect(variant.errors.size).to eq 1
+        expect(variant.errors[:base]).to eq ['["Dude wheres my car?"]']
+      end
 
-    it 'needs validation test cases' do
-      expect(false).to equal true
+      it 'reports with a singly nested error' do
+        allow(failure_sp_button).to receive(:errors){ {'variants' => ['the body needs {LINK}']} }
+        variant = create_variant # if it raises an error, it'll fail here
+        expect(variant.errors.size).to eq 1
+        expect(variant.errors[:base]).to eq ['{"variants"=>["the body needs {LINK}"]}']
+      end
+
+      it 'reports with an unnested error' do
+        allow(failure_sp_button).to receive(:errors){ {'variants' => 'your body needs {LINK}'} }
+        variant = create_variant # if it raises an error, it'll fail here
+        expect(variant.errors.size).to eq 1
+        expect(variant.errors[:base]).to eq ['{"variants"=>"your body needs {LINK}"}']
+      end
+
+      it 'reports with an unknown key' do
+        allow(failure_sp_button).to receive(:errors){ {'some_error' => [['your body wants {LINK}']]} }
+        variant = create_variant # if it raises an error, it'll fail here
+        expect(variant.errors.size).to eq 1
+        expect(variant.errors[:base]).to eq ['your body wants {LINK}']
+      end
     end
   end
 


### PR DESCRIPTION
Up to this point, our share button creation assumed that if it passed our validation, it also passed the validation on ShareProgress. This changes that to take any errors returned by SP seriously. It also tries to be tolerant of the SP API sending back stuff completely different from what they currently send, cause you never know.