### PR TITLE
Hack to make full_name and first/last name play together nicely.

### DIFF
--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -33,7 +33,7 @@ class Api::ActionsController < ApplicationController
   end
 
   def base_params
-    %w{page_id form_id}
+    %w{page_id form_id name}
   end
 
   def fields

--- a/app/controllers/api/braintree_controller.rb
+++ b/app/controllers/api/braintree_controller.rb
@@ -67,7 +67,7 @@ class Api::BraintreeController < ApplicationController
   end
 
   def find_or_create_user
-    user = params[:user].merge(name_split)
+    user = params[:user]
     # If user isn't associated with a token locally, create and persist the customer first
     if default_payment_method_token.blank?
       result = braintree::Customer.create({
@@ -101,19 +101,10 @@ class Api::BraintreeController < ApplicationController
     {
       nonce: params[:payment_method_nonce],
       amount: params[:amount].to_f,
-      user: params[:user].merge(name_split),
+      user: params[:user],
       currency: params[:currency],
       customer: Payment.customer(params[:user][:email])
     }
-  end
-
-  def name_split
-    if params[:user].has_key? :name
-      splitter = NameSplitter.new(full_name: params[:user][:name])
-      {first_name: splitter.first_name, last_name: splitter.last_name}
-    else
-      {}
-    end
   end
 
   def subscription_options

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -10,4 +10,14 @@ class Member < ActiveRecord::Base
     end
     id.present? ? find_by(id: id) : nil
   end
+
+  def full_name
+    "#{first_name} #{last_name}".strip
+  end
+
+  def full_name=(full_name)
+    splitter = NameSplitter.new(full_name: full_name)
+    self.first_name = splitter.first_name
+    self.last_name = splitter.last_name
+  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -11,11 +11,11 @@ class Member < ActiveRecord::Base
     id.present? ? find_by(id: id) : nil
   end
 
-  def full_name
+  def name
     "#{first_name} #{last_name}".strip
   end
 
-  def full_name=(full_name)
+  def name=(full_name)
     splitter = NameSplitter.new(full_name: full_name)
     self.first_name = splitter.first_name
     self.last_name = splitter.last_name

--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -12,7 +12,7 @@ module ActionBuilder
     return @user if @user.present?
     @user = Member.find_or_create_by(email: @params[:email])
     if @params.has_key? :name
-      @user.full_name = @params[:name]
+      @user.name = @params[:name]
     end
     @user.assign_attributes(filtered_params)
     @user.save if @user.changed

--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -11,6 +11,9 @@ module ActionBuilder
   def member
     return @user if @user.present?
     @user = Member.find_or_create_by(email: @params[:email])
+    if @params.has_key? :name
+      @user.full_name = @params[:name]
+    end
     @user.assign_attributes(filtered_params)
     @user.save if @user.changed
     @user

--- a/app/services/name_splitter.rb
+++ b/app/services/name_splitter.rb
@@ -1,0 +1,32 @@
+class NameSplitter
+  def initialize(full_name:)
+    @full_name = full_name
+  end
+
+  def first_name
+    @first_name || find_first_name
+  end
+
+  def last_name
+    @last_name || find_last_name
+  end
+
+  private
+  def find_first_name
+    split_name = @full_name.split
+    if split_name.length == 2
+      @first_name = split_name[0]
+    else
+      @first_name = split_name.slice(0, (split_name.length / 2)).join(' ')
+    end
+  end
+
+  def find_last_name
+    split_name = @full_name.split
+    if split_name.length == 2
+      @last_name = split_name[1]
+    else
+      @last_name = split_name.slice((split_name.length/ 2), split_name.length).join(' ')
+    end
+  end
+end

--- a/app/services/name_splitter.rb
+++ b/app/services/name_splitter.rb
@@ -1,6 +1,7 @@
 class NameSplitter
   def initialize(full_name:)
     @full_name = full_name
+    @split_name = @full_name.split
   end
 
   def first_name
@@ -13,20 +14,24 @@ class NameSplitter
 
   private
   def find_first_name
-    split_name = @full_name.split
-    if split_name.length == 2
-      @first_name = split_name[0]
-    else
-      @first_name = split_name.slice(0, (split_name.length / 2)).join(' ')
-    end
+    @first_name =
+        if @split_name.length == 1
+          @full_name
+        elsif @split_name.length == 2
+          @split_name[0]
+        else
+          @split_name.slice(0, (@split_name.length / 2)).join(' ') #integer division, so will always round to lower whole
+        end
   end
 
   def find_last_name
-    split_name = @full_name.split
-    if split_name.length == 2
-      @last_name = split_name[1]
-    else
-      @last_name = split_name.slice((split_name.length/ 2), split_name.length).join(' ')
-    end
+    @last_name =
+        if @split_name.length == 1
+          ''
+        elsif @split_name.length == 2
+          @split_name[1]
+        else
+          @split_name.slice((@split_name.length/ 2), @split_name.length).join(' ') #integer division, so will always round to lower whole
+        end
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -4,6 +4,12 @@ describe Member do
   let(:first_name) { 'Emilio' }
   let(:last_name) { 'Estevez' }
   let(:full_name) { "#{first_name} #{last_name}" }
+  let(:unicode_first) { 'Éöíñ'}
+  let(:unicode_last) { 'Ńūñèž' }
+  let(:unicode_full) { "#{unicode_first} #{unicode_last}" }
+  let(:chinese_first) { '台'}
+  let(:chinese_last) { '北' }
+  let(:chinese_full) { "#{chinese_first} #{chinese_last}"}
 
   it 'correctly joins first and last name' do
     member = Member.new
@@ -18,5 +24,21 @@ describe Member do
     expect(member.first_name).to eq(first_name)
     expect(member.last_name).to eq(last_name)
     expect(member.name).to eq(full_name)
+  end
+
+  it 'correctly handles unicode characters' do
+    member = Member.new
+    member.name = unicode_full
+    expect(member.first_name).to eq(unicode_first)
+    expect(member.last_name).to eq(unicode_last)
+    expect(member.name).to eq(unicode_full)
+  end
+
+  it 'correctly handles high-value unicode characters' do
+    member = Member.new
+    member.name = chinese_full
+    expect(member.first_name).to eq(chinese_first)
+    expect(member.last_name).to eq(chinese_last)
+    expect(member.name).to eq(chinese_full)
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -9,14 +9,14 @@ describe Member do
     member = Member.new
     member.first_name = first_name
     member.last_name = last_name
-    expect(member.full_name).to eq(full_name)
+    expect(member.name).to eq(full_name)
   end
 
   it 'correctly splits full_name into first and last name' do
     member = Member.new
-    member.full_name = full_name
+    member.name = full_name
     expect(member.first_name).to eq(first_name)
     expect(member.last_name).to eq(last_name)
-    expect(member.full_name).to eq(full_name)
+    expect(member.name).to eq(full_name)
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -21,24 +21,30 @@ describe Member do
   it 'correctly splits full_name into first and last name' do
     member = Member.new
     member.name = full_name
-    expect(member.first_name).to eq(first_name)
-    expect(member.last_name).to eq(last_name)
-    expect(member.name).to eq(full_name)
+    member.save
+    new_member = Member.find(member.id)
+    expect(new_member.first_name).to eq(first_name)
+    expect(new_member.last_name).to eq(last_name)
+    expect(new_member.name).to eq(full_name)
   end
 
   it 'correctly handles unicode characters' do
     member = Member.new
     member.name = unicode_full
-    expect(member.first_name).to eq(unicode_first)
-    expect(member.last_name).to eq(unicode_last)
-    expect(member.name).to eq(unicode_full)
+    member.save
+    new_member = Member.find(member.id)
+    expect(new_member.first_name).to eq(unicode_first)
+    expect(new_member.last_name).to eq(unicode_last)
+    expect(new_member.name).to eq(unicode_full)
   end
 
   it 'correctly handles high-value unicode characters' do
     member = Member.new
     member.name = chinese_full
-    expect(member.first_name).to eq(chinese_first)
-    expect(member.last_name).to eq(chinese_last)
-    expect(member.name).to eq(chinese_full)
+    member.save
+    new_member = Member.find(member.id)
+    expect(new_member.first_name).to eq(chinese_first)
+    expect(new_member.last_name).to eq(chinese_last)
+    expect(new_member.name).to eq(chinese_full)
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Member do
+  let(:first_name) { 'Emilio' }
+  let(:last_name) { 'Estevez' }
+  let(:full_name) { "#{first_name} #{last_name}" }
+
+  it 'correctly joins first and last name' do
+    member = Member.new
+    member.first_name = first_name
+    member.last_name = last_name
+    expect(member.full_name).to eq(full_name)
+  end
+
+  it 'correctly splits full_name into first and last name' do
+    member = Member.new
+    member.full_name = full_name
+    expect(member.first_name).to eq(first_name)
+    expect(member.last_name).to eq(last_name)
+    expect(member.full_name).to eq(full_name)
+  end
+end

--- a/spec/services/name_splitter_spec.rb
+++ b/spec/services/name_splitter_spec.rb
@@ -16,4 +16,48 @@ describe NameSplitter do
     expect(splitter.first_name).to eq(first_name)
     expect(splitter.last_name).to eq(last_name)
   end
+
+  it 'correctly handles single name full names' do
+    first_name = 'Cher'
+    last_name = ''
+    splitter = NameSplitter.new(full_name: "#{first_name}")
+    expect(splitter.first_name).to eq(first_name)
+    expect(splitter.last_name).to eq(last_name)
+  end
+
+  it 'correctly handles names with three provided names' do
+    first_name = 'Jennifer'
+    last_name = 'Jason Leigh'
+    splitter = NameSplitter.new(full_name: "#{first_name} #{last_name}")
+    expect(splitter.first_name).to eq(first_name)
+    expect(splitter.last_name).to eq(last_name)
+  end
+
+  it 'correctly handles names with five provided names' do
+    first_name = 'Charles Philip'
+    last_name = 'Arthur George Mountbatten-Windsor'
+    splitter = NameSplitter.new(full_name: "#{first_name} #{last_name}")
+    expect(splitter.first_name).to eq(first_name)
+    expect(splitter.last_name).to eq(last_name)
+  end
+
+  it 'correctly handles names with six provided names' do
+    first_name = 'Seal Henry Olusegun'
+    last_name = 'Olumide Adeola Samuel'
+    splitter = NameSplitter.new(full_name: "#{first_name} #{last_name}")
+    expect(splitter.first_name).to eq(first_name)
+    expect(splitter.last_name).to eq(last_name)
+  end
+
+  it 'does not group common name prefixes' do
+    # This is an explicit recognition of a place where this class doesn't effectively handle an edge case of
+    # a name which doesn't follow conventional Anglo naming standards. Hopefully, some day this test can be deleted,
+    # but for now it stands as a recognition that the proper treatment of these names is not included in the
+    # expected functionality of this class at this time.
+    first_name = 'Josefina de los Sagrados'
+    last_name = 'Corazones Fernández del Solar'
+    splitter = NameSplitter.new(full_name: "#{first_name} #{last_name}")
+    expect(splitter.first_name).to eq(first_name)
+    expect(splitter.last_name).to eq(last_name)
+  end
 end

--- a/spec/services/name_splitter_spec.rb
+++ b/spec/services/name_splitter_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe NameSplitter do
+  it 'splits names in two if there are only two elements' do
+    first_name = 'Eric'
+    last_name = 'Boersma'
+    splitter = NameSplitter.new(full_name: "#{first_name} #{last_name}")
+    expect(splitter.first_name).to eq(first_name)
+    expect(splitter.last_name).to eq(last_name)
+  end
+
+  it 'splits the names in half if there are an even number of names given' do
+    first_name = 'John Jacob'
+    last_name = 'Jingleheimer Schmidt'
+    splitter = NameSplitter.new(full_name: "#{first_name} #{last_name}")
+    expect(splitter.first_name).to eq(first_name)
+    expect(splitter.last_name).to eq(last_name)
+  end
+end


### PR DESCRIPTION
This is a hack. I’m not going to paper it over - it’s not a complete way to handle the fact that our forms ask for full name but our model assumes first/last name. This code is only here to solve that very specific problem, because other issues are being held up by that issue.

So. This is not good code, in the sense that it’s not doing nice things. But it’s code! It works! It has tests! It doesn’t fix the fact that the name field shows up on a form even when your name is present, but I wanted to get it out into the wild before I worried about that.