### PR TITLE
Remember member

### DIFF
--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -17,7 +17,8 @@ module ActionBuilder
   end
 
   def filtered_params
-    @params.compact.keep_if{ |k| permitted_keys.include? k.to_sym }
+    hash = @params.try(:to_unsafe_hash) || @params.to_h # for ActionController::Params
+    hash.symbolize_keys.compact.keep_if{ |k| permitted_keys.include? k }
   end
 
   def permitted_keys

--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -11,10 +11,17 @@ module ActionBuilder
   def member
     return @user if @user.present?
     @user = Member.find_or_create_by(email: @params[:email])
-    permitted = @user.attributes.keys.map(&:to_sym).reject!{|k| k == :id}
-    @user.assign_attributes(@params.compact.keep_if{ |k| permitted.include? k })
+    @user.assign_attributes(filtered_params)
     @user.save if @user.changed
     @user
+  end
+
+  def filtered_params
+    @params.compact.keep_if{ |k| permitted_keys.include? k.to_sym }
+  end
+
+  def permitted_keys
+    Member.new.attributes.keys.map(&:to_sym).reject!{|k| k == :id}
   end
 
   def page

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,7 +25,7 @@ end
 basic_form_fields = [
     {label: 'Email Address', name: 'email', required: true, data_type: 'email', form: basic_form},
     {label: 'Full Name', name: 'name', required: true, data_type: 'text', form: basic_form},
-    {label: 'Postal Code', name: 'postal', required: true, data_type: 'text', form: basic_form}
+    {label: 'Postal Code', name: 'postal', required: false, data_type: 'text', form: basic_form}
 ]
 
 basic_form_fields.each do |field|

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -65,25 +65,55 @@ describe ActionBuilder do
 
     let(:params) { {email: "silly@billy.com", country: "US", first_name: "Silly", last_name: "Billy", city: "Northampton", postal: "01060", address1: "10 Coates St.", address2: ""} }
 
-    it 'passes all keys as symbols' do
-      mab = MockActionBuilder.new(params)
-      expect(mab.filtered_params).to eq params
+    describe 'passes all' do
+
+      it 'keys as symbols' do
+        mab = MockActionBuilder.new(params)
+        expect(mab.filtered_params).to eq params
+      end
+
+      it 'keys as strings' do
+        mab = MockActionBuilder.new(params.stringify_keys)
+        expect(mab.filtered_params).to eq params.stringify_keys
+      end
+
+      it 'keys with indifferent access' do
+        mab = MockActionBuilder.new(params.with_indifferent_access)
+        expect(mab.filtered_params).to eq params.with_indifferent_access
+      end
+
+      it 'keys as action parameters' do
+        mab = MockActionBuilder.new(ActionController::Parameters.new(params))
+        expect(mab.filtered_params).to eq params.with_indifferent_access
+      end
     end
 
-    it 'passes all keys as strings' do
-      mab = MockActionBuilder.new(params.stringify_keys)
-      expect(mab.filtered_params).to eq params.stringify_keys
+    describe 'filters irrelevant' do
+
+      let(:porky_params) { params.merge(page_id: page.id, form_id: '3', blerg: false) }
+
+      it 'keys as symbols' do
+        mab = MockActionBuilder.new(porky_params)
+        expect(mab.filtered_params).to eq params
+      end
+
+      it 'keys as strings' do
+        mab = MockActionBuilder.new(porky_params.stringify_keys)
+        expect(mab.filtered_params).to eq params.stringify_keys
+      end
+
+      it 'keys with indifferent access' do
+        mab = MockActionBuilder.new(porky_params.with_indifferent_access)
+        expect(mab.filtered_params).to eq params.with_indifferent_access
+      end
+
+      it 'keys as action parameters' do
+        mab = MockActionBuilder.new(ActionController::Parameters.new(porky_params))
+        expect(mab.filtered_params).to eq params.with_indifferent_access
+      end
+
     end
 
-    it 'passes all keys with indifferent access' do
-      mab = MockActionBuilder.new(params.with_indifferent_access)
-      expect(mab.filtered_params).to eq params.with_indifferent_access
-    end
-
-    it 'passes all keys as action parameters' do
-      mab = MockActionBuilder.new(ActionController::Parameters.new(params))
-      expect(mab.filtered_params).to eq params.with_indifferent_access
-    end
   end
 
 end

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -43,4 +43,47 @@ describe ActionBuilder do
     mab.build_action
     expect(mab.previous_action).to eq(found_action)
   end
+
+  describe 'permitted_keys' do
+
+    let(:mab) { MockActionBuilder.new(page_id: page.id, email: member.email) }
+
+    it 'returns symbols' do
+      expect(mab.permitted_keys.map(&:class).uniq).to eq [Symbol]
+    end
+
+    it 'does not include the id' do
+      expect(mab.permitted_keys).not_to include(:id)
+    end
+
+    it 'includes all the other keys of member' do
+      expect(mab.permitted_keys).to include(:email, :country, :first_name, :last_name, :city, :postal, :title, :address1, :address2, :actionkit_user_id)
+    end
+  end
+
+  describe 'filtered_params' do
+
+    let(:params) { {email: "silly@billy.com", country: "US", first_name: "Silly", last_name: "Billy", city: "Northampton", postal: "01060", address1: "10 Coates St.", address2: ""} }
+
+    it 'passes all keys as symbols' do
+      mab = MockActionBuilder.new(params)
+      expect(mab.filtered_params).to eq params
+    end
+
+    it 'passes all keys as strings' do
+      mab = MockActionBuilder.new(params.stringify_keys)
+      expect(mab.filtered_params).to eq params.stringify_keys
+    end
+
+    it 'passes all keys with indifferent access' do
+      mab = MockActionBuilder.new(params.with_indifferent_access)
+      expect(mab.filtered_params).to eq params.with_indifferent_access
+    end
+
+    it 'passes all keys as action parameters' do
+      mab = MockActionBuilder.new(ActionController::Parameters.new(params))
+      expect(mab.filtered_params).to eq params.with_indifferent_access
+    end
+  end
+
 end

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -74,17 +74,17 @@ describe ActionBuilder do
 
       it 'keys as strings' do
         mab = MockActionBuilder.new(params.stringify_keys)
-        expect(mab.filtered_params).to eq params.stringify_keys
+        expect(mab.filtered_params).to eq params
       end
 
       it 'keys with indifferent access' do
         mab = MockActionBuilder.new(params.with_indifferent_access)
-        expect(mab.filtered_params).to eq params.with_indifferent_access
+        expect(mab.filtered_params).to eq params
       end
 
       it 'keys as action parameters' do
         mab = MockActionBuilder.new(ActionController::Parameters.new(params))
-        expect(mab.filtered_params).to eq params.with_indifferent_access
+        expect(mab.filtered_params).to eq params
       end
     end
 
@@ -99,17 +99,17 @@ describe ActionBuilder do
 
       it 'keys as strings' do
         mab = MockActionBuilder.new(porky_params.stringify_keys)
-        expect(mab.filtered_params).to eq params.stringify_keys
+        expect(mab.filtered_params).to eq params
       end
 
       it 'keys with indifferent access' do
         mab = MockActionBuilder.new(porky_params.with_indifferent_access)
-        expect(mab.filtered_params).to eq params.with_indifferent_access
+        expect(mab.filtered_params).to eq params
       end
 
       it 'keys as action parameters' do
         mab = MockActionBuilder.new(ActionController::Parameters.new(porky_params))
-        expect(mab.filtered_params).to eq params.with_indifferent_access
+        expect(mab.filtered_params).to eq params
       end
 
     end


### PR DESCRIPTION
There was a bug where we weren't saving any member data aside from the email. It stemmed from a bad assumption of hash keys with a hash with indifferent access. This PR mostly just writes tests around the bug. Should be ready to merge!

It also makes postal code not required by default in seeded form per Eoin's request.