### PR TITLE
Fix partial reading

### DIFF
--- a/app/liquid/liquid_file_system.rb
+++ b/app/liquid/liquid_file_system.rb
@@ -29,7 +29,7 @@ class LiquidFileSystem
     #
     def partials(title)
       Dir.glob([
-        "#{Rails.root}/app/views/plugins/**/_#{title}.liquid",
+        "#{Rails.root}/app/views/plugins/**/_#{title.to_s.parameterize.underscore}.liquid",
         "#{Rails.root}/app/liquid/views/partials/_#{title.to_s.parameterize.underscore}.liquid"
       ])
     end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -4,7 +4,7 @@
      secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
      omniauth_client_secret: <%= ENV['OMNIAUTH_CLIENT_SECRET'] %>
      omniauth_client_id: <%= ENV['OMNIAUTH_CLIENT_ID'] %>
-     liquid_templating_source: <%= ENV['LIQUID_TEMPLATING_SOURCE'] || 'file' %>
+     liquid_templating_source: <%= ENV['LIQUID_TEMPLATING_SOURCE'] || 'store' %>
      oauth_domain_whitelist:
        - 'sumofus.org'
 

--- a/spec/requests/liquid_rendering.rb
+++ b/spec/requests/liquid_rendering.rb
@@ -19,4 +19,24 @@ describe "Liquid page rendering" do
       end
     end
   end
+
+  describe 'rendering sidebars' do
+
+    before :each do
+      LiquidMarkupSeeder.seed(quiet: true) # transactional fixtures nuke em every test :/
+    end
+
+    it 'renders the fundraiser sidebar' do
+      page = create :page, liquid_layout: LiquidLayout.find_by(title: "Standard Fundraiser")
+      get "/pages/#{page.id}"
+      expect(response.body).to include('<div class="fundraiser-bar__content">')
+    end
+
+    it 'renders the fundraiser sidebar' do
+      page = create :page, liquid_layout: LiquidLayout.find_by(title: "Standard Petition")
+      get "/pages/#{page.id}"
+      expect(response.body).to include('<div class="petition-bar__content">')
+    end
+
+  end
 end


### PR DESCRIPTION
When we upgraded to ruby 2.3.0, it fixed [the ruby bug](https://bugs.ruby-lang.org/issues/10700) where filenames on case-sensitive OSes were read case-insensitively. This revealed a bug with the `LiquidFileSystem` class, and the fact that we needed smoke tests on rendering the sidebars. This fixes those things.