### PR TITLE
CTA customization and country auto-fill

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'codemirror-rails'
 gem 'selectize-rails'
 gem 'countries'
+gem 'geocoder'
 gem 'browserify-rails'
 gem 'font-awesome-sass'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
     font-awesome-sass (4.4.0)
       sass (>= 3.2)
     formatador (0.2.5)
+    geocoder (1.2.11)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     haml (4.0.7)
@@ -485,6 +486,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-sass
+  geocoder
   jbuilder (~> 2.0)
   jquery-rails
   liquid

--- a/app/assets/stylesheets/sumofus/global/typography.scss
+++ b/app/assets/stylesheets/sumofus/global/typography.scss
@@ -9,7 +9,7 @@ body {
   color: $chalkboard;
 }
 
-h1, h2, h3, h4, h5, h6, strong {
+h1, h2, h3, h4, h5, h6, strong, b {
   font-weight: bold;
 }
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,7 +24,8 @@ class PagesController < ApplicationController
   end
 
   def show
-    renderer = LiquidRenderer.new(@page)
+    country = request.location.country_code
+    renderer = LiquidRenderer.new(@page, country: country)
     @rendered = renderer.render
     render :show, layout: 'sumofus'
   end
@@ -42,7 +43,7 @@ class PagesController < ApplicationController
   end
 
   def follow_up
-    renderer = LiquidRenderer.new(@page, @page.secondary_liquid_layout)
+    renderer = LiquidRenderer.new(@page, layout: @page.secondary_liquid_layout)
     @rendered = renderer.render
     render :show, layout: 'sumofus'
   end

--- a/app/controllers/plugins/actions_controller.rb
+++ b/app/controllers/plugins/actions_controller.rb
@@ -23,6 +23,6 @@ class Plugins::ActionsController < ApplicationController
 
   def permitted_params
     params.require(:plugins_action).
-      permit(:description, :active, :target)
+      permit(:description, :active, :target, :cta)
   end
 end

--- a/app/liquid/liquid_helper.rb
+++ b/app/liquid/liquid_helper.rb
@@ -4,17 +4,18 @@ class LiquidHelper
     # when possible, I think we should try to make this match with
     # helpers in liquid docs to be more intuitive for people familiar with liquid
     # https://docs.shopify.com/themes/liquid-documentation/objects
-    def globals
+    def globals(country: nil)
       {
-        country_option_tags: country_option_tags
+        country_option_tags: country_option_tags(country)
       }
     end
 
-    def country_option_tags
+    def country_option_tags(user_country_code=nil)
       options = []
       names_with_codes = ISO3166::Country.all_names_with_codes(I18n.locale.to_s)
       names_with_codes.each do |name, code|
-        options << "<option value='#{code}'>#{name}</option>"
+        selected = (user_country_code == code) ? "selected='selected'" : ""
+        options << "<option value='#{code}' #{selected}>#{name}</option>"
       end
       options.join("\n")
     end

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -1,8 +1,9 @@
 class LiquidRenderer
 
-  def initialize(page, layout=nil)
+  def initialize(page, layout: nil, country: nil)
     @page = page
     @markup = layout.content unless layout.blank?
+    @country = country
   end
 
   def render
@@ -25,7 +26,7 @@ class LiquidRenderer
     @data ||= Plugins.data_for_view(@page).
                 merge( @page.liquid_data ).
                 merge( images: images ).
-                merge( LiquidHelper.globals ).
+                merge( LiquidHelper.globals(country: @country) ).
                 merge( shares: Shares.get_all(@page) ).
                 deep_stringify_keys
   end

--- a/app/models/plugins/action.rb
+++ b/app/models/plugins/action.rb
@@ -2,12 +2,14 @@ class Plugins::Action < ActiveRecord::Base
   belongs_to :page
   belongs_to :form
 
+  validates :cta, presence: true, allow_blank: false
+
   after_create :create_form
 
-  DEFAULTS = {}
+  DEFAULTS = { cta: 'Sign the Petition' }
 
   def liquid_data
-    attributes.merge('form_id' => form.try(:id),  'fields' => form_fields)
+    attributes.merge(form_id: form.try(:id), fields: form_fields)
   end
 
   def form_fields

--- a/app/views/plugins/actions/_action.liquid
+++ b/app/views/plugins/actions/_action.liquid
@@ -42,14 +42,14 @@
             {% endcase %}
           </div>
         {% endfor %}
-        <button type="submit" class="button action-bar__submit-button">Sign the petition</button>
+        <button type="submit" class="button action-bar__submit-button">{{ plugins.action[ref].cta }}</button>
       </form>
     </div>
   </div>
 
   <div class="action-bar__mobile-ui">
     <div class="action-bar__mobile-ui__bottom-bar">
-      <button class="button action-bar__open-button">Sign the petition</button>
+      <button class="button action-bar__open-button">{{ plugins.action[ref].cta }}</button>
     </div>
   </div>
 

--- a/app/views/plugins/actions/_form.slim
+++ b/app/views/plugins/actions/_form.slim
@@ -13,6 +13,10 @@
           = f.text_field :target, class: 'form-control'
 
         .form-group
+          = f.label :cta, "Call to Action"
+          = f.text_field :cta, class: 'form-control', placeholder: 'Sign the Petition'
+
+        .form-group
           = submit_tag t('common.save'), class: 'btn btn-default xhr-feedback'
 
     .well

--- a/app/views/plugins/actions/_preview.html.slim
+++ b/app/views/plugins/actions/_preview.html.slim
@@ -5,4 +5,5 @@
 - if plugin.form
   == render partial: 'forms/preview', locals: { form: plugin.form }
 
-  button.btn.btn-default Sign
+  button.btn.btn-default
+    = plugin.cta

--- a/db/migrate/20151002221626_add_cta_to_plugins_actions.rb
+++ b/db/migrate/20151002221626_add_cta_to_plugins_actions.rb
@@ -1,0 +1,5 @@
+class AddCtaToPluginsActions < ActiveRecord::Migration
+  def change
+    add_column :plugins_actions, :cta, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150930130924) do
+ActiveRecord::Schema.define(version: 20151002221626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,12 +152,12 @@ ActiveRecord::Schema.define(version: 20150930130924) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "compiled_html"
-    t.string   "status",                     default: "pending"
-    t.text     "messages"
     t.text     "content",                    default: ""
     t.boolean  "thermometer",                default: false
     t.boolean  "featured",                   default: false
     t.boolean  "active",                     default: false
+    t.string   "status",                     default: "pending"
+    t.text     "messages"
     t.integer  "liquid_layout_id"
     t.integer  "secondary_liquid_layout_id"
   end
@@ -179,6 +179,7 @@ ActiveRecord::Schema.define(version: 20150930130924) do
     t.text     "description"
     t.string   "ref"
     t.string   "target"
+    t.string   "cta"
   end
 
   add_index "plugins_actions", ["form_id"], name: "index_plugins_actions_on_form_id", using: :btree

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -80,7 +80,7 @@ describe PagesController do
     end
 
     it 'instantiates a LiquidRenderer and calls render' do
-      expect(LiquidRenderer).to have_received(:new).with(page)
+      expect(LiquidRenderer).to have_received(:new).with(page, country: "RD")
       expect(renderer).to have_received(:render)
     end
 
@@ -107,7 +107,7 @@ describe PagesController do
     end
 
     it 'instantiates a LiquidRenderer and calls render' do
-      expect(LiquidRenderer).to have_received(:new).with(page, page.secondary_liquid_layout)
+      expect(LiquidRenderer).to have_received(:new).with(page, layout: page.secondary_liquid_layout)
       expect(renderer).to have_received(:render)
     end
 

--- a/spec/factories/plugins_actions.rb
+++ b/spec/factories/plugins_actions.rb
@@ -3,5 +3,8 @@ FactoryGirl.define do
     page nil
     active false
     form nil
+    cta "Sign the Petition"
+    target "The man"
+    description "Gotta save the world and stuff"
   end
 end

--- a/spec/models/plugins/action_spec.rb
+++ b/spec/models/plugins/action_spec.rb
@@ -1,5 +1,27 @@
 require 'rails_helper'
 
-RSpec.describe Plugins::Action, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Plugins::Action do
+  
+  let(:action) { create :plugins_action }
+
+  subject{ action }
+
+  it { is_expected.to be_valid }
+  it { is_expected.to respond_to :description }
+  it { is_expected.to respond_to :target }
+  it { is_expected.to respond_to :cta }
+  it { is_expected.to respond_to :page_id }
+  it { is_expected.to respond_to :active }
+  it { is_expected.to respond_to :ref }
+
+  it 'is invalid without cta' do
+    action.cta = ""
+    expect(action).to be_invalid
+  end
+
+  it "is valid without target" do
+    action.target = ""
+    expect(action).to be_valid
+  end
+
 end


### PR DESCRIPTION
Three changes
- allow the CTA button on the action form to be set in the admin. On new forms, it defaults to "Sign the Petition" but on old ones it may need to go back and be changed again.
- the country dropdown now has the user's country automatically selected based on their request location.
- reset.css clobbered bold tags, added them to the list of strong