### PR TITLE
Step skipping

### DIFF
--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -15,16 +15,20 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     'blur  .fundraiser-bar__custom-field': 'resetCustom',
     'click .fundraiser-bar__amount-button': 'advanceToDetails',
     'click .fundraiser-bar__first-continue': 'advanceToDetails',
+    'click .fundraiser-bar__clear-form': 'clearForm',
     'click .action-bar__clear-form': 'clearForm',
     'ajax:success form.action': 'advanceToPayment',
     'submit form#hosted-fields': 'disableButton',
     'change select.fundraiser-bar__currency-selector': 'switchCurrency',
     'click .fundraiser-bar__engage-currency-switcher': 'showCurrencySwitcher',
+    'click .fundraiser-bar__mistaken-identity': 'showSecondStep',
   },
 
   // options: object with any of the following keys
   //    followUpUrl: the url to redirect to after success
   //    currency: the three letter capitalized currency code to use
+  //    amount: a preselected donation amount, if > 0 the first step will be skipped
+  //    outstandingFields: the number of step 2 form fields that need to to be filled by the user
   //    donationBands: an object with three letter currency codes as keys
   //      and array of numbers, integers or floats, to display as donation amounts
   initialize: function(options) {
@@ -35,9 +39,48 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     this.donationAmount = 0;
     this.handleFormErrors();
     this.followUpUrl = options.followUpUrl;
+    this.initializeSkipping(options);
     if (!this.isMobile()) {
       this.selectizeCountry();
     }
+  },
+
+  initializeSkipping: function(options){
+    if (options.amount > 0) {
+      this.setDonationAmount(options.amount);
+    }
+    this.hidingStepTwo = false;
+    // here we deliberately abuse the fact that non-numbers compared
+    // with > always return false
+    this.hideSteps((options.amount > 0), (options.outstandingFields == 0));
+  },
+
+  hideSteps: function(amountKnown, memberKnown) {
+    if (amountKnown && memberKnown) {
+      this.changeStep(3);
+      this.hideSecondStep();
+    } else if (memberKnown) {
+      this.hideSecondStep();
+    } else if (amountKnown) {
+      this.changeStep(2);
+    }
+  },
+
+  hideSecondStep: function() {
+    this.$('.fundraiser-bar__steps').addClass('fundraiser-bar__steps--two-step');
+    this.$('.fundraiser-bar__mistaken-identity').removeClass('hidden-irrelevant');
+    this.$('.fundraiser-bar__step-label[data-step="2"]').css('visibility', 'hidden');
+    this.$('.fundraiser-bar__step-number[data-step="3"]').text(2);
+    this.hidingStepTwo = true;
+  },
+
+  showSecondStep: function() {
+    this.$('.fundraiser-bar__steps').removeClass('fundraiser-bar__steps--two-step');
+    this.$('.fundraiser-bar__mistaken-identity').addClass('hidden-irrelevant');
+    this.$('.fundraiser-bar__step-label[data-step="2"]').css('visibility', 'visible');
+    this.$('.fundraiser-bar__step-number[data-step="3"]').text(3);
+    this.hidingStepTwo = false;
+    this.changeStep(2);
   },
 
   isMobile: function() {
@@ -72,7 +115,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     }
     this.setDonationAmount(amount);
     if (this.donationAmount > 0) {
-      this.changeStep(2)
+      this.hidingStepTwo ? this.changeStep(3) : this.changeStep(2);
     }
   },
 

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -15,13 +15,12 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     'blur  .fundraiser-bar__custom-field': 'resetCustom',
     'click .fundraiser-bar__amount-button': 'advanceToDetails',
     'click .fundraiser-bar__first-continue': 'advanceToDetails',
-    'click .fundraiser-bar__clear-form': 'clearForm',
+    'click .fundraiser-bar__clear-form': 'showSecondStep',
     'click .action-bar__clear-form': 'clearForm',
     'ajax:success form.action': 'advanceToPayment',
     'submit form#hosted-fields': 'disableButton',
     'change select.fundraiser-bar__currency-selector': 'switchCurrency',
     'click .fundraiser-bar__engage-currency-switcher': 'showCurrencySwitcher',
-    'click .fundraiser-bar__mistaken-identity': 'showSecondStep',
   },
 
   // options: object with any of the following keys
@@ -68,7 +67,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
 
   hideSecondStep: function() {
     this.$('.fundraiser-bar__steps').addClass('fundraiser-bar__steps--two-step');
-    this.$('.fundraiser-bar__mistaken-identity').removeClass('hidden-irrelevant');
+    this.$('.fundraiser-bar__welcome-text').removeClass('hidden-irrelevant');
     this.$('.fundraiser-bar__step-label[data-step="2"]').css('visibility', 'hidden');
     this.$('.fundraiser-bar__step-number[data-step="3"]').text(2);
     this.hidingStepTwo = true;
@@ -76,9 +75,10 @@ const FundraiserBar = Backbone.View.extend(_.extend(
 
   showSecondStep: function() {
     this.$('.fundraiser-bar__steps').removeClass('fundraiser-bar__steps--two-step');
-    this.$('.fundraiser-bar__mistaken-identity').addClass('hidden-irrelevant');
+    this.$('.fundraiser-bar__welcome-text').addClass('hidden-irrelevant');
     this.$('.fundraiser-bar__step-label[data-step="2"]').css('visibility', 'visible');
     this.$('.fundraiser-bar__step-number[data-step="3"]').text(3);
+    this.clearForm();
     this.hidingStepTwo = false;
     this.changeStep(2);
   },

--- a/app/assets/stylesheets/sumofus/components/fundraiser.scss
+++ b/app/assets/stylesheets/sumofus/components/fundraiser.scss
@@ -2,7 +2,15 @@
   &__steps {
     position: relative;
     width: 100%;
-    margin-top: 21px;
+    margin: 21px auto 0;
+    @include transition(width 0.2s linear);
+
+    &--two-step {
+    @include transition(width 0s linear);
+      position: relative;
+      width: 70%;
+      margin: 21px auto 0;
+    }
   }
   &__step-connector {
     width: 70%;
@@ -125,6 +133,13 @@
     &.fa {
       margin-right: 6px;
       font-size: 20px;
+    }
+  }
+  &__mistaken-identity {
+    margin-bottom: 12px;
+    font-size: 14px;
+    .fundraiser-bar__clear-form {
+      display: inline;
     }
   }
 }

--- a/app/assets/stylesheets/sumofus/components/fundraiser.scss
+++ b/app/assets/stylesheets/sumofus/components/fundraiser.scss
@@ -135,13 +135,6 @@
       font-size: 20px;
     }
   }
-  &__mistaken-identity {
-    margin-bottom: 12px;
-    font-size: 14px;
-    .fundraiser-bar__clear-form {
-      display: inline;
-    }
-  }
 }
 
 .hosted-fields {

--- a/app/assets/stylesheets/sumofus/components/petition.scss
+++ b/app/assets/stylesheets/sumofus/components/petition.scss
@@ -46,7 +46,6 @@
     float: left;
     font-size: 14px;
     line-height: 14px;
-    font-weight: bold;
     margin-bottom: 10px;
   }
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,11 +29,11 @@ class PagesController < ApplicationController
   end
 
   def show
-    raise ActiveRecord::RecordNotFound unless @page.active? || user_signed_in?
-    recognized_member = Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
-    renderer = LiquidRenderer.new(@page, request_country: request_country, member: recognized_member)
-    @rendered = renderer.render
-    render :show, layout: 'sumofus'
+    render_liquid(@page.liquid_layout)
+  end
+
+  def follow_up
+    render_liquid(@page.secondary_liquid_layout)
   end
 
   def update
@@ -49,13 +49,15 @@ class PagesController < ApplicationController
     end
   end
 
-  def follow_up
-    renderer = LiquidRenderer.new(@page, layout: @page.secondary_liquid_layout)
+  private
+
+  def render_liquid(layout)
+    raise ActiveRecord::RecordNotFound unless @page.active? || user_signed_in?
+    recognized_member = Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
+    renderer = LiquidRenderer.new(@page, request_country: request_country, member: recognized_member, layout: layout, url_params: params)
     @rendered = renderer.render
     render :show, layout: 'sumofus'
   end
-
-  private
 
   def get_page
     @page = Page.find(params[:id])

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -26,7 +26,7 @@ class LiquidRenderer
   end
 
   def data
-    @data ||= Plugins.data_for_view(@page).
+    @data ||= Plugins.data_for_view(@page, {form_values: @member.try(:attributes)}).
                 merge( @page.liquid_data ).
                 merge( images: images ).
                 merge( primary_image: image_urls(@page.image_to_display) ).

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -1,11 +1,12 @@
 class LiquidRenderer
   include Rails.application.routes.url_helpers
 
-  def initialize(page, layout: nil, request_country: nil, member: nil)
+  def initialize(page, layout: nil, request_country: nil, member: nil, url_params: {})
     @page = page
     @markup = layout.content unless layout.blank?
     @request_country = request_country
     @member = member
+    @url_params = url_params
   end
 
   def render
@@ -31,6 +32,7 @@ class LiquidRenderer
                 merge( primary_image: image_urls(@page.image_to_display) ).
                 merge( LiquidHelper.globals(request_country: @request_country, member: @member, page: @page) ).
                 merge( shares: Shares.get_all(@page) ).
+                merge( url_params: @url_params ).
                 merge( follow_up_url: follow_up_page_path(@page.id)).
                 deep_stringify_keys
   end

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -8,9 +8,15 @@
   {% endif %}
   <input type='hidden' name='form_id' value='{{ form_id }}' />
   {% for field in fields %}
-    <div class="form__group {% if member[field.name] %}form__group--prefilled{% endif %}">
+    {% if member[field.name] %}
+      {% assign prefilled = true %}
+    {% elsif member and field.required == false %}
+      {% assign prefilled = true %}
+    {% else %}
+      {% assign prefilled = false %}
+    {% endif %}
+    <div class="form__group {% if prefilled %}form__group--prefilled{% endif %}">
       {% case field.data_type %}
-
       {% when 'text' %}
         <input type="text" name="{{field.name}}" class="form-control" id="" placeholder="{{ field.label }}" value="{{member[field.name]}}"/>
       {% when 'email' %}

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -8,7 +8,9 @@
   {% endif %}
   <input type='hidden' name='form_id' value='{{ form_id }}' />
   {% for field in fields %}
-    {% if member[field.name] %}
+    {% if outstanding_fields contains field.name %}
+      {% assign prefilled = false %}
+    {% elsif member[field.name] %}
       {% assign prefilled = true %}
     {% elsif member and field.required == false %}
       {% assign prefilled = true %}

--- a/app/models/plugins.rb
+++ b/app/models/plugins.rb
@@ -26,14 +26,14 @@ module Plugins
         Plugins::Fundraiser ]
     end
 
-    def data_for_view(page)
+    def data_for_view(page, supplemental_data={})
       default_ref = 'default'
       plugins_data = page.plugins.inject({}) do |memo, plugin|
         if plugin
           plugin_name = plugin.name.underscore
           memo[plugin_name] = {} unless memo.include? plugin_name
           ref = plugin.ref.present? ? plugin.ref : default_ref
-          memo[plugin_name][ref] = plugin.liquid_data
+          memo[plugin_name][ref] = plugin.liquid_data(supplemental_data)
         end
         memo
       end

--- a/app/models/plugins/action.rb
+++ b/app/models/plugins/action.rb
@@ -8,8 +8,12 @@ class Plugins::Action < ActiveRecord::Base
 
   DEFAULTS = { cta: 'Sign the Petition' }
 
-  def liquid_data
-    attributes.merge(form_id: form.try(:id), fields: form_fields)
+  def liquid_data(supplemental_data={})
+    attributes.merge(
+      form_id: form.try(:id),
+      fields: form_fields,
+      outstanding_fields: outstanding_fields(supplemental_data[:form_values]).map(&:to_s)
+    )
   end
 
   def form_fields
@@ -18,6 +22,11 @@ class Plugins::Action < ActiveRecord::Base
 
   def name
     self.class.name.demodulize
+  end
+
+  def outstanding_fields(form_values)
+    return [] if form.blank?
+    FormValidator.new({form_id: form_id}.merge(form_values || {})).errors.keys
   end
 
   private

--- a/app/models/plugins/action.rb
+++ b/app/models/plugins/action.rb
@@ -1,37 +1,12 @@
 class Plugins::Action < ActiveRecord::Base
+  include Plugins::HasForm
+
   belongs_to :page
-  belongs_to :form
-
   validates :cta, presence: true, allow_blank: false
-
-  after_create :create_form
 
   DEFAULTS = { cta: 'Sign the Petition' }
 
   def liquid_data(supplemental_data={})
-    attributes.merge(
-      form_id: form.try(:id),
-      fields: form_fields,
-      outstanding_fields: outstanding_fields(supplemental_data[:form_values]).map(&:to_s)
-    )
-  end
-
-  def form_fields
-    form ? form.form_elements.map(&:attributes) : []
-  end
-
-  def name
-    self.class.name.demodulize
-  end
-
-  def outstanding_fields(form_values)
-    return [] if form.blank?
-    FormValidator.new({form_id: form_id}.merge(form_values || {})).errors.keys
-  end
-
-  private
-
-  def create_form
-    update(form: Form.create(master: false, name: "action:#{id}"))
+    attributes.merge(form_liquid_data(supplemental_data))
   end
 end

--- a/app/models/plugins/fundraiser.rb
+++ b/app/models/plugins/fundraiser.rb
@@ -1,38 +1,13 @@
 class Plugins::Fundraiser < ActiveRecord::Base
+  include Plugins::HasForm
+
   belongs_to :page
-  belongs_to :form
   belongs_to :donation_band
 
   DEFAULTS = { title: 'Donate now' }
 
-  after_create :create_form
-
   def liquid_data(supplemental_data={})
     bands = donation_band.present? ? donation_band.internationalize.to_json : "null"
-    attributes.merge(
-      form_id: form_id,
-      fields: form_fields,
-      donation_bands: bands,
-      outstanding_fields: outstanding_fields(supplemental_data[:form_values]).map(&:to_s)
-    )
-  end
-
-  def form_fields
-    form ? form.form_elements.map(&:attributes) : []
-  end
-
-  def name
-    self.class.name.demodulize
-  end
-
-  def outstanding_fields(form_values)
-    return [] if form_id.blank?
-    FormValidator.new({form_id: form_id}.merge(form_values || {})).errors.keys
-  end
-
-  private
-
-  def create_form
-    update(form: Form.create(master: false, name: "fundraiser:#{id}"))
+    attributes.merge(form_liquid_data(supplemental_data)).merge(donation_bands: bands)
   end
 end

--- a/app/models/plugins/has_form.rb
+++ b/app/models/plugins/has_form.rb
@@ -1,0 +1,35 @@
+module Plugins::HasForm
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :form
+    after_create :create_form
+  end
+
+  def form_fields
+    form ? form.form_elements.map(&:attributes) : []
+  end
+
+  def name
+    self.class.name.demodulize
+  end
+
+  def outstanding_fields(form_values)
+    return [] if form.blank?
+    FormValidator.new({form_id: form_id}.merge(form_values || {})).errors.keys
+  end
+
+  private
+
+  def create_form
+    update(form: Form.create(master: false, name: "#{name}:#{id}"))
+  end
+
+  def form_liquid_data(supplemental_data)
+    {
+      form_id: form.try(:id),
+      fields: form_fields,
+      outstanding_fields: outstanding_fields(supplemental_data[:form_values]).map(&:to_s)
+    }
+  end
+end

--- a/app/models/plugins/thermometer.rb
+++ b/app/models/plugins/thermometer.rb
@@ -17,7 +17,7 @@ class Plugins::Thermometer < ActiveRecord::Base
     current_total / goal.to_f * 100
   end
 
-  def liquid_data
+  def liquid_data(supplemental_data={})
     attributes.merge(
       percentage: current_progress,
       remaining: number_with_delimiter(goal - current_total),

--- a/app/services/form_validator.rb
+++ b/app/services/form_validator.rb
@@ -1,7 +1,7 @@
 class FormValidator
 
   def initialize(params)
-    @params = params
+    @params = params.symbolize_keys
   end
 
   def form

--- a/app/views/form_elements/_element.slim
+++ b/app/views/form_elements/_element.slim
@@ -4,6 +4,8 @@ li.list-group-item data-id=element.id
   = element.label
 
   .control-bar
+    - if element.required
+      span.label.label-primary required
     span.label.label-info = element.data_type
 
     = link_to form_form_element_path(form, element),

--- a/app/views/forms/_add_element.slim
+++ b/app/views/forms/_add_element.slim
@@ -12,7 +12,7 @@
         = link_to '#', class: 'modal-open'
           span.glyphicon.glyphicon-question-sign
   .checkbox
-    = f.label :require do
+    = f.label :required do
       = f.check_box :required
       = t('plugins.action.make_required')
 

--- a/app/views/forms/_preview.html.slim
+++ b/app/views/forms/_preview.html.slim
@@ -1,12 +1,13 @@
 form
   - form.form_elements.each do |element|
     .form-element.form-group.clearfix
+      - label = "#{element.label}#{element.required ? '*' : ''}"
       - case element.data_type
       - when 'text', 'email', 'phone'
-        input.form-control placeholder=element.label
+        input.form-control placeholder=label
       - when 'country'
         = select_tag '', options_for_select(ISO3166::Country.all_names_with_codes), class: "form-control"
       - when 'checkbox'
         = check_box_tag element.name
         '&nbsp;
-        = element.label
+        = label

--- a/app/views/plugins/actions/_action.liquid
+++ b/app/views/plugins/actions/_action.liquid
@@ -25,6 +25,7 @@
         {% include 'Form',
           cta: plugins.action[ref].cta,
           form_id: plugins.action[ref].form_id,
+          outstanding_fields: plugins.fundraiser[ref].outstanding_fields,
           fields: plugins.action[ref].fields %}
       </div>
     </div>

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -49,6 +49,9 @@
             fields: plugins.fundraiser[ref].fields %}
         </div>
         <div class="fundraiser-bar__step-panel form--big" data-step="3">
+          <div class="fundraiser-bar__mistaken-identity hidden-irrelevant">
+            Welcome back, {{member.welcome_name}}! <a href="javascript:;" class="fundraiser-bar__clear-form">Not you?</a>
+          </div>
           <form action='/' id="hosted-fields">
             <div class="form__group">
               <div class="hosted-fields__host hosted-fields__number"></div>
@@ -83,7 +86,9 @@
       var myFundraiserBar = new window.FundraiserBar({
         followUpUrl: "{{ follow_up_url }}",
         currency: "{{ guessed_currency }}",
-        donationBands: {{ plugins.fundraiser[ref].donation_bands }}
+        donationBands: {{ plugins.fundraiser[ref].donation_bands }},
+        amount: {% if url_params['amount'] == blank %} 0 {% else %} {{ url_params['amount'] }}{% endif %},
+        outstandingFields: {{ plugins.fundraiser[ref].outstanding_fields.size }}
       });
     });
   </script>

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -46,6 +46,7 @@
             cta: 'Proceed to payment',
             form_id: plugins.fundraiser[ref].form_id,
             form_url_postscript: '/validate',
+            outstanding_fields: plugins.fundraiser[ref].outstanding_fields,
             fields: plugins.fundraiser[ref].fields %}
         </div>
         <div class="fundraiser-bar__step-panel form--big" data-step="3">

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -49,8 +49,9 @@
             fields: plugins.fundraiser[ref].fields %}
         </div>
         <div class="fundraiser-bar__step-panel form--big" data-step="3">
-          <div class="fundraiser-bar__mistaken-identity hidden-irrelevant">
-            Welcome back, {{member.welcome_name}}! <a href="javascript:;" class="fundraiser-bar__clear-form">Not you?</a>
+          <div class="fundraiser-bar__welcome-text hidden-irrelevant">
+            Welcome back, {{member.welcome_name}}! <br />
+            <a href="javascript:;" class=" fundraiser-bar__clear-form">Not you?</a>
           </div>
           <form action='/' id="hosted-fields">
             <div class="form__group">

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
 
     factory :form_with_email do
       after(:create) do |form, evaluator|
-        create :form_element, form: form, name: 'email', label: 'Email'
+        create :form_element, form: form, name: 'email', label: 'Email', data_type: 'email'
       end
     end
 

--- a/spec/javascripts/fixtures/magic_lamp.rb
+++ b/spec/javascripts/fixtures/magic_lamp.rb
@@ -1,6 +1,8 @@
 MagicLamp.define(controller: PagesController) do
   fixture(name: 'pages/fundraiser') do
     @page = FactoryGirl.create :page, liquid_layout: LiquidLayout.find_by(title: 'Standard Fundraiser')
+    form = FactoryGirl.create :form_with_email
+    @page.plugins.each { |pl| if pl.name == 'Fundraiser' then pl.update_attributes(form: form) end }
     params[:id] = @page.id
     show
   end

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -11,215 +11,287 @@ describe("fundraiser", function() {
     };
   });
 
-  afterEach(function() {
-    suite.server.restore();
-    suite.fundraiserBar.redirectTo.restore();
+  describe('instantiation', function(){
+
+    it('sets the default currency if currency passed');
+    it('displays the values from the correct passed donation band');
+
+    describe('outstanding fields is empty list', function(){
+
+      describe('amount is not passed', function(){
+        it('starts on the first step');
+        it('hides the second step');
+        it('displays the second step when user requests');
+        it('clears prefilled fields when second step displayed');
+      });
+
+      describe('amount is greater than zero ', function(){
+        it('skips to the third step');
+        it('displays the correct amount');
+        it('hides the second step');
+        it('displays the second step when user requests');
+        it('clears prefilled fields when second step displayed');
+      });
+    });
+
+    describe('outstanding fields is not passed', function(){
+
+      describe('amount is not passed', function(){
+        it('starts on the first step');
+        it('displays the second step');
+      });
+
+      describe('amount is greater than zero ', function(){
+        it('skips to the second step');
+        it('displays the correct amount');
+        it('displays the second step');
+      });
+    });
+
+    describe('outstanding fields is list of fields', function(){
+
+      describe('amount is not passed', function(){
+        it('starts on the first step');
+        it('displays the second step');
+      });
+
+      describe('amount is greater than zero ', function(){
+        it('skips to the second step');
+        it('displays the correct amount');
+        it('displays the second step');
+      });
+    });
+
+    describe('degenerate arguments', function(){
+
+      describe('it starts on first step when amount', function(){
+        it('is negative');
+        it('is zero');
+        it('is a string');
+        it('is null');
+        it('is an array');
+      })
+
+      it('shows second step when outstandingFields', function(){
+        it('is an object');
+        it('is null');
+        it('is a number');
+        it('is a string');
+      });
+    });
+
   });
 
-  beforeEach(function() {
-    MagicLamp.wish("pages/fundraiser");
+  describe('interactions', function(){
+
+    beforeEach(function() {
+      MagicLamp.wish("pages/fundraiser");
 
 
-    suite.server = sinon.fakeServer.create();
-    suite.server.respondWith("GET", '/api/braintree/token',
-                            [200, { "Content-Type": "application/json" },
-                            '{ "token": "'+helpers.btClientToken+'" }' ]);
+      suite.server = sinon.fakeServer.create();
+      suite.server.respondWith("GET", '/api/braintree/token',
+                              [200, { "Content-Type": "application/json" },
+                              '{ "token": "'+helpers.btClientToken+'" }' ]);
 
-    suite.follow_up_url = "/pages/636/follow-up";
-    suite.fundraiserBar = new window.FundraiserBar({ followUpUrl: suite.follow_up_url });
-    sinon.stub(suite.fundraiserBar, 'redirectTo');
-    suite.server.respond(); // respond to request for token
+      suite.follow_up_url = "/pages/636/follow-up";
+      suite.fundraiserBar = new window.FundraiserBar({ followUpUrl: suite.follow_up_url });
+      sinon.stub(suite.fundraiserBar, 'redirectTo');
+      suite.server.respond(); // respond to request for token
+    });
+
+    afterEach(function() {
+      suite.server.restore();
+      suite.fundraiserBar.redirectTo.restore();
+    });
+
+    describe('loading and first panel', function(){
+
+      it("starts on the first step", function() {
+        expect(helpers.currentStepOf(3)).to.eq(1);
+      });
+
+      it('does not display the "next" button', function(){
+        expect($('.fundraiser-bar__first-continue')).to.have.css('display', 'none');
+      });
+
+      it('autofills the custom amount with a dollar sign', function(){
+        var $el = $('.fundraiser-bar__custom-field');
+        expect($el).to.have.value('');
+        $el.focus();
+        expect($el).to.have.value('$');
+      });
+
+      it('reveals the "next" button when a custom amount is entered', function(){
+        var $next = $('.fundraiser-bar__first-continue');
+        var $input = $('.fundraiser-bar__custom-field');
+        expect($next).to.have.css('display','none');
+        $input.focus();
+        expect($next).not.to.have.css('display','none');
+        $input.blur();
+        expect($next).have.css('display','none');
+        $input.focus();
+        $input.val('$25');
+        $input.blur();
+        expect($next).not.to.have.css('display','none');
+      });
+
+      it('moves to step 2 when amount button clicked', function(){
+        $('.fundraiser-bar__amount-button').click();
+        expect(helpers.currentStepOf(3)).to.eq(2);
+      });
+
+      it('moves to step 2 when next clicked with custom amount', function(){
+        $('.fundraiser-bar__custom-field').val('$22');
+        $('.fundraiser-bar__first-continue').click();
+        expect(helpers.currentStepOf(3)).to.eq(2);
+      });
+
+      it('does not move to step 2 if custom amount has only dollar sign', function(){
+        $('.fundraiser-bar__custom-field').val('$');
+        $('.fundraiser-bar__first-continue').click();
+        expect(helpers.currentStepOf(3)).to.eq(1);
+      });
+
+      it('displays the amount over step 1 after moving ahead', function(){
+        $('.fundraiser-bar__custom-field').val('$22');
+        $('.fundraiser-bar__first-continue').click();
+        expect($('.fundraiser-bar__display-amount').text()).to.eq('$22');
+      });
+
+      it('changes the buttons to the right band when currency changes', function(){
+        suite.fundraiserBar.donationBands['GBP'] = [1, 2, 3, 4, 5, 6, 7];
+        $('.fundraiser-bar__currency-selector').val('GBP').change();
+        var $buttons = $('.fundraiser-bar__amount-button');
+        var texts = $buttons.map(function(ii, el){ return $(el).text() }).toArray();
+        var vals =  $buttons.map(function(ii, el){ return $(el).data('amount'); }).toArray();
+        expect($buttons.length).to.equal(7);
+        expect(texts).to.include.members(['£1', '£2', '£3', '£4', '£5', '£6', '£7']);
+        expect(vals).to.include.members([1, 2, 3, 4, 5, 6, 7]);
+      });
+
+      it('shows the selector when prompted', function(){
+        var $selector = $('.fundraiser-bar__currency-selector');
+        expect($selector).to.have.css('display','none');
+        $('.fundraiser-bar__engage-currency-switcher').click();
+        expect($selector).not.to.have.css('display','none');
+      });
+
+      it('changes the reported currency code when currency changes', function(){
+        expect($('.fundraiser-bar__current-currency').text()).to.equal('USD');
+        $('.fundraiser-bar__currency-selector').val('AUD').change();
+        expect($('.fundraiser-bar__current-currency').text()).to.equal('AUD');
+      });
+
+      it('changes the filled in currency symbol when clicking in', function(){
+        $('.fundraiser-bar__currency-selector').val('GBP').change();
+        var $el = $('.fundraiser-bar__custom-field');
+        expect($el).to.have.value('');
+        $el.focus();
+        expect($el).to.have.value('£');
+      });
+
+      it('displays the amount over step 1 with correct currency after moving on', function(){
+        $('.fundraiser-bar__currency-selector').val('EUR').change();
+        $('.fundraiser-bar__custom-field').val('$22');
+        $('.fundraiser-bar__first-continue').click();
+        expect($('.fundraiser-bar__display-amount').text()).to.eq('€22');
+      });
+    });
+
+    describe('second panel', function(){
+      // most of the interaction on the form are on the form js, which is beyond the scope
+      // of this test suite
+
+      beforeEach(function(){
+        $('.fundraiser-bar__custom-field').val('$22');
+        $('.fundraiser-bar__first-continue').click();
+      });
+
+      it('returns to panel 1 if number 1 is clicked', function(){
+        $('.fundraiser-bar__step-label[data-step="1"] .fundraiser-bar__step-number').click();
+        expect(helpers.currentStepOf(3)).to.eq(1);
+      });
+
+      it('makes a request to validate the form', function(){
+        $('.action-bar__submit-button').click();
+        var request = helpers.last(suite.server.requests);
+        expect(request.method).to.eq("POST");
+        expect(request.url).to.match(suite.validatePath);
+      });
+
+      it('moves to panel 3 if validation passes', function(){
+        $('.action-bar__submit-button').click();
+        helpers.last(suite.server.requests).respond(200, { "Content-Type": "application/json" }, '{}');
+        expect(helpers.currentStepOf(3)).to.eq(3);
+      });
+
+      it('stays on panel 2 if validation fails', function(){
+        $('.action-bar__submit-button').click();
+        helpers.last(suite.server.requests).respond(422, { "Content-Type": "application/json" }, '{ "errors": {} }');
+        expect(helpers.currentStepOf(3)).to.eq(2);
+      });
+    });
+
+    describe('third panel', function() {
+
+      beforeEach(function(){
+        suite.server.respondWith("POST", this.validatePath, ["200", {}, ""]);
+        $('.fundraiser-bar__custom-field').val('$22');
+        $('.fundraiser-bar__first-continue').click();
+        $('.action-bar__submit-button').click();
+
+        suite.server.respond();
+        expect(helpers.currentStepOf(3)).to.eq(3);
+      });
+
+      it('disables the button when the form submits', function(){
+        var $button = $('.fundraiser-bar__submit-button');
+        expect($button).not.to.have.class('button--disabled');
+        $button.click();
+        expect($button).to.have.class('button--disabled');
+      });
+
+      xit('first makes a request to braintree', function(){
+        // I don't think we can test this without some serious iframe hackery
+      });
+
+      it('sends the nonce to the server after receiving it from braintree', function(){
+        suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
+        request = helpers.last(suite.server.requests);
+        expect(request.method).to.eq("POST");
+        expect(request.url).to.eq("/api/braintree/transaction");
+
+        expect(helpers.lastRequestBodyPairs(suite)).to.include.members(["payment_method_nonce="+helpers.btNonce, "amount=22"]);
+      });
+
+      it("sends 'recurring' as false by default", function(){
+        suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
+        expect(helpers.lastRequestBodyPairs(suite)).to.include.members(["recurring=false"]);
+      });
+
+      it("sends 'recurring' as true if it's checked", function(){
+        $('input.fundraiser-bar__recurring').click();
+        suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
+        expect(helpers.lastRequestBodyPairs(suite)).to.include.members(["recurring=true"]);
+      });
+
+      it('loads the follow-up url after success from the server', function(){
+        suite.server.respondWith('POST', "/api/braintree/transaction", [200, { "Content-Type": "application/json" }, '{ "success": "true" }' ]);
+        suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
+        suite.server.respond();
+        expect(suite.fundraiserBar.redirectTo).to.have.been.calledWith(suite.follow_up_url);
+      });
+
+      it('submits the currency and amount to the server', function(){
+        suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
+        request = helpers.last(suite.server.requests);
+        bodyPairs = decodeURI(request.requestBody).split('&');
+        expect(bodyPairs).to.include.members(['currency=USD', "amount=22"]);
+      });
+
+      xit('displays validation errors passed back from the server', function(){
+        // it doesn't actually do this yet, spec is here as a reminder
+      });
+    });
   });
-
-
-  describe('loading and first panel', function(){
-
-    it("shows only the first two panels of the donate panel", function() {
-      expect(helpers.currentStepOf(3)).to.eq(1);
-    });
-
-    it('does not display the "next" button', function(){
-      expect($('.fundraiser-bar__first-continue')).to.have.css('display', 'none');
-    });
-
-    it('autofills the custom amount with a dollar sign', function(){
-      var $el = $('.fundraiser-bar__custom-field');
-      expect($el).to.have.value('');
-      $el.focus();
-      expect($el).to.have.value('$');
-    });
-
-    it('reveals the "next" button when a custom amount is entered', function(){
-      var $next = $('.fundraiser-bar__first-continue');
-      var $input = $('.fundraiser-bar__custom-field');
-      expect($next).to.have.css('display','none');
-      $input.focus();
-      expect($next).not.to.have.css('display','none');
-      $input.blur();
-      expect($next).have.css('display','none');
-      $input.focus();
-      $input.val('$25');
-      $input.blur();
-      expect($next).not.to.have.css('display','none');
-    });
-
-    it('moves to step 2 when amount button clicked', function(){
-      $('.fundraiser-bar__amount-button').click();
-      expect(helpers.currentStepOf(3)).to.eq(2);
-    });
-
-    it('moves to step 2 when next clicked with custom amount', function(){
-      $('.fundraiser-bar__custom-field').val('$22');
-      $('.fundraiser-bar__first-continue').click();
-      expect(helpers.currentStepOf(3)).to.eq(2);
-    });
-
-    it('does not move to step 2 if custom amount has only dollar sign', function(){
-      $('.fundraiser-bar__custom-field').val('$');
-      $('.fundraiser-bar__first-continue').click();
-      expect(helpers.currentStepOf(3)).to.eq(1);
-    });
-
-    it('displays the amount over step 1 after moving ahead', function(){
-      $('.fundraiser-bar__custom-field').val('$22');
-      $('.fundraiser-bar__first-continue').click();
-      expect($('.fundraiser-bar__display-amount').text()).to.eq('$22');
-    });
-
-    it('changes the buttons to the right band when currency changes', function(){
-      suite.fundraiserBar.donationBands['GBP'] = [1, 2, 3, 4, 5, 6, 7];
-      $('.fundraiser-bar__currency-selector').val('GBP').change();
-      var $buttons = $('.fundraiser-bar__amount-button');
-      var texts = $buttons.map(function(ii, el){ return $(el).text() }).toArray();
-      var vals =  $buttons.map(function(ii, el){ return $(el).data('amount'); }).toArray();
-      expect($buttons.length).to.equal(7);
-      expect(texts).to.include.members(['£1', '£2', '£3', '£4', '£5', '£6', '£7']);
-      expect(vals).to.include.members([1, 2, 3, 4, 5, 6, 7]);
-    });
-
-    it('shows the selector when prompted', function(){
-      var $selector = $('.fundraiser-bar__currency-selector');
-      expect($selector).to.have.css('display','none');
-      $('.fundraiser-bar__engage-currency-switcher').click();
-      expect($selector).not.to.have.css('display','none');
-    });
-
-    it('changes the reported currency code when currency changes', function(){
-      expect($('.fundraiser-bar__current-currency').text()).to.equal('USD');
-      $('.fundraiser-bar__currency-selector').val('AUD').change();
-      expect($('.fundraiser-bar__current-currency').text()).to.equal('AUD');
-    });
-
-    it('changes the filled in currency symbol when clicking in', function(){
-      $('.fundraiser-bar__currency-selector').val('GBP').change();
-      var $el = $('.fundraiser-bar__custom-field');
-      expect($el).to.have.value('');
-      $el.focus();
-      expect($el).to.have.value('£');
-    });
-
-    it('displays the amount over step 1 with correct currency after moving on', function(){
-      $('.fundraiser-bar__currency-selector').val('EUR').change();
-      $('.fundraiser-bar__custom-field').val('$22');
-      $('.fundraiser-bar__first-continue').click();
-      expect($('.fundraiser-bar__display-amount').text()).to.eq('€22');
-    });
-  });
-
-  describe('second panel', function(){
-    // most of the interaction on the form are on the form js, which is beyond the scope
-    // of this test suite
-
-    beforeEach(function(){
-      $('.fundraiser-bar__custom-field').val('$22');
-      $('.fundraiser-bar__first-continue').click();
-    });
-
-    it('returns to panel 1 if number 1 is clicked', function(){
-      $('.fundraiser-bar__step-label[data-step="1"] .fundraiser-bar__step-number').click();
-      expect(helpers.currentStepOf(3)).to.eq(1);
-    });
-
-    it('makes a request to validate the form', function(){
-      $('.action-bar__submit-button').click();
-      var request = helpers.last(suite.server.requests);
-      expect(request.method).to.eq("POST");
-      expect(request.url).to.match(suite.validatePath);
-    });
-
-    it('moves to panel 3 if validation passes', function(){
-      $('.action-bar__submit-button').click();
-      helpers.last(suite.server.requests).respond(200, { "Content-Type": "application/json" }, '{}');
-      expect(helpers.currentStepOf(3)).to.eq(3);
-    });
-
-    it('stays on panel 2 if validation fails', function(){
-      $('.action-bar__submit-button').click();
-      helpers.last(suite.server.requests).respond(422, { "Content-Type": "application/json" }, '{ "errors": {} }');
-      expect(helpers.currentStepOf(3)).to.eq(2);
-    });
-  });
-
-  describe('third panel', function() {
-
-    beforeEach(function(){
-      suite.server.respondWith("POST", this.validatePath, ["200", {}, ""]);
-      $('.fundraiser-bar__custom-field').val('$22');
-      $('.fundraiser-bar__first-continue').click();
-      $('.action-bar__submit-button').click();
-
-      suite.server.respond();
-      expect(helpers.currentStepOf(3)).to.eq(3);
-    });
-
-    it('disables the button when the form submits', function(){
-      var $button = $('.fundraiser-bar__submit-button');
-      expect($button).not.to.have.class('button--disabled');
-      $button.click();
-      expect($button).to.have.class('button--disabled');
-    });
-
-    xit('first makes a request to braintree', function(){
-      // I don't think we can test this without some serious iframe hackery
-    });
-
-    it('sends the nonce to the server after receiving it from braintree', function(){
-      suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
-      request = helpers.last(suite.server.requests);
-      expect(request.method).to.eq("POST");
-      expect(request.url).to.eq("/api/braintree/transaction");
-
-      expect(helpers.lastRequestBodyPairs(suite)).to.include.members(["payment_method_nonce="+helpers.btNonce, "amount=22"]);
-    });
-
-    it("sends 'recurring' as false by default", function(){
-      suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
-      expect(helpers.lastRequestBodyPairs(suite)).to.include.members(["recurring=false"]);
-    });
-
-    it("sends 'recurring' as true if it's checked", function(){
-      $('input.fundraiser-bar__recurring').click();
-      suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
-      expect(helpers.lastRequestBodyPairs(suite)).to.include.members(["recurring=true"]);
-    });
-
-    it('loads the follow-up url after success from the server', function(){
-      suite.server.respondWith('POST', "/api/braintree/transaction", [200, { "Content-Type": "application/json" }, '{ "success": "true" }' ]);
-      suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
-      suite.server.respond();
-      expect(suite.fundraiserBar.redirectTo).to.have.been.calledWith(suite.follow_up_url);
-    });
-
-    it('submits the currency and amount to the server', function(){
-      suite.fundraiserBar.fakeNonceSuccess({nonce: helpers.btNonce});
-      request = helpers.last(suite.server.requests);
-      bodyPairs = decodeURI(request.requestBody).split('&');
-      expect(bodyPairs).to.include.members(['currency=USD', "amount=22"]);
-    });
-
-    xit('displays validation errors passed back from the server', function(){
-      // it doesn't actually do this yet, spec is here as a reminder
-    });
-  });
-
 });

--- a/spec/liquid/liquid_renderer_spec.rb
+++ b/spec/liquid/liquid_renderer_spec.rb
@@ -7,6 +7,26 @@ describe LiquidRenderer do
   let(:page) { create :page, liquid_layout: liquid_layout, content: 'sliiiiide to the left' }
   let(:renderer) { LiquidRenderer.new(page) }
 
+  describe 'new' do
+    it 'receives the correct arguments' do
+      expect{
+        LiquidRenderer.new(page, layout: liquid_layout, request_country: 'RD', member: {}, url_params: {hi: 'a'})
+      }.not_to raise_error
+    end
+
+    it 'requires only page' do
+      expect{
+        LiquidRenderer.new(page)
+      }.not_to raise_error
+    end
+
+    it 'does not receive arbitrary keyword arguments' do
+      expect{
+        LiquidRenderer.new(page, secondary_layout: liquid_layout)
+      }.to raise_error(ArgumentError)
+    end
+  end
+
   describe "render" do
     it "returns an html string with the title" do
       expect(renderer.render).to include("<h1>#{page.title}</h1>")
@@ -33,7 +53,7 @@ describe LiquidRenderer do
     end
 
     it "should have expected keys" do
-      expected_keys = ['plugins', 'ref', 'title', 'content', 'images', 'shares', 'country_option_tags']
+      expected_keys = ['plugins', 'ref', 'title', 'content', 'images', 'shares', 'country_option_tags', 'url_params', 'primary_image', 'follow_up_url']
       actual_keys = renderer.data.keys
       expected_keys.each do |expected_key|
         expect(actual_keys).to include(expected_key)

--- a/spec/models/plugins/action_spec.rb
+++ b/spec/models/plugins/action_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
+require_relative 'shared_examples'
 
 describe Plugins::Action do
   let(:action) { create :plugins_action }
 
   subject{ action }
+
+  include_examples "plugin with form", :plugins_action
 
   it { is_expected.to be_valid }
   it { is_expected.to respond_to :description }

--- a/spec/models/plugins/fundraiser_spec.rb
+++ b/spec/models/plugins/fundraiser_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
+require_relative 'shared_examples'
 
 describe Plugins::Fundraiser do
   let(:fundraiser) { create :plugins_fundraiser }
 
   subject{ fundraiser }
+
+  include_examples "plugin with form", :plugins_fundraiser
 
   it { is_expected.to be_valid }
   it { is_expected.to respond_to :title }

--- a/spec/models/plugins/plugins_spec.rb
+++ b/spec/models/plugins/plugins_spec.rb
@@ -67,6 +67,10 @@ describe Plugins do
         expect(data_for_view[:plugins]['action'].keys[0]).to eq data_for_view[:ref]
       end
 
+      it 'can receive supplemental data ' do
+        expect{ Plugins.data_for_view(page, {some: 'stuff'}) }.not_to raise_error
+      end
+
     end
 
   end

--- a/spec/models/plugins/shared_examples.rb
+++ b/spec/models/plugins/shared_examples.rb
@@ -1,0 +1,36 @@
+shared_examples "plugin with form" do |plugin_sym|
+
+  let(:plugin) { create plugin_sym }
+  let(:form) { create :form_with_email }
+
+  it "can accept random supplemental data to liquid_data method" do
+    expect{ plugin.liquid_data({foo: 'bar'}) }.not_to raise_error
+  end
+
+  it "serializes outstanding_fields without a form or values" do
+    plugin.form_id = nil
+    expect( plugin.liquid_data[:outstanding_fields]).to eq []
+  end
+
+  it "serializes outstanding_fields without a form but with values" do
+    plugin.form_id = nil
+    expect( plugin.liquid_data({form_values: {email: 'a'}})[:outstanding_fields]).to eq []
+  end
+
+  it "serializes outstanding_fields without values but with a form" do
+    plugin.form_id = form.id
+    plugin.form.form_elements.each{ |el| el.update_attributes(required: true) }
+    expect( plugin.liquid_data[:outstanding_fields]).to eq ['email']
+  end
+
+  it "serializes outstanding_fields with a form and values" do
+    plugin.form_id = form.id
+    expect( plugin.liquid_data({form_values: {email: 'a'}})[:outstanding_fields]).to eq ['email']
+  end
+
+  it "serializes outstanding_fields with a form and values that match" do
+    plugin.form_id = form.id
+    expect( plugin.liquid_data({form_values: {email: 'neal@test.com'}})[:outstanding_fields]).to eq []
+  end
+
+end

--- a/spec/models/plugins/thermometer_spec.rb
+++ b/spec/models/plugins/thermometer_spec.rb
@@ -6,6 +6,10 @@ describe Plugins::Thermometer do
   let(:test_page) { Page.create! title: 'test page', action_count: starting_action_count, liquid_layout: liquid_layout }
   let(:thermometer) { Plugins::Thermometer.create! offset: 0, goal: 1000, page: test_page }
 
+  it "can accept random supplemental data to liquid_data method" do
+    expect{ thermometer.liquid_data({foo: 'bar'}) }.not_to raise_error
+  end
+
   it 'correctly returns the current total' do
     expect(thermometer.current_total).to eq(starting_action_count)
   end

--- a/spec/services/form_validator_spec.rb
+++ b/spec/services/form_validator_spec.rb
@@ -15,23 +15,28 @@ describe FormValidator do
       expect(subject).to be_valid
     end
 
+    it 'is valid with value and string key' do
+      params.merge!('address1' => 'bar')
+      expect(subject).to be_valid
+    end
+
     context "is invalid" do
       it "without value" do
         expect(subject).to_not be_valid
       end
 
       it "with nil" do
-        params.merge!(address: nil)
+        params.merge!(address1: nil)
         expect(subject).to_not be_valid
       end
 
       it "with false" do
-        params.merge!(address: false)
+        params.merge!(address1: false)
         expect(subject).to_not be_valid
       end
 
       it "with empty string" do
-        params.merge!(address: "")
+        params.merge!(address1: "")
         expect(subject).to_not be_valid
       end
     end


### PR DESCRIPTION
This PR makes the fundraiser bar hide the second step if the member is recognized by akid or member id, and skips the first step, preselecting the amount, if the amount is passed in the url parameters. Most of the code is test code for the javascript and the back end changes made to accomodate this.

The biggest back end change this makes is that we now pass data from the controller to the liquid_data method of the plugins. This allows us to check the form against the existing data to determine if the user data step can in fact be skipped, and tells us if any prefilled data won't pass validation.