### PR TITLE
Refactor error display

### DIFF
--- a/app/assets/javascripts/ajax.js
+++ b/app/assets/javascripts/ajax.js
@@ -1,3 +1,5 @@
+let ErrorDisplay = require('show_errors');
+
 $(function(){
   var handleStart = function(e,i){
     var button = $(e.target).find('.xhr-feedback');
@@ -24,7 +26,7 @@ $(function(){
       removeClass('label-success').
       addClass('label-danger').
       text('Save failed.');
-    window.Champaign.showErrors(e, data);
+    ErrorDisplay.show(e, data);
   };
 
   var handleSuccess = function(e){

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,10 +29,10 @@
 //= require show_errors
 //= require dropzone_image_upload
 //= require selectize_config.js
-//= require ajax
 //= require configure_quill_editor
 //= require_tree ./plugins/admin
 
+require('ajax')
 require('page');
 require("plugins_toggle");
 require("collection_editor");

--- a/app/assets/javascripts/page_edit_bar.js
+++ b/app/assets/javascripts/page_edit_bar.js
@@ -1,3 +1,5 @@
+let ErrorDisplay = require('show_errors');
+
 let PageModel = Backbone.Model.extend({
   urlRoot: '/api/pages',
 
@@ -117,7 +119,7 @@ let PageEditBar = Backbone.View.extend({
       this.enableSubmit();
       $('.page-edit-bar__save-box').addClass('page-edit-bar__save-box--has-error')
       if(data.status == 422) {
-        Champaign.showErrors(e, data);
+        ErrorDisplay.show(e, data);
         $('.page-edit-bar__error-message').text("The server didn't like something you entered. Click here to see the error.");
         $.publish('page:errors');
       } else {

--- a/app/assets/javascripts/show_errors.js
+++ b/app/assets/javascripts/show_errors.js
@@ -2,51 +2,48 @@
 // For it to work properly, you need to pass data from the controller like:
 //   format.json { render json: {errors: link.errors, name: 'link'}, status: :unprocessable_entity }
 // The name field is for if the form element names are prefixed, eg 'link[title]'
+let ErrorDisplay = {
 
-// this is ripe for a refactor to use the event system, and could be a backbone view too
-
-window.Champaign = window.Champaign || {};
-window.Champaign.showErrors = function(e, data) {
-
-  if (!e || !data || !data.responseText || data.status != 422) {
-    return; // no reason to try if we dont have what we need
-  }
-
-  // use the relevant form if the event was a form submission
-  $form = ($(e.target) && $(e.target).length > 0) ? $(e.target) : $('form');
-  response = $.parseJSON(data.responseText);
-
-  var errorMsg = function(field_name, msgs) {
-    var msg = (typeof msgs === "string") ? msgs : msgs[0]
-    var prefix = window.I18n ? I18n.t('errors.this_field') : 'This field';
-    return ["<div class='error-msg'>", prefix, " ", msg, "</div>"].join('');
-  }
-
-  var clearErrors = function() {
-    $form.find('has-error').removeClass('has-error');
-    $form.find('.error-msg').remove();
-  }
-
-  var hideError = function(e) {
-    $(this).removeClass('has-error').parent().removeClass('has-error');
-    $(this).siblings('.error-msg').remove();
-  }
-
-  var findField = function(field_name) {
-    if (response.name) {
-      field_name = [response.name, '[', field_name, ']'].join('');
+  show(e, data) {
+    if (!e || !data || !data.responseText || data.status != 422) {
+      return; // no reason to try if we dont have what we need
     }
-    return $form.find("[name='" + field_name + "']");
-  }
+    // use the relevant form if the event was a form submission
+    this.$form = ($(e.target) && $(e.target).length > 0) ? $(e.target) : $('form');
+    this.response = $.parseJSON(data.responseText);
+    this.clearErrors(this.$form);
+    $.each(this.response.errors, (f, m) => { this.showError(f, m) });
+  },
 
-  var showError = function(field_name, msgs) {
-    field = findField(field_name);
-    field.addClass('has-error').parent().addClass('has-error');
-    field.parent().append(errorMsg(field_name, msgs));
-    field.on('focus', hideError)
-  }
+  clearErrors($form) {
+    $form.find('.has-error').removeClass('has-error');
+    $form.find('.error-msg').remove();
+  },
 
-  clearErrors();
-  $.each(response.errors, showError);
+  showError(field_name, msgs) {
+    let $field = this.findField(field_name);
+    $field.addClass('has-error').parent().addClass('has-error');
+    $field.parent().append(this.errorMsg(field_name, msgs));
+    $field.on('focus', (e) => { this.hideError(e) })
+  },
+
+  errorMsg(field_name, msgs) {
+    let msg = (typeof msgs === "string") ? msgs : msgs[0]
+    let prefix = window.I18n ? I18n.t('errors.this_field') : 'This field';
+    return `<div class='error-msg'>${prefix} ${msg}</div>`;
+  },
+
+  hideError(e) {
+    $(e.target).removeClass('has-error').parent().removeClass('has-error');
+    $(e.target).siblings('.error-msg').remove();
+  },
+
+  findField(field_name) {
+    if (this.response.name) {
+      field_name = [this.response.name, '[', field_name, ']'].join('');
+    }
+    return this.$form.find("[name='" + field_name + "']");
+  },
 }
 
+module.exports = ErrorDisplay

--- a/app/assets/javascripts/show_errors.js
+++ b/app/assets/javascripts/show_errors.js
@@ -24,7 +24,7 @@ let ErrorDisplay = {
     let $field = this.findField(field_name, $form, response);
     $field.addClass('has-error').parent().addClass('has-error');
     $field.parent().append(this.errorMsg(field_name, msgs));
-    $field.on('focus', (e) => { this.hideError(e) })
+    $field.on('change', (e) => { this.hideError(e) })
   },
 
   errorMsg(field_name, msgs) {

--- a/app/assets/javascripts/show_errors.js
+++ b/app/assets/javascripts/show_errors.js
@@ -8,7 +8,8 @@ let ErrorDisplay = {
     if (!e || !data || !data.responseText || data.status != 422) {
       return; // no reason to try if we dont have what we need
     }
-    // use the relevant form if the event was a form submission
+    // use the relevant form if the event was a form submission.
+    // otherwise, search in all the forms on the page.
     let $form = ($(e.target) && $(e.target).length > 0) ? $(e.target) : $('form');
     let response = $.parseJSON(data.responseText);
     this.clearErrors($form);

--- a/app/assets/javascripts/show_errors.js
+++ b/app/assets/javascripts/show_errors.js
@@ -9,10 +9,10 @@ let ErrorDisplay = {
       return; // no reason to try if we dont have what we need
     }
     // use the relevant form if the event was a form submission
-    this.$form = ($(e.target) && $(e.target).length > 0) ? $(e.target) : $('form');
-    this.response = $.parseJSON(data.responseText);
-    this.clearErrors(this.$form);
-    $.each(this.response.errors, (f, m) => { this.showError(f, m) });
+    let $form = ($(e.target) && $(e.target).length > 0) ? $(e.target) : $('form');
+    let response = $.parseJSON(data.responseText);
+    this.clearErrors($form);
+    $.each(response.errors, (f, m) => { this.showError(f, m, $form, response) });
   },
 
   clearErrors($form) {
@@ -20,8 +20,8 @@ let ErrorDisplay = {
     $form.find('.error-msg').remove();
   },
 
-  showError(field_name, msgs) {
-    let $field = this.findField(field_name);
+  showError(field_name, msgs, $form, response) {
+    let $field = this.findField(field_name, $form, response);
     $field.addClass('has-error').parent().addClass('has-error');
     $field.parent().append(this.errorMsg(field_name, msgs));
     $field.on('focus', (e) => { this.hideError(e) })
@@ -38,11 +38,11 @@ let ErrorDisplay = {
     $(e.target).siblings('.error-msg').remove();
   },
 
-  findField(field_name) {
-    if (this.response.name) {
-      field_name = [this.response.name, '[', field_name, ']'].join('');
+  findField(field_name, $form, response) {
+    if (response.name) {
+      field_name = [response.name, '[', field_name, ']'].join('');
     }
-    return this.$form.find("[name='" + field_name + "']");
+    return $form.find("[name='" + field_name + "']");
   },
 }
 

--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -1,11 +1,17 @@
+let ErrorDisplay = require('show_errors');
+
 const FormMethods = {
 
   handleFormErrors: function() {
-    this.$('form').on('ajax:error', window.Champaign.showErrors);
+    this.$('form').on('ajax:error', (e, d) => { ErrorDisplay.show(e, d); });
   },
 
   selectizeCountry: function() {
     $('.petition-bar__country-selector').selectize();
+  },
+
+  clearFormErrors: function() {
+    ErrorDisplay.clearErrors(this.$('form'));
   },
 
   clearForm: function(){

--- a/app/assets/javascripts/sumofus/backbone/petition_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/petition_bar.js
@@ -26,6 +26,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
   },
 
   handleSuccess: function(e, data) {
+    this.clearFormErrors();
     if (data.follow_up_url) {
       window.location.href = data.follow_up_url
     } else {

--- a/app/assets/stylesheets/sumofus/components/form.scss
+++ b/app/assets/stylesheets/sumofus/components/form.scss
@@ -10,6 +10,11 @@
         border-color: $orange;
       }
     }
+    &.has-error {
+      .selectize-control.single .selectize-input {
+        border-color: $orange;
+      }
+    }
     .error-msg {
       color: $orange;
       font-size: 14px;

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -185,7 +185,7 @@ en:
       offset: "Offset (number of fake signatures to add to true count)"
     fundraiser:
       donation_band: "Default Donation Band for unknown user:"
-      title: "Donate now"
+      title: "Title (eg 'Donate now')"
 
   ak_logs:
     index:

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -10,6 +10,13 @@ FactoryGirl.define do
       end
     end
 
+    factory :form_with_email_and_name do
+      after(:create) do |form, evaluator|
+        create :form_element, form: form, name: 'email', label: 'Email', data_type: 'email', required: true
+        create :form_element, form: form, name: 'name', label: 'Full name', data_type: 'text', required: true
+      end
+    end
+
     factory :form_with_fields do
       after(:create) do |form, evaluator|
         create_list(:form_element, 2, form: form)

--- a/spec/javascripts/fixtures/magic_lamp.rb
+++ b/spec/javascripts/fixtures/magic_lamp.rb
@@ -7,3 +7,13 @@ MagicLamp.define(controller: PagesController) do
     show
   end
 end
+
+MagicLamp.define(controller: PagesController) do
+  fixture(name: 'pages/petition') do
+    @page = FactoryGirl.create :page, liquid_layout: LiquidLayout.find_by(title: 'Standard Petition')
+    form = FactoryGirl.create :form_with_email_and_name
+    @page.plugins.each { |pl| if pl.name == 'Petition' then pl.update_attributes(form: form) end }
+    params[:id] = @page.id
+    show
+  end
+end

--- a/spec/javascripts/member-ui/form_error_spec.js
+++ b/spec/javascripts/member-ui/form_error_spec.js
@@ -1,0 +1,127 @@
+//= require sumofus
+
+// this is a feature test of show_errors.js that ensures
+// it performs in an end-user facing context
+describe("Inline form errors", function() {
+  var suite = this;
+  suite.timeout(20000);
+
+  before(function() {
+    suite.actionPath = /\/api\/pages\/[0-9]+\/actions/;
+  });
+
+  beforeEach(function(){
+    MagicLamp.wish("pages/petition");
+    suite.server = sinon.fakeServer.create();
+    suite.server.respondWith("GET", '/api/braintree/token',
+                            [200, { "Content-Type": "application/json" },
+                            '{ "token": "'+helpers.btClientToken+'" }' ]);
+    suite.petitionBar = new window.PetitionBar(); // binds the form events
+  });
+
+  afterEach(function(){
+    suite.server.restore();
+  });
+
+  it('begins with no error messages', function(){
+    expect($('.has-error').length).to.eq(0);
+    expect($('.error-msg').length).to.eq(0);
+  });
+
+  describe('two errors', function(){
+
+    beforeEach(function(){
+      suite.server.respondWith("POST", suite.actionPath,
+                               [422, { "Content-Type": "application/json" },
+                              '{"errors":{"email":["is not a valid email address"], "name":["is required"]}}' ]);
+      $('.petition-bar__submit-button').click();
+      suite.server.respond();
+    });
+
+    it('adds "has-error" class to field and parent', function(){
+      expect($('input[name="email"]')).to.have.class('has-error');
+      expect($('input[name="email"]').parent()).to.have.class('has-error');
+      expect($('input[name="name"]')).to.have.class('has-error');
+      expect($('input[name="name"]').parent()).to.have.class('has-error');
+    });
+
+    it('adds an error message to all relevant fields', function(){
+      var $msg = $('input[name="email"]').parent().find('.error-msg');
+      expect($msg).to.have.length.above(0);
+      expect($msg.text()).to.have.length.above(0);
+      $msg = $('input[name="name"]').parent().find('.error-msg');
+      expect($msg).to.have.length.above(0);
+      expect($msg.text()).to.have.length.above(0);
+    });
+  });
+
+  describe('one error', function(){
+
+    beforeEach(function(){
+      suite.server.respondWith("POST", suite.actionPath,
+                               [422, { "Content-Type": "application/json" },
+                              '{"errors":{"email":["is not a valid email address"]}}' ]);
+      $('.petition-bar__submit-button').click();
+      suite.server.respond();
+    });
+
+    it('can add an error message to just one field', function(){
+      var $msg = $('input[name="email"]').parent().find('.error-msg');
+      expect($msg).to.have.length.above(0);
+      expect($msg.text()).to.have.length.above(0);
+      $msg = $('input[name="name"]').parent().find('.error-msg');
+      expect($msg).to.have.length(0);
+      expect($msg.text()).to.have.length(0);
+    });
+
+    it('dismisses the error when field receives focus', function(){
+      var $input = $('input[name="email"]');
+      $input.focus();
+      expect($input.parent()).not.to.have.class('has-error');
+      expect($input.parent().find('.has-error')).to.have.length(0);
+      expect($input.parent().find('.error-msg')).to.have.length(0);
+    });
+  });
+
+  describe('on second submission', function(){
+
+    beforeEach(function(){
+      suite.server.respondWith("POST", suite.actionPath,
+                               [422, { "Content-Type": "application/json" },
+                              '{"errors":{"email":["is not a valid email address"], "name":["is required"]}}' ]);
+      $('.petition-bar__submit-button').click();
+      suite.server.respond();
+    });
+
+    it('replaces existing error message if still has error', function(){
+      expect($('input[name="email"].has-error').siblings('.error-msg').text()).to.eq('This field is not a valid email address');
+      suite.server.respondWith("POST", suite.actionPath,
+                               [422, { "Content-Type": "application/json" },
+                              '{"errors":{"email":["is too hot to handle"], "name":["is required"]}}' ]);
+      $('.petition-bar__submit-button').click();
+      suite.server.respond();
+      expect($('input[name="email"].has-error').siblings('.error-msg').text()).to.eq('This field is too hot to handle');
+    });
+
+    it('does not change anything if error is identical', function(){
+      expect($('input[name="email"].has-error').siblings('.error-msg')).to.have.length(1);
+      expect($('input[name="email"].has-error').siblings('.error-msg').text()).to.eq('This field is not a valid email address');
+      $('.petition-bar__submit-button').click();
+      suite.server.respond();
+      expect($('input[name="email"].has-error').siblings('.error-msg')).to.have.length(1);
+      expect($('input[name="email"].has-error').siblings('.error-msg').text()).to.eq('This field is not a valid email address');
+    });
+
+    it('clears the error on success', function(){
+      expect($('input[name="email"].has-error').siblings('.error-msg')).to.have.length(1);
+      suite.server.respondWith("POST", suite.actionPath, [200, { "Content-Type": "application/json" }, '{}' ]);
+      $('.petition-bar__submit-button').click();
+      suite.server.respond();
+      expect($('input[name="email"]').siblings('.error-msg')).to.have.length(0);
+      expect($('input[name="email"]')).not.to.have.class('has-error');
+    });
+  });
+
+});
+
+

--- a/spec/javascripts/member-ui/form_error_spec.js
+++ b/spec/javascripts/member-ui/form_error_spec.js
@@ -74,9 +74,17 @@ describe("Inline form errors", function() {
       expect($msg.text()).to.have.length(0);
     });
 
-    it('dismisses the error when field receives focus', function(){
+    it('does not dismiss the error when field receives focus', function(){
       var $input = $('input[name="email"]');
       $input.focus();
+      expect($input.parent()).to.have.class('has-error');
+      expect($input.parent().find('.has-error')).to.have.length.above(0);
+      expect($input.parent().find('.error-msg')).to.have.length.above(0);
+    });
+
+    it('dismisses the error when field value changes', function(){
+      var $input = $('input[name="email"]');
+      $input.change();
       expect($input.parent()).not.to.have.class('has-error');
       expect($input.parent().find('.has-error')).to.have.length(0);
       expect($input.parent().find('.error-msg')).to.have.length(0);

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -376,20 +376,20 @@ describe("Fundraiser", function() {
       });
 
       it('makes a request to validate the form', function(){
-        $('.action-bar__submit-button').click();
+        $('.petition-bar__submit-button').click();
         var request = helpers.last(suite.server.requests);
         expect(request.method).to.eq("POST");
         expect(request.url).to.match(suite.validatePath);
       });
 
       it('moves to panel 3 if validation passes', function(){
-        $('.action-bar__submit-button').click();
+        $('.petition-bar__submit-button').click();
         helpers.last(suite.server.requests).respond(200, { "Content-Type": "application/json" }, '{}');
         expect(helpers.currentStepOf(3)).to.eq(3);
       });
 
       it('stays on panel 2 if validation fails', function(){
-        $('.action-bar__submit-button').click();
+        $('.petition-bar__submit-button').click();
         helpers.last(suite.server.requests).respond(422, { "Content-Type": "application/json" }, '{ "errors": {} }');
         expect(helpers.currentStepOf(3)).to.eq(2);
       });
@@ -401,7 +401,7 @@ describe("Fundraiser", function() {
         suite.server.respondWith("POST", this.validatePath, ["200", {}, ""]);
         $('.fundraiser-bar__custom-field').val('$22');
         $('.fundraiser-bar__first-continue').click();
-        $('.action-bar__submit-button').click();
+        $('.petition-bar__submit-button').click();
 
         suite.server.respond();
         expect(helpers.currentStepOf(3)).to.eq(3);


### PR DESCRIPTION
This PR does a light refactor of `show_errors.js`. Previously, it had this weird global namespace thing, it had a weird design pattern, and it had no spec. Now, it's encapsulated in an object, uses es6, gets imported through browserify, and has a pretty solid spec that tests it through the integration with the petition bar.

There's a small outstanding bug where the border hasn't been changing on the country selector when there's an error and I want to wrap that up before this gets merged, but the code is ready for review.