### PR TITLE
WIP - Braintree paypal / needed somewhere to converse

### DIFF
--- a/app/controllers/api/braintree_controller.rb
+++ b/app/controllers/api/braintree_controller.rb
@@ -97,11 +97,7 @@ class Api::BraintreeController < ApplicationController
   def default_payment_method_token
    local_customer.try(:card_vault_token)
   end
-
-  def customer_id
-    local_customer.try(:card_vault_token)
-  end
-
+  
   def local_customer
     @local_customer ||= ::Payment.customer(params[:user][:email])
   end

--- a/app/controllers/api/braintree_controller.rb
+++ b/app/controllers/api/braintree_controller.rb
@@ -60,7 +60,7 @@ class Api::BraintreeController < ApplicationController
 
         customer = Payment::BraintreeCustomer.find_or_initialize_by(email: user[:email])
         customer.update(
-          card_vault_token: result.customer.payment_methods.first.token,
+          default_payment_method_token: result.customer.payment_methods.first.token,
           customer_id: result.customer.id,
           first_name: user[:firstname] || user[:name],
           last_name: user[:last_name]
@@ -95,9 +95,9 @@ class Api::BraintreeController < ApplicationController
   end
 
   def default_payment_method_token
-   local_customer.try(:card_vault_token)
+   local_customer.try(:default_payment_method_token)
   end
-  
+
   def local_customer
     @local_customer ||= ::Payment.customer(params[:user][:email])
   end

--- a/app/controllers/api/braintree_controller.rb
+++ b/app/controllers/api/braintree_controller.rb
@@ -63,10 +63,21 @@ class Api::BraintreeController < ApplicationController
           customer_id: result.customer.id,
           first_name: user[:firstname] || user[:name],
           last_name: user[:last_name],
-          card_last_4: result.customer.payment_methods.first.last_4
+          card_last_4: get_card_digits(result)
         )
         result
       end
+    end
+  end
+
+  def get_card_digits(braintree_response)
+    # If the subscription was a PayPal payment, it has no card number and a dummy number will be used instead,
+    # since it's a required field in the ActionKit API.
+    if braintree_response.customer.payment_methods.first.class==Braintree::PayPalAccount
+      '1111'
+    # else just return the four digits
+    else
+      braintree_response.customer.payment_methods.first.last_4
     end
   end
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -85,16 +85,8 @@ module Payment
 
     def customer_attrs
       {
-        card_type:        card.card_type,
-        card_bin:         card.bin,
-        cardholder_name:  card.cardholder_name,
-        card_debit:       card.debit,
-        card_last_4:      card.last_4,
         default_payment_method_token: card.token,
-        email:            customer_details.email,
-        first_name:       customer_details.first_name,
-        last_name:        customer_details.last_name,
-        customer_id:      customer_details.id
+        customer_id:                  customer_details.id,
       }
     end
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -87,7 +87,7 @@ module Payment
         cardholder_name:  card.cardholder_name,
         card_debit:       card.debit,
         card_last_4:      card.last_4,
-        card_vault_token: card.token,
+        default_payment_method_token: card.token,
         email:            customer_details.email,
         first_name:       customer_details.first_name,
         last_name:        customer_details.last_name,

--- a/db/migrate/20151209002652_rename_card_vault_token.rb
+++ b/db/migrate/20151209002652_rename_card_vault_token.rb
@@ -1,0 +1,5 @@
+class RenameCardVaultToken < ActiveRecord::Migration
+  def change
+    rename_column :payment_braintree_customers, :card_vault_token, :default_payment_method_token
+  end
+end

--- a/db/migrate/20151211000003_add_foreign_key_to_braintree_customers.rb
+++ b/db/migrate/20151211000003_add_foreign_key_to_braintree_customers.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToBraintreeCustomers < ActiveRecord::Migration
+  def change
+      add_reference :payment_braintree_customers, :member, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20151211002746_remove_extra_fields_from_braintree_customers.rb
+++ b/db/migrate/20151211002746_remove_extra_fields_from_braintree_customers.rb
@@ -1,0 +1,15 @@
+class RemoveExtraFieldsFromBraintreeCustomers < ActiveRecord::Migration
+  def change
+    change_table(:payment_braintree_customers) do |t|
+      t.remove :card_type,
+               :card_bin,
+               :cardholder_name,
+               :card_debit,
+               :card_last_4,
+               :card_unqiue_number_identifier,
+               :email,
+               :first_name,
+               :last_name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -193,26 +193,10 @@ ActiveRecord::Schema.define(version: 20151211002746) do
   end
 
   create_table "payment_braintree_customers", force: :cascade do |t|
-<<<<<<< HEAD
     t.string   "default_payment_method_token"
     t.string   "customer_id"
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
-=======
-    t.string   "card_type"
-    t.string   "card_bin"
-    t.string   "cardholder_name"
-    t.string   "card_debit"
-    t.string   "card_last_4"
-    t.string   "default_payment_method_token"
-    t.string   "card_unqiue_number_identifier"
-    t.string   "email"
-    t.string   "first_name"
-    t.string   "last_name"
-    t.string   "customer_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
->>>>>>> ab4592e546605110050b4793e50655ec0348da12
     t.integer  "member_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151210132734) do
+ActiveRecord::Schema.define(version: 20151211002746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -170,11 +170,11 @@ ActiveRecord::Schema.define(version: 20151210132734) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "compiled_html"
+    t.string   "status",                     default: "pending"
+    t.text     "messages"
     t.text     "content",                    default: ""
     t.boolean  "featured",                   default: false
     t.boolean  "active",                     default: false
-    t.string   "status",                     default: "pending"
-    t.text     "messages"
     t.integer  "liquid_layout_id"
     t.integer  "secondary_liquid_layout_id"
     t.integer  "action_count",               default: 0
@@ -193,20 +193,14 @@ ActiveRecord::Schema.define(version: 20151210132734) do
   end
 
   create_table "payment_braintree_customers", force: :cascade do |t|
-    t.string   "card_type"
-    t.string   "card_bin"
-    t.string   "cardholder_name"
-    t.string   "card_debit"
-    t.string   "card_last_4"
-    t.string   "card_vault_token"
-    t.string   "card_unqiue_number_identifier"
-    t.string   "email"
-    t.string   "first_name"
-    t.string   "last_name"
+    t.string   "default_payment_method_token"
     t.string   "customer_id"
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.integer  "member_id"
   end
+
+  add_index "payment_braintree_customers", ["member_id"], name: "index_payment_braintree_customers_on_member_id", using: :btree
 
   create_table "payment_braintree_subscriptions", force: :cascade do |t|
     t.string   "subscription_id"
@@ -384,6 +378,7 @@ ActiveRecord::Schema.define(version: 20151210132734) do
   add_foreign_key "pages", "languages"
   add_foreign_key "pages", "liquid_layouts"
   add_foreign_key "pages", "liquid_layouts", column: "secondary_liquid_layout_id"
+  add_foreign_key "payment_braintree_customers", "members"
   add_foreign_key "payment_braintree_subscriptions", "pages"
   add_foreign_key "payment_braintree_transactions", "pages"
   add_foreign_key "plugins_actions", "forms"

--- a/lib/payment_processor/clients/braintree/transaction.rb
+++ b/lib/payment_processor/clients/braintree/transaction.rb
@@ -18,13 +18,14 @@ module PaymentProcessor
         # * +:customer+ - Instance of existing Braintree customer. Must respond to +customer_id+ (optional)
         #
         def self.make_transaction(nonce:, amount:, currency:, user:, customer: nil)
+          byebug
           new(nonce, amount, currency, user, customer).sale
         end
 
         def initialize(nonce, amount, currency, user, customer)
           @amount = amount
           @nonce = nonce
-          @user = user
+          @user = Member.find_by(email: user[:email])
           @currency = currency
           @customer = customer
         end

--- a/spec/controllers/api/braintree_controller_spec.rb
+++ b/spec/controllers/api/braintree_controller_spec.rb
@@ -25,7 +25,7 @@ describe Api::BraintreeController do
   describe 'POST subscription' do
     context 'valid subscription' do
       let(:payment_method) { double(:default_payment_method, token: 'a1b2c3' ) }
-      let(:customer) { double(:customer, email: 'foo@example.com', card_vault_token: 'a1b2c3') }
+      let(:customer) { double(:customer, email: 'foo@example.com', default_payment_method_token: 'a1b2c3') }
       let(:subscription_object) { double(:subscription_object, success?: true, subscription: double(id: 'xyz123')) }
 
       let(:params) do {
@@ -111,7 +111,7 @@ describe Api::BraintreeController do
 
     describe "valid transaction with recurring parameter" do
       let(:payment_method) { double(:default_payment_method, token: 'a1b2c3' ) }
-      let(:customer) { double(:customer, email: 'foo@example.com', card_vault_token: 'a1b2c3') }
+      let(:customer) { double(:customer, email: 'foo@example.com', default_payment_method_token: 'a1b2c3') }
       let(:subscription_object) { double(:subscription_object, success?: true, subscription: double(id: 'kj2qnp')) }
 
       let(:params) do {

--- a/spec/factories/payment_braintree_customers.rb
+++ b/spec/factories/payment_braintree_customers.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     cardholder_name "MyString"
     card_debit "MyString"
     card_last_4 "MyString"
-    card_vault_token "MyString"
+    default_payment_method_token "MyString"
     card_unqiue_number_identifier "MyString"
     email { Faker::Internet.email }
     first_name "MyString"

--- a/spec/fixtures/vcr_cassettes/braintree_subscription_paypal.yml
+++ b/spec/fixtures/vcr_cassettes/braintree_subscription_paypal.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<public_key>:<private_key>@api.sandbox.braintreegateway.com/merchants/<merchant_id>/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <email>foo_paypal@example.com</email>
+          <first-name nil="true"/>
+          <last-name nil="true"/>
+          <payment-method-nonce>fake-paypal-future-nonce</payment-method-nonce>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.54.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 09 Dec 2015 23:28:58 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 2vtm97htjg9x4v78
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"183f83435f8cff840c1a334e67dfc3d0"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bb5a5fb3a002015273743a5a25a264d1
+      X-Runtime:
+      - '0.795380'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIADq5aFYAA6RTy3LiMBC88xUu32WBEyigbJPTfkH2shdqbI1tZfVwSXLA
+        +fqVH0CCyWErx+nu0Yx6ZpLDWYrgHY3lWqXhKlqGAapCM66qNPz9+otsw0O2
+        SIrWOi3RZIsgSDjL1s+bzfN2EyfUBz3muaIG5YiPN6rKT3Xn8tp87D5ik9DP
+        bK8uubGOKJAYKC7S0JkWQzpQAr5jCi0bUN0MRwlcZKXWxwa6BsQLnkE2AiOf
+        kNCR7XVNrdX81RLOM+yEueXuQQcGwSEj4ALXNZiGzIeOSwyzeLlak1VMlrvX
+        +Gkfb/fr7Z+E3hKG/LZh/5d/SxjrD1MgJUfB7LUlxh0pwDA7PQrGQDd1PDpC
+        oCh0q9xXRS+YSUbQwzkXwi8BgcogShxmd2/IIPyhKeMb03qRL6v1Gb0oGZbQ
+        ikupXGuBoMKs7ymhE3kVj7N/A4UR0/jNXgxKLqFC0hqR1c41dk8pWIvORrkB
+        rpy3oPI9n6Drk6m3rHfkKNHVmh2FrjQdbYwaVR1QvXOjVS9JLSiW67O/k2uF
+        S03b5rYwvHH+9B7MbtA4/RdVtpPbt9IbMkYX7ofbNP7bkv4wFQrCFXe85++9
+        LUFYb+4j6bRCdL5D95gdQGDMoDd29t3bsLPFPwAAAP//AwAczAMelAQAAA==
+    http_version: 
+  recorded_at: Wed, 09 Dec 2015 23:28:58 GMT
+- request:
+    method: post
+    uri: https://<public_key>:<private_key>@api.sandbox.braintreegateway.com/merchants/<merchant_id>/subscriptions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <subscription>
+          <payment-method-token>9m8jf2</payment-method-token>
+          <plan-id>subscription_USD</plan-id>
+          <price>0.0</price>
+          <merchant-account-id>USD</merchant-account-id>
+        </subscription>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.54.0
+      X-Apiversion:
+      - '4'
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 09 Dec 2015 23:33:14 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 2vtm97htjg9x4v78
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      X-Ua-Compatible:
+      - IE=Edge,chrome=1
+      Etag:
+      - '"3d58d57ef11f9d2d857eb00628275a42"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 780568325c960660b948486562f167a2
+      X-Runtime:
+      - '0.696425'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIADq6aFYAA5RVTXPbIBC951dodCeS7KYTZ2Rl2mn7B5pceulgCVu0AjQL
+        ZOx/3wVk2ZJwJr3B7nuP/QLK56PokjcGmiu5TYv7PE2YrFXD5WGbvr78II/p
+        c3VXarvTNfDeIKy6S5KSNg1RUifm1LNtSgHoKc28Z0c7KmtW5fd5Xmbnnffw
+        rkNd0tATUXsilDTtIMClYQcGabVBSgQ24fcMuGoIkw1iDBsk3DKtVnnxmeQF
+        yR8vQjN8TEsbCiaq9kCKFck3C7ULw+vVwHDZEGquBAwXE5GX1fppvX4qPv0q
+        swvB823f/B//QgjnWwAmDTlHWZ/qjs2LW+CxMZxXwHJr0lONSVmWSN5tUwOW
+        DV1tuK6VlSbW8T3lnQVGPGB+Js7AxB8YHPQlhnfLvoR6Bd5Ua3jQRygzXDqL
+        YFC3FFOjtT+IoP3157cyizkcQTKce8KOPQd2TmunVMeoTCuXeplNIAPpGKIh
+        VPh0wpgvzBPs1djEWUvAgn970jczobFG0oodho93aNJtvWhuT3lDTAvKHtr3
+        r9QCOfBPwg2VYKbFFIz6y2S1EY9/9itHiTg9C18G14vrt+W379jZ41HAx8ck
+        rJ0Vb5+xuvpSG/6GfRq2zmOA0w5HGKjTW6Q6dRMrubmBCf2Yz8WedhoPvIaE
+        +8FCDgrc1hWfisUtcum0SsbsFrpFHNlUFOOiUtPaBR67hqEIpOUaCacJYDhk
+        QOBQhwnzRvfIoEP0H3x4RvyocLMZITPNoPqOnfuq8JsRFJ8uZxnJV90nWlnA
+        DtOeo0zEcSbd/GNCjWMj4+o5z3+0DDXDjy6b/nT/AAAA//8DAMVRqG4gBwAA
+    http_version: 
+  recorded_at: Wed, 09 Dec 2015 23:33:14 GMT
+recorded_with: VCR 3.0.0

--- a/spec/requests/api/braintree_spec.rb
+++ b/spec/requests/api/braintree_spec.rb
@@ -53,6 +53,15 @@ describe "Braintree API" do
         expect(body[:subscription_id]).to match(/[a-z0-9]{6}/)
       end
     end
+
+    it 'successfully subscribes a user with PayPal' do
+      VCR.use_cassette('braintree_subscription_paypal') do
+        post_subscription(user: { email: 'foo_paypal@example.com'}, payment_method_nonce: 'fake-paypal-future-nonce')
+        expect(body[:success]).to be true
+        expect(body[:subscription_id]).to match(/[a-z0-9]{6}/)
+        (expect Payment.customer('foo_paypal@example.com').card_last_4.to_i).to be 1111
+      end
+    end
   end
 
   describe "making a transaction" do

--- a/spec/requests/api/braintree_spec.rb
+++ b/spec/requests/api/braintree_spec.rb
@@ -33,7 +33,7 @@ describe "Braintree API" do
   end
 
   describe 'making a subscription' do
-    let!(:customer) { create(:payment_braintree_customer, email: 'foo@example.com', card_vault_token: '4y5dr6' )}
+    let!(:customer) { create(:payment_braintree_customer, email: 'foo@example.com', default_payment_method_token: '4y5dr6' )}
 
     context "successful subscription" do
       it 'creates subscription' do
@@ -94,7 +94,7 @@ describe "Braintree API" do
             expect(customer).to_not be nil
             expect(customer.email).to eq('foo@example.com')
             expect(customer.customer_id).to match(/\d{8}/)
-            expect(customer.card_vault_token).to match(/[a-z0-9]{6}/)
+            expect(customer.default_payment_method_token).to match(/[a-z0-9]{6}/)
           end
         end
       end
@@ -114,7 +114,7 @@ describe "Braintree API" do
           expect(customer).to_not be nil
           expect(customer.email).to eq('foo@example.com')
           expect(customer.customer_id).to match(/\d{8}/)
-          expect(customer.card_vault_token).to match(/[a-z0-9]{6}/)
+          expect(customer.default_payment_method_token).to match(/[a-z0-9]{6}/)
 
           expect(body[:subscription_id]).to match(/[a-z0-9]{6}/)
         end


### PR DESCRIPTION
@osahyoun I'm not sure at what point the last four digits get stored in the transaction, so I'm not sure any changes are required to ensure that the last four digits that have been stored for the user match the ones in the transaction. Could we talk about that / could you tell me if there's anything that would check and update the Braintree customer in the transaction class?

That said, we were talking some about our local storage for Braintree customers.
I feel like the storage for local customers should be tied closer to members. There could be a foreign key column for `member_id` in the braintree customers table (after all, all donors are members). Other than that, I'm not sure I understand the necessity of storing extensive BT customer data in a table locally. There's a lot of duplicate data with the members table, and the only step where we use the local donors table currently is to see if the customer exists in the Braintree vault (if they have an existing payment token locally). I think everything else in the table is accessible from the Braintree response object for transactions or subscriptions, and we will be using the response objects together with params to construct the JSON that gets sent to ActionKit. So we basically don't even use the local donors table. Is there a good reason for making the distinction between members and braintree customers, or could the local donors table be stripped down to just contain data that's not duplicated in the members table? (Is there a use case for that data, generally speaking, other than to look up if the payment method token exists?)

Another thing I thought of is that we should be able to distinguish payments made with PayPal from credit card payments. Overall I feel like we should rethink our local architecture a little bit. @osahyoun if you're feeling better tomorrow and have some time, it'd be great if you could think about this a little and write back to me or we could have a talk.