### PR TITLE
Set AK API host as a constant. No reason for it to be in ENV.

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,7 +35,6 @@
 
 
 # Direct ActionKit Connection variables.
-#    ak_api_url: 'set this based on your ActionKit API URL.'
 #    ak_username: 'Set this based on an account which has API access to your ActionKit instance for direct data pushing to AK, in a .local file.'
 #    ak_password: 'Just like ak_username.'
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -22,7 +22,6 @@
 
 
 # Direct ActionKit Connection variables.
-     ak_api_url: <%= ENV['AK_API_URL'] %>
      ak_username: <%= ENV['AK_USERNAME'] %>
      ak_password: <%= ENV['AK_PASSWORD'] %>
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -31,7 +31,6 @@
 
 
 # Direct ActionKit Connection variables.
-     ak_api_url: 'https://act.sumofus.org/rest/v1'
      ak_username: 'ak_username'
      ak_password: 'ak_password'
 

--- a/lib/action_kit/client.rb
+++ b/lib/action_kit/client.rb
@@ -1,10 +1,13 @@
 module ActionKit
   module Client
     extend self
+
+    HOST = 'https://act.sumofus.org/rest/v1'
+
     def client(verb, path, params)
       Typhoeus::Request.send(
         verb,
-        "#{Settings.ak_api_url}/#{path}/",
+        URI.join(HOST, '/rest/v1/', "#{path}/"),
         { userpwd: "#{Settings.ak_username}:#{Settings.ak_password}" }.merge(params)
       )
     end


### PR DESCRIPTION
This was causing plenty of trouble around slug checking whenever we changed environments. 