### PR TITLE
Upload new image for existing fb share

### DIFF
--- a/app/views/share/facebooks/_facebook.html.slim
+++ b/app/views/share/facebooks/_facebook.html.slim
@@ -1,6 +1,9 @@
 .row
   .col-md-3
-    = image_tag facebook.image(:thumb), class: 'img-responsive img-rounded'
+    - if facebook.image.exists?
+      = image_tag facebook.image(:thumb), class: 'img-responsive img-rounded'
+    - else
+      h3 = t('share.facebook.no_image')
   .col-md-9
     h4 = facebook.title
     = simple_format facebook.description

--- a/app/views/share/facebooks/_share_fields.html.slim
+++ b/app/views/share/facebooks/_share_fields.html.slim
@@ -5,8 +5,12 @@
   = form.label :description, t('share.facebook.form.description')
   = form.text_area :description, class: 'form-control'
 
+- if @share.image.exists?
+  .form-group
+    = image_tag @share.image(:thumb)
+
 .form-group
-  = form.label :image, t('share.facebook.form.image')
+  = form.label :image, ( @share.new_record? ? t('share.facebook.form.image') : t('share.facebook.form.update_image')  )
   = form.file_field :image
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,10 +135,12 @@ en:
 
     facebook:
       title: 'Facebook Share Headline'
+      no_image: 'No Image'
       form:
         title: 'Facebook Share title'
         description: 'Facebook Share text'
-        image: "Add an image. Leave blank to use the page's default"
+        image: "Add an image. Leave blank to use the page's default."
+        update_image: "Click to replace image."
 
     twitter:
       title: 'Twitter Retweet Variant'


### PR DESCRIPTION
Don't show broken image when missing. Allow campaigner to upload a new image for existing fb share.