### PR TITLE
Publishing notice

### DIFF
--- a/app/assets/javascripts/sumofus.js
+++ b/app/assets/javascripts/sumofus.js
@@ -16,3 +16,4 @@
 require("sumofus/scroll");
 window.PetitionBar = require('sumofus/backbone/petition_bar');
 window.FundraiserBar = require('sumofus/backbone/fundraiser_bar');
+window.CampaignerOverlay = require('sumofus/backbone/campaigner_overlay');

--- a/app/assets/javascripts/sumofus/backbone/campaigner_overlay.js
+++ b/app/assets/javascripts/sumofus/backbone/campaigner_overlay.js
@@ -1,0 +1,25 @@
+const CampaignerOverlay = Backbone.View.extend({
+
+  el: '.campaigner-overlay',
+
+  events: {
+    'click .campaigner-overlay__close': 'disappear',
+    'ajax:success': 'togglePublish',
+  },
+
+  disappear() {
+    this.$el.css('bottom', '-1000px');
+    this.status = this.$el.data('status');
+  },
+
+  togglePublish() {
+    let $field = this.$('.campaigner-overlay__publish-field');
+    $field.val($field.val() == 'true' ? false : true);
+    this.status = (this.status === 'active' ? 'inactive' : 'active');
+    this.$el.toggleClass('campaigner-overlay--active');
+    this.$el.toggleClass('campaigner-overlay--inactive');
+  },
+
+});
+
+module.exports = CampaignerOverlay;

--- a/app/assets/stylesheets/sumofus/components/campaigner-overlay.scss
+++ b/app/assets/stylesheets/sumofus/components/campaigner-overlay.scss
@@ -1,7 +1,36 @@
-.campaigner-overlay__edit-link {
+.campaigner-overlay{
   position: fixed;
-  top: 20px;
-  right: 20px;
+  bottom: -20px;
+  left: 6px;
   z-index: 10000;
   color: white;
+  width: 130px;
+  @include box-sizing(border-box);
+  padding: 15px 15px 30px;
+  font-size: 12px;
+  border-radius: 5px;
+
+  &--active {
+    background: darkgreen;
+  }
+  &--inactive {
+    background: darkorange;
+  }
+  &__active-status {
+    font-weight: bold;
+    margin-bottom: 10px;
+    font-size: 15px;
+  }
+
+  &__edit-link {
+    float: left;
+    display: block;
+    width: 100%;
+    color: white;
+    margin-top: 10px;
+    text-decoration: underline;
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }

--- a/app/assets/stylesheets/sumofus/components/campaigner-overlay.scss
+++ b/app/assets/stylesheets/sumofus/components/campaigner-overlay.scss
@@ -6,31 +6,68 @@
   color: white;
   width: 130px;
   @include box-sizing(border-box);
+  @include transition(bottom 1s linear);
   padding: 15px 15px 30px;
   font-size: 12px;
   border-radius: 5px;
 
   &--active {
     background: darkgreen;
+    .campaigner-overlay__info--inactive {
+      display: none;
+    }
   }
   &--inactive {
     background: darkorange;
+    .campaigner-overlay__info--active {
+      display: none;
+    }
   }
-  &__active-status {
+  &__status {
     font-weight: bold;
     margin-bottom: 10px;
     font-size: 15px;
   }
-
+  &__close {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    cursor: pointer;
+  }
+  &__toggle-publish {
+    background: none;
+    border: none;
+    margin: 0;
+    padding-left: 0;
+    padding-right: 0;
+    float: left;
+    position: relative;
+  }
   &__edit-link {
+    float: right;
+    padding-top: 2px;
+  }
+  &__edit-link, &__toggle-publish {
+    line-height: 12px;
+    height: 14px;
+    font-size: 12px;
+    text-decoration: underline;
+    color: white;
+    cursor: pointer;
+    display: inline;
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  &__actions {
     float: left;
     display: block;
     width: 100%;
     color: white;
     margin-top: 10px;
-    text-decoration: underline;
-    &:hover {
-      text-decoration: none;
+    form {
+      float: left;
     }
   }
 }

--- a/app/views/layouts/sumofus.slim
+++ b/app/views/layouts/sumofus.slim
@@ -15,5 +15,3 @@ html
     = yield
 
     .mobile-indicator
-    - if current_user && @page.present?
-      = link_to 'Edit Page', edit_page_path(@page), class: 'campaigner-overlay__edit-link'

--- a/app/views/pages/_campaigner_overlay.slim
+++ b/app/views/pages/_campaigner_overlay.slim
@@ -1,0 +1,24 @@
+- if user_signed_in? && page.present?
+  .campaigner-overlay.mobile-hide class="#{page.active? ? 'campaigner-overlay--active' : 'campaigner-overlay--inactive'}" data-status="#{page.active? ? 'active' : 'inactive'}"
+    .campaigner-overlay__close.fa.fa-close
+    .campaigner-overlay__status.campaigner-overlay__info--active
+      | Published
+    .campaigner-overlay__status.campaigner-overlay__info--inactive
+      | Not published
+    .campaigner-overlay__message.campaigner-overlay__info--active
+      | Anyone with the link can view.
+    .campaigner-overlay__message.campaigner-overlay__info--inactive
+      | Only campaigners can view.
+    .campaigner-overlay__actions
+      = form_for page, url: api_page_path(page), remote: true do |ff|
+        / we have nested page[page][active] to match the massive nested form submitted with the one-form
+        = ff.fields_for :page do |f|
+          = f.hidden_field :active, class: 'campaigner-overlay__publish-field', value: !page.active?
+          = f.submit "Publish", class: 'campaigner-overlay__toggle-publish campaigner-overlay__info--inactive'
+          = f.submit "Unpublish", class: 'campaigner-overlay__toggle-publish campaigner-overlay__info--active'
+      = link_to 'Edit', edit_page_path(page), class: 'campaigner-overlay__edit-link'
+
+  javascript:
+    $(document).ready(function(){
+      var myCampaignerOverlay = new window.CampaignerOverlay();
+    });

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -1,2 +1,9 @@
 = @rendered
 
+- if user_signed_in? && @page.present?
+  .campaigner-overlay class="#{@page.active? ? 'campaigner-overlay--active' : 'campaigner-overlay--inactive'}"
+    .campaigner-overlay__active-status
+      = @page.active? ? "Published" : "Not published"
+    .campaigner-overlay__active_message
+      = @page.active? ? "Anyone with the link can view." : "Only campaigners can view."
+    = link_to 'Edit Page', edit_page_path(@page), class: 'campaigner-overlay__edit-link'

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -1,9 +1,26 @@
 = @rendered
 
 - if user_signed_in? && @page.present?
-  .campaigner-overlay class="#{@page.active? ? 'campaigner-overlay--active' : 'campaigner-overlay--inactive'}"
-    .campaigner-overlay__active-status
-      = @page.active? ? "Published" : "Not published"
-    .campaigner-overlay__active_message
-      = @page.active? ? "Anyone with the link can view." : "Only campaigners can view."
-    = link_to 'Edit Page', edit_page_path(@page), class: 'campaigner-overlay__edit-link'
+  .campaigner-overlay.mobile-hide class="#{@page.active? ? 'campaigner-overlay--active' : 'campaigner-overlay--inactive'}" data-status="#{@page.active? ? 'active' : 'inactive'}"
+    .campaigner-overlay__close.fa.fa-close
+    .campaigner-overlay__status.campaigner-overlay__info--active
+      | Published
+    .campaigner-overlay__status.campaigner-overlay__info--inactive
+      | Not published
+    .campaigner-overlay__message.campaigner-overlay__info--active
+      | Anyone with the link can view.
+    .campaigner-overlay__message.campaigner-overlay__info--inactive
+      | Only campaigners can view.
+    .campaigner-overlay__actions
+      = form_for @page, url: api_page_path(@page), remote: true do |ff|
+        / we have nested page[page][active] to match the massive nested form submitted with the one-form
+        = ff.fields_for :page do |f|
+          = f.hidden_field :active, class: 'campaigner-overlay__publish-field', value: !@page.active?
+          = f.submit "Publish", class: 'campaigner-overlay__toggle-publish campaigner-overlay__info--inactive'
+          = f.submit "Unpublish", class: 'campaigner-overlay__toggle-publish campaigner-overlay__info--active'
+      = link_to 'Edit', edit_page_path(@page), class: 'campaigner-overlay__edit-link'
+
+  javascript:
+    $(document).ready(function(){
+      var myCampaignerOverlay = new window.CampaignerOverlay();
+    });

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -1,26 +1,2 @@
 = @rendered
-
-- if user_signed_in? && @page.present?
-  .campaigner-overlay.mobile-hide class="#{@page.active? ? 'campaigner-overlay--active' : 'campaigner-overlay--inactive'}" data-status="#{@page.active? ? 'active' : 'inactive'}"
-    .campaigner-overlay__close.fa.fa-close
-    .campaigner-overlay__status.campaigner-overlay__info--active
-      | Published
-    .campaigner-overlay__status.campaigner-overlay__info--inactive
-      | Not published
-    .campaigner-overlay__message.campaigner-overlay__info--active
-      | Anyone with the link can view.
-    .campaigner-overlay__message.campaigner-overlay__info--inactive
-      | Only campaigners can view.
-    .campaigner-overlay__actions
-      = form_for @page, url: api_page_path(@page), remote: true do |ff|
-        / we have nested page[page][active] to match the massive nested form submitted with the one-form
-        = ff.fields_for :page do |f|
-          = f.hidden_field :active, class: 'campaigner-overlay__publish-field', value: !@page.active?
-          = f.submit "Publish", class: 'campaigner-overlay__toggle-publish campaigner-overlay__info--inactive'
-          = f.submit "Unpublish", class: 'campaigner-overlay__toggle-publish campaigner-overlay__info--active'
-      = link_to 'Edit', edit_page_path(@page), class: 'campaigner-overlay__edit-link'
-
-  javascript:
-    $(document).ready(function(){
-      var myCampaignerOverlay = new window.CampaignerOverlay();
-    });
+= render 'campaigner_overlay', page: @page

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -39,8 +39,8 @@ fr:
     processing: En cours de traitement...
     submit: Envoyer
   thermometer:
-    signatures: fr(signatures) # as in '225 signatures'
-    until: fr(until) # as in '25 signatures until 250'
+    signatures: signatures #, par exemple '225 signatures'
+    until: jusqu'à #, par exemple '25 signatures jusqu'à 250'
   share:
     cta: Partagez la pétition avec vos ami(e)s afin de tripler votre impact!
   errors:


### PR DESCRIPTION
This PR adds a little tab to the bottom left corner of all action pages to alert campaigners as to whether it is published or not. This includes a link to publish or unpublish directly there, a link to edit the page, and a n X in the corner to dismiss it in case it's covering something you want to see.

![publish-notice](https://cloud.githubusercontent.com/assets/102218/12180597/2e643076-b543-11e5-8c40-b5e3f39347f7.gif)

I also threw the two missing french translations into this PR.