### PR TITLE
Add option to deploy to testing environment through CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,3 +36,9 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-staging'
+  testing:
+      branch: testing-env
+      commands:
+        - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+        - docker push soutech/champaign_web
+        - ./deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-testing'


### PR DESCRIPTION
There's now a testing environment up on Elastic Beanstalk - this change to circle.yml will allow you to specify any branch to deploy to the testing environment. As an type of testing environment that members won't be interacting with, the test env uses the same SQS queue as staging. Consequently, both are handled by the same AK worker. The test env has its own RDS, though, because the desired test branch might have migrations we don't want to hit staging.