### PR TITLE
Remote links

### DIFF
--- a/app/liquid/views/partials/_links.liquid
+++ b/app/liquid/views/partials/_links.liquid
@@ -1,6 +1,6 @@
 {% for link in link_list %}
   <div class="page-link">
-    <a href="{{ link.url }}">{{ link.title }}</a>
+    <a href="{{ link.url }}" target="_blank">{{ link.title }}</a>
     {% unless link.source == blank and link.date == blank %}
       <br />
     {% endunless %}

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -3,6 +3,23 @@ class Link < ActiveRecord::Base
   has_paper_trail on: [:update, :destroy]
 
   validates :url, :title, presence: true, allow_blank: false
+  validate :url_has_protocol
   validates_associated :page
+
+  before_validation :prepend_protocol
+
+  private
+
+  def url_has_protocol
+    unless /^(https?:)?\/\//i =~ url
+      errors.add(:url, 'must have a protocol (like http://)')
+    end
+  end
+
+  def prepend_protocol
+    unless url.blank? || /\/\//i =~ url
+      self.url = "//#{url}"
+    end
+  end
 
 end

--- a/app/views/pages/_link.slim
+++ b/app/views/pages/_link.slim
@@ -1,6 +1,6 @@
 li.list-group-item data-id=link.id
   = link.title
-  = " <#{link_to link.url, link.url}>. ".html_safe
+  = " <#{link_to link.url, link.url, target: 'blank'}>. ".html_safe
   - unless link.source.blank?
     = " #{link.source}. "
   = link.date

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -25,6 +25,37 @@ describe Link do
         link.date = nil
         expect(link).to be_valid
       end
+
+      it 'starting url with www.' do
+        link.url = 'www.google.com'
+        expect(link).to be_valid
+        expect(link.url).to eq '//www.google.com'
+      end
+
+      it 'with bare url' do
+        link.url = 'google.com'
+        expect(link).to be_valid
+        expect(link.url).to eq '//google.com'
+      end
+
+      it 'with url starting with http://' do
+        link.url = 'http://google.com'
+        expect(link).to be_valid
+        expect(link.url).to eq 'http://google.com'
+      end
+
+      it 'with url starting with https://' do
+        link.url = 'https://google.com'
+        expect(link).to be_valid
+        expect(link.url).to eq 'https://google.com'
+      end
+
+      it 'with url starting with //' do
+        link.url = '//google.com'
+        expect(link).to be_valid
+        expect(link.url).to eq '//google.com'
+      end
+
     end
 
     describe 'should be invalid' do
@@ -48,6 +79,19 @@ describe Link do
         link.url = "   "
         expect(link).to be_invalid
       end
+
+      it 'with a url with http:// in the middle' do
+        link.url = 'google.com/http://google.com'
+        expect(link).to be_invalid
+        expect(link.url).to eq 'google.com/http://google.com'
+      end
+
+      it 'with a url with // in the middle' do
+        link.url = 'google.com//sweet'
+        expect(link).to be_invalid
+        expect(link.url).to eq 'google.com//sweet'
+      end
+
     end
   end
 end


### PR DESCRIPTION
Before, when a campaigner created a link to a source for a page, if that was entered without a protocol like `http://` as a prefix, rails assumed it was an internal link and tried to link you to `localhost:3000/pages/motherjones.org`. This validates that all links are saved with a protocol, and has a filter run before validation to add the protocol deferring prefix `//` to urls that have none.

It also changes the links on the pages to open in new tabs instead of the existing one.