### PR TITLE
Little fixes

### DIFF
--- a/app/assets/stylesheets/sumofus/global/typography.scss
+++ b/app/assets/stylesheets/sumofus/global/typography.scss
@@ -12,6 +12,9 @@ body {
 h1, h2, h3, h4, h5, h6, strong, b {
   font-weight: bold;
 }
+i {
+  font-style: italic;
+}
 
 h1 {
   @include rem(font-size, 2.6rem, true);

--- a/app/liquid/views/layouts/sumofus.liquid
+++ b/app/liquid/views/layouts/sumofus.liquid
@@ -2,12 +2,12 @@
 
   <div class="cover-photo__overlay">
 
-    <a href="http://sumofus.org/">
-      <div class="header-logo header-logo--dark checks-top checks-top--at-top">
+    <div class="header-logo header-logo--dark checks-top checks-top--at-top">
+      <a href="http://sumofus.org/">
         <div class="header-logo__logo sumofus-logo--negative"></div>
-        <div class="header-logo__tagline sumofus-logo--tagline">Fighting for people over profits</div>
-      </div>
-    </a>
+      </a>
+      <div class="header-logo__tagline sumofus-logo--tagline">Fighting for people over profits</div>
+    </div>
 
     <div class="cover-photo__titles">
       <div class="center-content">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,37 @@
+<h2>Log in</h2>
+
+<%- if devise_mapping.omniauthable? %>
+  <section class="col-xs-12">
+    <%= link_to "Sign in with your SumOfUs email", omniauth_authorize_path(resource_name, 'google_oauth2'), class: 'btn btn-primary btn-lg' %><br />
+  </section>
+<% end -%>
+
+<section class="col-xs-4">
+  <h4>or log in with a password</h4>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="form-group">
+      <%= f.label :email %><br />
+      <%= f.email_field :email, class: 'form-control' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :password %><br />
+      <%= f.password_field :password, autocomplete: "off", class: 'form-control' %>
+    </div>
+
+    <% if devise_mapping.rememberable? -%>
+      <div class="form-group">
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me %>
+      </div>
+    <% end -%>
+
+    <div class="actions">
+      <%= f.submit "Log in", class: 'btn btn-default' %>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= render "devise/shared/links", no_omniauth: true %>
+  </div>  
+</section>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -14,7 +14,7 @@
   <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.omniauthable? %>
+<%- if devise_mapping.omniauthable? && !defined?(no_omniauth) %>
   <%- resource_class.omniauth_providers.each do |provider| %>
     <%= link_to "Sign in with #{provider.to_s.titleize}", omniauth_authorize_path(resource_name, provider) %><br />
   <% end -%>


### PR DESCRIPTION
This takes care of three little tickets
- make italics in the WYSIWYG actually show up as italic on the campaign page
- link only the SOU logo to SOU.org, not the entire header
- make the log in page feature Google Oauth much more prominently.