### PR TITLE
Donation errors

### DIFF
--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -209,7 +209,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
       $errors.removeClass('hidden-closed');
       $errors.find('.fundraiser-bar__error-detail').remove();
       if (data.status == 422 && data.responseJSON && data.responseJSON.errors) {
-        var messages = _.map(data.responseJSON.errors, function(error){
+        var messages = data.responseJSON.errors.map(function(error){
           if (error.declined) {
             return "Your card was declined by the payment processor. Please try a different payment method."
           } else {

--- a/app/assets/stylesheets/sumofus/components/fundraiser.scss
+++ b/app/assets/stylesheets/sumofus/components/fundraiser.scss
@@ -140,6 +140,28 @@
       font-size: 20px;
     }
   }
+  &__errors {
+    background: #fdd7d1;
+    width: 100%;
+    padding: 18px 26px;
+    margin: -26px -26px 20px;
+    border-top: 2px solid #f8492e;
+    border-bottom: 2px solid #f8492e;
+    font-size: 14px;
+    line-height: 16px;
+  }
+  &__error-intro {
+    padding-left: 40px;
+    padding-bottom: 10px;
+    min-height: 30px;
+  }
+  .fa-exclamation-triangle {
+    position: absolute;
+    top: 21px;
+    left: 26px;
+    color: #f8492e;
+    font-size: 30px;
+  }
 }
 
 .hosted-fields {

--- a/app/assets/stylesheets/sumofus/global/colors.scss
+++ b/app/assets/stylesheets/sumofus/global/colors.scss
@@ -2,6 +2,7 @@ $teal: #00c0cf;
 $night-sky: #1c2333;
 $navy: #30394f;
 $orange: #f8492e;
+$light-orange: lighten($orange, 33%);
 
 // 3rd party colors
 $facebook: #597ac7;

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -23,6 +23,12 @@
         </div>
       </div>
       <div class="fundraiser-bar__main form--big">
+        <div class="fundraiser-bar__errors hidden-closed">
+          <span class="fa fa-exclamation-triangle"></span>
+          <div class="fundraiser-bar__error-intro">
+            We were unable to process your donation!
+          </div>
+        </div>
         <div class="fundraiser-bar__step-panel" data-step="1">
           <div class="fundraiser-bar__amount-buttons">
           </div>

--- a/lib/payment_processor/clients/braintree/error_processing.rb
+++ b/lib/payment_processor/clients/braintree/error_processing.rb
@@ -85,6 +85,7 @@ module PaymentProcessor
 
         def processor_declined_error
           [{
+            declined: true,
             code: @response.transaction.processor_response_code,
             message: @response.transaction.processor_response_text
           }]
@@ -92,6 +93,7 @@ module PaymentProcessor
 
         def settlement_declined_error
           [{
+            declined: true,
             code: @response.transaction.processor_settlement_response_code,
             message: @response.transaction.processor_settlement_response_text
           }]
@@ -99,6 +101,7 @@ module PaymentProcessor
 
         def gateway_rejected_error
           [{
+            declined: true,
             code: '',
             message: @response.transaction.gateway_rejection_reason
           }]

--- a/spec/requests/api/braintree_spec.rb
+++ b/spec/requests/api/braintree_spec.rb
@@ -173,6 +173,7 @@ describe "Braintree API" do
           expect(
             body[:errors].first
           ).to eq({
+            "declined"=> true,
             "code"    => "2100",
             "message" => "Processor Declined"
           })
@@ -185,6 +186,7 @@ describe "Braintree API" do
           expect(
             body[:errors].first
           ).to eq({
+            "declined"=> true,
             "code"    => '',
             "message" => "application_incomplete"
           })


### PR DESCRIPTION
This PR shows the donor any errors from the Champaign server. It has built in error messages for card declines and 500 errors, and others simply display the message from Braintree. It includes specs, wrapping up the long-pending specs.

<img width="316" alt="screenshot 2015-12-11 16 17 11" src="https://cloud.githubusercontent.com/assets/102218/11756929/f1fa0d52-a022-11e5-8d35-591d4aed6425.png">
