### PR TITLE
WIP-ish - clean up braintree customer / rename card vault token to default payment method token

### DIFF
--- a/app/controllers/api/braintree_controller.rb
+++ b/app/controllers/api/braintree_controller.rb
@@ -60,7 +60,7 @@ class Api::BraintreeController < ApplicationController
         # persist customer locally
         customer = Payment::BraintreeCustomer.find_or_initialize_by(email: user[:email])
         customer.update(
-          card_vault_token: result.customer.payment_methods.first.token,
+          default_payment_method_token: result.customer.payment_methods.first.token,
           customer_id: result.customer.id,
           first_name: user[:firstname] || user[:name],
           last_name: user[:last_name],
@@ -95,13 +95,9 @@ class Api::BraintreeController < ApplicationController
   end
 
   def default_payment_method_token
-   local_customer.try(:card_vault_token)
+   local_customer.try(:default_payment_method_token)
   end
-
-  def customer_id
-    local_customer.try(:card_vault_token)
-  end
-
+  
   def local_customer
     @local_customer ||= ::Payment.customer(params[:user][:email])
   end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -108,9 +108,8 @@ module Payment
         cardholder_name:  card.cardholder_name,
         card_debit:       card.debit,
         card_last_4:      card.last_4,
-        card_vault_token: card.token,
+        default_payment_method_token: card.token,
         customer_id:      customer_details.id,
-        email:            customer_details.email,
         member:           @action.member
       }
     end

--- a/db/migrate/20151214213221_update_braintree_customer.rb
+++ b/db/migrate/20151214213221_update_braintree_customer.rb
@@ -1,0 +1,10 @@
+class UpdateBraintreeCustomer < ActiveRecord::Migration
+  def change
+    rename_column :payment_braintree_customers, :card_vault_token, :default_payment_method_token
+    change_table :payment_braintree_customers do |t|
+      t.remove :card_unqiue_number_identifier,
+               :email,
+               :first_name,
+               :last_name
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151214155329) do
+ActiveRecord::Schema.define(version: 20151214213221) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,7 +198,7 @@ ActiveRecord::Schema.define(version: 20151214155329) do
     t.string   "cardholder_name"
     t.string   "card_debit"
     t.string   "card_last_4"
-    t.string   "card_vault_token"
+    t.string   "default_payment_method_token"
     t.string   "card_unqiue_number_identifier"
     t.string   "email"
     t.string   "first_name"

--- a/spec/controllers/api/braintree_controller_spec.rb
+++ b/spec/controllers/api/braintree_controller_spec.rb
@@ -40,7 +40,7 @@ describe Api::BraintreeController do
   describe 'POST subscription' do
     context 'valid subscription' do
       let(:payment_method) { double(:default_payment_method, token: 'a1b2c3' ) }
-      let(:customer) { double(:customer, email: 'foo@example.com', card_vault_token: 'a1b2c3') }
+      let(:customer) { double(:customer, email: 'foo@example.com', default_payment_method_token: 'a1b2c3') }
       let(:subscription_object) { double(:subscription_object, success?: true, subscription: double(id: 'xyz123')) }
 
       before do
@@ -120,7 +120,7 @@ describe Api::BraintreeController do
 
     describe "valid transaction with recurring parameter" do
       let(:payment_method) { double(:default_payment_method, token: 'a1b2c3' ) }
-      let(:customer) { double(:customer, email: 'foo@example.com', card_vault_token: 'a1b2c3') }
+      let(:customer) { double(:customer, email: 'foo@example.com', default_payment_method_token: 'a1b2c3') }
       let(:subscription_object) { double(:subscription_object, success?: true, subscription: double(id: 'kj2qnp')) }
 
       let(:params_with_recurring) { params.merge(recurring: true) }

--- a/spec/factories/payment_braintree_customers.rb
+++ b/spec/factories/payment_braintree_customers.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     cardholder_name "MyString"
     card_debit "MyString"
     card_last_4 "MyString"
-    card_vault_token "MyString"
+    default_payment_method_token "MyString"
     card_unqiue_number_identifier "MyString"
     email { Faker::Internet.email }
     first_name "MyString"

--- a/spec/requests/api/braintree_spec.rb
+++ b/spec/requests/api/braintree_spec.rb
@@ -35,7 +35,7 @@ describe "Braintree API" do
   end
 
   describe 'making a subscription' do
-    let!(:customer) { create(:payment_braintree_customer, email: 'foo@example.com', card_vault_token: '4y5dr6' )}
+    let!(:customer) { create(:payment_braintree_customer, email: 'foo@example.com', default_payment_method_token: '4y5dr6' )}
 
     context "successful subscription" do
       it 'creates subscription' do
@@ -135,7 +135,7 @@ describe "Braintree API" do
           it 'persists braintree customer' do
             expect(customer).to_not be nil
             expect(customer.customer_id).to match(/\d{8}/)
-            expect(customer.card_vault_token).to match(/[a-z0-9]{6}/)
+            expect(customer.default_payment_method_token).to match(/[a-z0-9]{6}/)
           end
 
           it 'associates with member' do
@@ -159,7 +159,7 @@ describe "Braintree API" do
           expect(customer).to_not be nil
           expect(customer.email).to eq('foo@example.com')
           expect(customer.customer_id).to match(/\d{8}/)
-          expect(customer.card_vault_token).to match(/[a-z0-9]{6}/)
+          expect(customer.default_payment_method_token).to match(/[a-z0-9]{6}/)
 
           expect(body[:subscription_id]).to match(/[a-z0-9]{6}/)
         end


### PR DESCRIPTION
So far this only includes renaming `card_vault_token` to `default_payment_method_token` and removing unused fields from `Payment::BraintreeCustomer`. This can either be merged now or I can add more changes if that seems meaningful to you. One thing that I think we might still want to address is how to store data for customers using PayPal - the only relevant fields for PayPal users in `Payment::BraintreeCustomer` right now are `customer_id` and `default_payment_method_token`. All other fields are credit/debit card specific.