### PR TITLE
Fix JS tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,10 @@ gem 'font-awesome-sass'
 gem 'money'
 gem 'google_currency'
 
+# Sprockets 3 breaks Teaspoon.
+# see https://github.com/modeset/teaspoon/issues/443
+gem 'sprockets-rails', '< 3.0'
+
 # Braintree as a payment processor
 gem 'braintree', '~> 2.54.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,10 +409,10 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.0)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
-      sprockets (>= 3.0.0)
+    sprockets-rails (2.3.3)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      sprockets (>= 2.8, < 4.0)
     teaspoon (1.1.1)
       railties (>= 3.2.5, < 5)
     teaspoon-mocha (2.3.3)
@@ -508,6 +508,7 @@ DEPENDENCIES
   slim-rails
   spring
   spring-commands-rspec
+  sprockets-rails (< 3.0)
   teaspoon
   teaspoon-mocha
   terminal-notifier-guard

--- a/circle/specs-and-rake-tasks
+++ b/circle/specs-and-rake-tasks
@@ -22,8 +22,8 @@ done
 echo "OK"
 
 # Run javascript tests
-#RAILS_ENV=test rake db:schema:load
-#RAILS_ENV=test bundle exec teaspoon
+RAILS_ENV=test rake db:schema:load
+RAILS_ENV=test bundle exec teaspoon
 
 # Runs tests
 rspec spec


### PR DESCRIPTION
Addresses two issues
- someone merged a [commit](https://github.com/SumOfUs/Champaign/commit/02bd77e13e9b48c404f7a9808be874018f4f9a56) that turned off the js tests cause we were in a hurry to deploy to staging, but then forgot to turn them back on when the hastily constructed demo branch was turned into the new base branch. This PR turns those tests back on.
- the JS tests stopped being able to run locally when the rails and ruby version bumps brought us onto `sprockets-rails` 3. There is a [known issue](https://github.com/modeset/teaspoon/issues/443) where sprockets 3 breaks teaspoon. The current recommended solution is to stay on `sprockets-rails` 2.3, so I did that. 

JS tests are now passing on CI!