### PR TITLE
Separate personalization data

### DIFF
--- a/app/assets/javascripts/sumofus.js
+++ b/app/assets/javascripts/sumofus.js
@@ -14,6 +14,7 @@
 //= require_directory ./plugins
 
 require("sumofus/scroll");
-window.PetitionBar = require('sumofus/backbone/petition_bar');
-window.FundraiserBar = require('sumofus/backbone/fundraiser_bar');
-window.CampaignerOverlay = require('sumofus/backbone/campaigner_overlay');
+window.sumofus = {};
+window.sumofus.PetitionBar = require('sumofus/backbone/petition_bar');
+window.sumofus.FundraiserBar = require('sumofus/backbone/fundraiser_bar');
+window.sumofus.CampaignerOverlay = require('sumofus/backbone/campaigner_overlay');

--- a/app/assets/javascripts/sumofus/backbone/currency_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/currency_methods.js
@@ -17,7 +17,7 @@ const CurrencyMethods = {
     'NZD': '$',
   },
 
-  showDonationBandForCurrency: function(currency) {
+  showDonationBandForCurrency(currency) {
     let candidates = [[this.donationBands,          currency],
                   [this.DEFAULT_DONATION_BANDS, currency],
                   [this.donationBands,          'USD'],
@@ -31,7 +31,7 @@ const CurrencyMethods = {
     };
   },
 
-  showDonationBand: function(amounts, currency) {
+  showDonationBand(amounts, currency) {
     let $buttonContainer = this.$('.fundraiser-bar__amount-buttons');
     $buttonContainer.html('');
     for (let ii = 0; ii < amounts.length; ii++) {
@@ -40,7 +40,7 @@ const CurrencyMethods = {
     };
   },
 
-  setCurrency: function(currency) {
+  setCurrency(currency) {
     if( this.CURRENCY_SYMBOLS[currency] === undefined) {
       this.currency = this.DEFAULT_CURRENCY;
     } else {
@@ -52,7 +52,7 @@ const CurrencyMethods = {
     this.showDonationBandForCurrency(this.currency);
   },
 
-  setupCurrencySelector: function() {
+  setupCurrencySelector() {
     let $select = this.$('select.fundraiser-bar__currency-selector');
     _.each(_.keys(this.CURRENCY_SYMBOLS), function(currency, ii){
       let option = `<option value="${currency}">${currency}</option>`
@@ -60,17 +60,17 @@ const CurrencyMethods = {
     });
   },
 
-  switchCurrency: function(e) {
+  switchCurrency(e) {
     this.setCurrency(this.$('select.fundraiser-bar__currency-selector').val());
   },
 
-  initializeCurrency: function(currency, donationBands) {
+  initializeCurrency(currency, donationBands) {
     this.setupCurrencySelector();
     this.donationBands = donationBands || this.DEFAULT_DONATION_BANDS;
     this.setCurrency(currency || this.DEFAULT_CURRENCY);
   },
 
-  showCurrencySwitcher: function(e) {
+  showCurrencySwitcher(e) {
     this.$('.fundraiser-bar__engage-currency-switcher').addClass('hidden-irrelevant');
     this.$('.fundraiser-bar__currency-selector').slideDown();
   },

--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -18,6 +18,7 @@ const FormMethods = {
     let $fields_holder = this.$('.form__group--prefilled');
     $fields_holder.removeClass('form__group--prefilled');
     $fields_holder.find('input').removeAttr('value');
+    $fields_holder.parents('form').trigger('reset');
     $('.petition-bar__welcome-text').addClass('hidden-irrelevant');
   },
 
@@ -27,7 +28,7 @@ const FormMethods = {
   },
 
   partialPrefill: function(prefillValues, fieldsToSkipPrefill) {
-    if(typeof prefillValues !== typeof {}) { return; }
+    if(!_.isObject(prefillValues)) { return; }
     fieldsToSkipPrefill = fieldsToSkipPrefill || [];
     this.$('.petition-bar__field-container input, select').each((ii, field) => {
       let $field = $(field);

--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -51,9 +51,10 @@ const FormMethods = {
     return this.$('.petition-bar__field-container').length;
   },
 
-  showFormClearer(member) {
-    this.$().member.welcome_name
-  }
+  showFormClearer(plugin_type, member) {
+    this.$(`.${plugin_type}-bar__welcome-name`).text(member.welcome_name);
+    this.$(`.${plugin_type}-bar__welcome-text`).removeClass('hidden-irrelevant');
+  },
 };
 
 module.exports = FormMethods;

--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -21,20 +21,20 @@ const FormMethods = {
     $('.petition-bar__welcome-text').addClass('hidden-irrelevant');
   },
 
-  prefillForm: function(member, outstandingFields){
-    if(typeof outstandingFields !== typeof []) { return; }
-    if(typeof member !== typeof {}) { return; }
-    this.$('.petition-bar__field-container').each((ii, container) => {
-      let $container = $(container);
-      let $field = $container.find('input, select');
-      let name = $field.attr('name');
-      if (outstandingFields.indexOf(name) > -1) {
-        return; // if its marked outstanding, the value we have wouldn't pass validation
-      } else if(outstandingFields.length === 0) {
-        $container.addClass('form__group--prefilled');
-      }
-      if (member.hasOwnProperty(name)) {
-        $field.val(member[name]);
+  completePrefill: function(prefillValues) {
+    this.$('.petition-bar__field-container').addClass('form__group--prefilled');
+    this.partialPrefill(prefillValues, []);
+  },
+
+  partialPrefill: function(prefillValues, fieldsToSkipPrefill) {
+    if(typeof prefillValues !== typeof {}) { return; }
+    fieldsToSkipPrefill = fieldsToSkipPrefill || [];
+    this.$('.petition-bar__field-container input, select').each((ii, field) => {
+      let $field = $(field);
+      let name = $field.prop('name');
+      console.log('prefilling field with name',name);
+      if (prefillValues.hasOwnProperty(name) && fieldsToSkipPrefill.indexOf(name) === -1) {
+        $field.val(prefillValues[name]);
       }
     });
   },

--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -2,25 +2,25 @@ let ErrorDisplay = require('show_errors');
 
 const FormMethods = {
 
-  handleFormErrors: function() {
+  handleFormErrors() {
     this.$('form').on('ajax:error', (e, d) => { ErrorDisplay.show(e, d); });
   },
 
-  selectizeCountry: function() {
+  selectizeCountry() {
     $('.petition-bar__country-selector').selectize();
   },
 
-  clearFormErrors: function() {
+  clearFormErrors() {
     ErrorDisplay.clearErrors(this.$('form'));
   },
 
-  formCanAutocomplete: function(outstandingFields, member) {
+  formCanAutocomplete(outstandingFields, member) {
     return (_.isArray(outstandingFields) &&
             outstandingFields.length === 0 &&
             (this.formFieldCount() === 0 || _.isObject(member)));
   },
 
-  clearForm: function(){
+  clearForm(){
     let $fields_holder = this.$('.form__group--prefilled');
     $fields_holder.removeClass('form__group--prefilled');
     $fields_holder.find('input, select').val('');
@@ -30,12 +30,12 @@ const FormMethods = {
     $('.petition-bar__welcome-text').addClass('hidden-irrelevant');
   },
 
-  completePrefill: function(prefillValues) {
+  completePrefill(prefillValues) {
     this.$('.petition-bar__field-container').addClass('form__group--prefilled');
     this.partialPrefill(prefillValues, []);
   },
 
-  partialPrefill: function(prefillValues, fieldsToSkipPrefill) {
+  partialPrefill(prefillValues, fieldsToSkipPrefill) {
     if(!_.isObject(prefillValues)) { return; }
     fieldsToSkipPrefill = fieldsToSkipPrefill || [];
     this.$('.petition-bar__field-container input, select').each((ii, field) => {
@@ -47,11 +47,11 @@ const FormMethods = {
     });
   },
 
-  formFieldCount: function() {
+  formFieldCount() {
     return this.$('.petition-bar__field-container').length;
   },
 
-  showFormClearer: function(member) {
+  showFormClearer(member) {
     this.$().member.welcome_name
   }
 };

--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -32,7 +32,6 @@ const FormMethods = {
     this.$('.petition-bar__field-container input, select').each((ii, field) => {
       let $field = $(field);
       let name = $field.prop('name');
-      console.log('prefilling field with name',name);
       if (prefillValues.hasOwnProperty(name) && fieldsToSkipPrefill.indexOf(name) === -1) {
         $field.val(prefillValues[name]);
       }

--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -21,6 +21,31 @@ const FormMethods = {
     $('.petition-bar__welcome-text').addClass('hidden-irrelevant');
   },
 
+  prefillForm: function(member, outstandingFields){
+    if(typeof outstandingFields !== typeof []) { return; }
+    if(typeof member !== typeof {}) { return; }
+    this.$('.petition-bar__field-container').each((ii, container) => {
+      let $container = $(container);
+      let $field = $container.find('input, select');
+      let name = $field.attr('name');
+      if (outstandingFields.indexOf(name) > -1) {
+        return; // if its marked outstanding, the value we have wouldn't pass validation
+      } else if(outstandingFields.length === 0) {
+        $container.addClass('form__group--prefilled');
+      }
+      if (member.hasOwnProperty(name)) {
+        $field.val(member[name]);
+      }
+    });
+  },
+
+  formFieldCount: function() {
+    return this.$('.petition-bar__field-container').length;
+  },
+
+  showFormClearer: function(member) {
+    this.$().member.welcome_name
+  }
 };
 
 module.exports = FormMethods;

--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -14,10 +14,18 @@ const FormMethods = {
     ErrorDisplay.clearErrors(this.$('form'));
   },
 
+  formCanAutocomplete: function(outstandingFields, member) {
+    return (_.isArray(outstandingFields) &&
+            outstandingFields.length === 0 &&
+            (this.formFieldCount() === 0 || _.isObject(member)));
+  },
+
   clearForm: function(){
     let $fields_holder = this.$('.form__group--prefilled');
     $fields_holder.removeClass('form__group--prefilled');
-    $fields_holder.find('input').removeAttr('value');
+    $fields_holder.find('input, select').val('');
+    $fields_holder.find('select').each((ii, el)=>{ el.selectedIndex = -1; });
+    $fields_holder.find('.selectized').each((ii, el)=>{ el.selectize.clear(); });
     $fields_holder.parents('form').trigger('reset');
     $('.petition-bar__welcome-text').addClass('hidden-irrelevant');
   },

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -53,19 +53,23 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     }
     this.hidingStepTwo = false;
     let amountKnown = (options.amount > 0); // non-numbers with > are always false
-    let memberKnown = (options.outstandingFields && options.outstandingFields.length === 0);
-    this.prefillForm(options.member, options.outstandingFields);
-    this.hideSteps(amountKnown, memberKnown, options.member);
+    let formComplete = ((typeof options.outstandingFields === typeof []) && 
+                        (options.outstandingFields.length === 0) &&
+                        (this.formFieldCount() === 0 || (typeof options.member == typeof {})));
+    this.hideSteps(amountKnown, formComplete, options.member, options.outstandingFields);
   },
 
-  hideSteps (amountKnown, memberKnown, member) {
-    if (amountKnown && memberKnown) {
+  hideSteps (amountKnown, formComplete, member, fieldsToSkipPrefill) {
+    if (amountKnown && formComplete) {
       this.changeStep(3);
       this.hideSecondStep(member);
-    } else if (memberKnown) {
+      this.completePrefill(member);
+    } else if (formComplete) {
       this.hideSecondStep(member);
+      this.completePrefill(member);
     } else if (amountKnown) {
       this.changeStep(2);
+      this.partialPrefill(member, fieldsToSkipPrefill);
     }
   },
 
@@ -73,7 +77,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     this.$('.fundraiser-bar__steps').addClass('fundraiser-bar__steps--two-step');
     this.$('.fundraiser-bar__step-label[data-step="2"]').css('visibility', 'hidden');
     this.$('.fundraiser-bar__step-number[data-step="3"]').text(2);
-    if (this.formFieldCount > 0) { // don't offer to reveal fields if nothing to show
+    if (this.formFieldCount() > 0) { // don't offer to reveal fields if nothing to show
       this.$('.fundraiser-bar__welcome-text').removeClass('hidden-irrelevant');
       this.$('.fundraiser-bar__welcome-name').text(member.welcome_name);
     }

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -16,7 +16,6 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     'click .fundraiser-bar__amount-button': 'advanceToDetails',
     'click .fundraiser-bar__first-continue': 'advanceToDetails',
     'click .fundraiser-bar__clear-form': 'showSecondStep',
-    'click .petition-bar__clear-form': 'clearForm',
     'ajax:success form.action': 'advanceToPayment',
     'submit form#hosted-fields': 'disableButton',
     'change select.fundraiser-bar__currency-selector': 'switchCurrency',
@@ -53,9 +52,9 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     }
     this.hidingStepTwo = false;
     let amountKnown = (options.amount > 0); // non-numbers with > are always false
-    let formComplete = ((typeof options.outstandingFields === typeof []) && 
-                        (options.outstandingFields.length === 0) &&
-                        (this.formFieldCount() === 0 || (typeof options.member == typeof {})));
+    let formComplete = (_.isArray(options.outstandingFields) &&
+                        options.outstandingFields.length === 0 &&
+                        (this.formFieldCount() === 0 || _.isObject(options.member)));
     this.hideSteps(amountKnown, formComplete, options.member, options.outstandingFields);
   },
 

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -52,27 +52,31 @@ const FundraiserBar = Backbone.View.extend(_.extend(
       this.setDonationAmount(options.amount);
     }
     this.hidingStepTwo = false;
-    // here we deliberately abuse the fact that non-numbers compared
-    // with > always return false
-    this.hideSteps((options.amount > 0), (options.outstandingFields == 0));
+    let amountKnown = (options.amount > 0); // non-numbers with > are always false
+    let memberKnown = (options.outstandingFields && options.outstandingFields.length === 0);
+    this.prefillForm(options.member, options.outstandingFields);
+    this.hideSteps(amountKnown, memberKnown, options.member);
   },
 
-  hideSteps (amountKnown, memberKnown) {
+  hideSteps (amountKnown, memberKnown, member) {
     if (amountKnown && memberKnown) {
       this.changeStep(3);
-      this.hideSecondStep();
+      this.hideSecondStep(member);
     } else if (memberKnown) {
-      this.hideSecondStep();
+      this.hideSecondStep(member);
     } else if (amountKnown) {
       this.changeStep(2);
     }
   },
 
-  hideSecondStep () {
+  hideSecondStep (member) {
     this.$('.fundraiser-bar__steps').addClass('fundraiser-bar__steps--two-step');
-    this.$('.fundraiser-bar__welcome-text').removeClass('hidden-irrelevant');
     this.$('.fundraiser-bar__step-label[data-step="2"]').css('visibility', 'hidden');
     this.$('.fundraiser-bar__step-number[data-step="3"]').text(2);
+    if (this.formFieldCount > 0) { // don't offer to reveal fields if nothing to show
+      this.$('.fundraiser-bar__welcome-text').removeClass('hidden-irrelevant');
+      this.$('.fundraiser-bar__welcome-name').text(member.welcome_name);
+    }
     this.hidingStepTwo = true;
   },
 

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -31,8 +31,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
   //    member: an object with fields that will prefill the form
   //    pageId: the ID of the plugin's page database record.
   //      and array of numbers, integers or floats, to display as donation amounts
-  initialize (options) {
-    options = options || {};
+  initialize (options = {}) {
     this.initializeCurrency(options.currency, options.donationBands)
     this.initializeSticky();
     this.initializeBraintree();

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -69,6 +69,8 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     } else if (amountKnown) {
       this.changeStep(2);
       this.partialPrefill(member, fieldsToSkipPrefill);
+    } else {
+      this.partialPrefill(member, fieldsToSkipPrefill);
     }
   },
 

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -79,8 +79,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     this.$('.fundraiser-bar__step-label[data-step="2"]').css('visibility', 'hidden');
     this.$('.fundraiser-bar__step-number[data-step="3"]').text(2);
     if (this.formFieldCount() > 0) { // don't offer to reveal fields if nothing to show
-      this.$('.fundraiser-bar__welcome-text').removeClass('hidden-irrelevant');
-      this.$('.fundraiser-bar__welcome-name').text(member.welcome_name);
+      this.showFormClearer('fundraiser', member);
     }
     this.hidingStepTwo = true;
   },

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -26,11 +26,13 @@ const FundraiserBar = Backbone.View.extend(_.extend(
   //    followUpUrl: the url to redirect to after success
   //    currency: the three letter capitalized currency code to use
   //    amount: a preselected donation amount, if > 0 the first step will be skipped
-  //    outstandingFields: the number of step 2 form fields that need to to be filled by the user
+  //    outstandingFields: the names of step 2 form fields that can't be prefilled
   //    donationBands: an object with three letter currency codes as keys
+  //    member: an object with fields that will prefill the form
   //    pageId: the ID of the plugin's page database record.
   //      and array of numbers, integers or floats, to display as donation amounts
   initialize (options) {
+    options = options || {};
     this.initializeCurrency(options.currency, options.donationBands)
     this.initializeSticky();
     this.initializeBraintree();
@@ -52,9 +54,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     }
     this.hidingStepTwo = false;
     let amountKnown = (options.amount > 0); // non-numbers with > are always false
-    let formComplete = (_.isArray(options.outstandingFields) &&
-                        options.outstandingFields.length === 0 &&
-                        (this.formFieldCount() === 0 || _.isObject(options.member)));
+    let formComplete = this.formCanAutocomplete(options.outstandingFields, options.member);
     this.hideSteps(amountKnown, formComplete, options.member, options.outstandingFields);
   },
 

--- a/app/assets/javascripts/sumofus/backbone/hosted_fields.js
+++ b/app/assets/javascripts/sumofus/backbone/hosted_fields.js
@@ -1,10 +1,10 @@
 const HostedFieldsMethods = {
 
-  initializeBraintree: function() {
+  initializeBraintree() {
     this.getClientToken(this.setupFields());
   },
 
-  braintreeSettings: function() {
+  braintreeSettings() {
     return {
       id: "hosted-fields",
       onPaymentMethodReceived: this.paymentMethodReceived(),
@@ -54,13 +54,13 @@ const HostedFieldsMethods = {
     };
   },
 
-  setupFields: function() {
+  setupFields() {
     return (clientToken) => {
       braintree.setup(clientToken, "custom", this.braintreeSettings());
     }
   },
 
-  handleErrors: function() {
+  handleErrors() {
     return (error) => {
       this.enableButton();
       if (error.details !== undefined && error.details.invalidFieldKeys !== undefined) {
@@ -71,14 +71,14 @@ const HostedFieldsMethods = {
     }
   },
 
-  showError: function(fieldName, msg) {
+  showError(fieldName, msg) {
     fieldName = this.standardizeFieldName(fieldName);
     let $holder = $(`.hosted-fields__${fieldName}`).parent();
     $holder.find('.error-msg').remove();
     $holder.append(`<div class='error-msg'>${this.translateFieldName(fieldName)} ${msg}</div>`);
   },
 
-  showCardType: function(card) {
+  showCardType(card) {
     if (card == null || card.type == null ) {
       this.$('.hosted-fields__card-type').addClass('hidden-irrelevant');
     } else {
@@ -98,16 +98,16 @@ const HostedFieldsMethods = {
     }
   },
 
-  clearError: function(fieldName) {
+  clearError(fieldName) {
     fieldName = this.standardizeFieldName(fieldName);
     this.$(`.hosted-fields__${fieldName}`).parent().find('.error-msg').remove();
   },
 
-  standardizeFieldName: function(fieldName) {
+  standardizeFieldName(fieldName) {
     return /expiration/.test(fieldName) ? 'expiration' : fieldName;
   },
 
-  translateFieldName: function(fieldName) {
+  translateFieldName(fieldName) {
     if (['expiration', 'cvv', 'number', 'postalCode'].indexOf(this.standardizeFieldName(fieldName)) > -1) {
       return I18n.t(`fundraiser.fields.${fieldName}`)
     } else {
@@ -115,7 +115,7 @@ const HostedFieldsMethods = {
     }
   },
 
-  getClientToken: function(callback) {
+  getClientToken(callback) {
     $.get('/api/braintree/token', function(resp, success){
       callback(resp.token);
     });

--- a/app/assets/javascripts/sumofus/backbone/petition_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/petition_bar.js
@@ -34,7 +34,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
     if (this.formCanAutocomplete(options.outstandingFields, options.member)) {
       this.completePrefill(options.member);
       if (this.formFieldCount() > 0) {
-        $('.petition-bar__welcome-text').removeClass('hidden-irrelevant');
+        this.showFormClearer('petition', options.member);
       }
     } else {
       this.partialPrefill(options.member, options.outstandingFields);

--- a/app/assets/javascripts/sumofus/backbone/petition_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/petition_bar.js
@@ -18,7 +18,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
   // options: object with any of the following keys
   //    outstandingFields: the names of step 2 form fields that can't be prefilled
   //    member: an object with fields that will prefill the form
-  initialize: function(options) {
+  initialize(options) {
     options = options || {};
     this.petitionTextMinHeight = 120; // pixels
     this.checkBlurbHeight();
@@ -30,7 +30,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
     }
   },
 
-  initializePrefill: function(options) {
+  initializePrefill(options) {
     if (this.formCanAutocomplete(options.outstandingFields, options.member)) {
       this.completePrefill(options.member);
       if (this.formFieldCount() > 0) {
@@ -41,7 +41,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
     }
   },
 
-  handleSuccess: function(e, data) {
+  handleSuccess(e, data) {
     this.clearFormErrors();
     if (data.follow_up_url) {
       window.location.href = data.follow_up_url
@@ -51,19 +51,19 @@ const PetitionBar = Backbone.View.extend(_.extend(
     }
   },
 
-  isMobile: function() {
+  isMobile() {
     return $('.mobile-indicator').is(':visible');
   },
 
-  hide: function() {
+  hide() {
     this.$el.addClass('petition-bar--mobile-view--closed').removeClass('petition-bar--mobile-view--open');
   },
 
-  reveal: function() {
+  reveal() {
     this.$el.removeClass('petition-bar--mobile-view--closed').addClass('petition-bar--mobile-view--open');
   },
 
-  checkBlurbHeight: function (){
+  checkBlurbHeight (){
     if (this.$('.petition-bar__top').outerHeight() > this.petitionTextMinHeight) {
       this.blurbIsTall = true;
     } else {
@@ -72,7 +72,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
     }
   },
 
-  toggleBlurb: function() {
+  toggleBlurb() {
     if (this.blurbIsTall) {
       if (this.$('.petition-bar__expand-arrow').hasClass('petition-bar__expand-arrow--expanded')) {
         this.expandBlurb();
@@ -83,12 +83,12 @@ const PetitionBar = Backbone.View.extend(_.extend(
     }
   },
 
-  expandBlurb: function() {
+  expandBlurb() {
     this.$('.petition-bar__main').css('top', '');
     this.$el.parent('.sticky-wrapper').css('top', '');
   },
 
-  collapseBlurb: function() {
+  collapseBlurb() {
     const height = this.$('.petition-bar__top').outerHeight();
     this.$('.petition-bar__main').css('top', `${height}px`);
     this.$el.parent('.sticky-wrapper').css('top', `-${height}px`);

--- a/app/assets/javascripts/sumofus/backbone/petition_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/petition_bar.js
@@ -18,8 +18,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
   // options: object with any of the following keys
   //    outstandingFields: the names of step 2 form fields that can't be prefilled
   //    member: an object with fields that will prefill the form
-  initialize(options) {
-    options = options || {};
+  initialize(options = {}) {
     this.petitionTextMinHeight = 120; // pixels
     this.checkBlurbHeight();
     this.handleFormErrors();

--- a/app/assets/javascripts/sumofus/backbone/petition_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/petition_bar.js
@@ -15,13 +15,29 @@ const PetitionBar = Backbone.View.extend(_.extend(
     'ajax:success form.action': 'handleSuccess',
   },
 
-  initialize: function() {
+  // options: object with any of the following keys
+  //    outstandingFields: the names of step 2 form fields that can't be prefilled
+  //    member: an object with fields that will prefill the form
+  initialize: function(options) {
+    options = options || {};
     this.petitionTextMinHeight = 120; // pixels
     this.checkBlurbHeight();
     this.handleFormErrors();
     this.initializeSticky();
+    this.initializePrefill(options);
     if (!this.isMobile()) {
       this.selectizeCountry();
+    }
+  },
+
+  initializePrefill: function(options) {
+    if (this.formCanAutocomplete(options.outstandingFields, options.member)) {
+      this.completePrefill(options.member);
+      if (this.formFieldCount() > 0) {
+        $('.petition-bar__welcome-text').removeClass('hidden-irrelevant');
+      }
+    } else {
+      this.partialPrefill(options.member, options.outstandingFields);
     }
   },
 

--- a/app/assets/javascripts/sumofus/backbone/sticky_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/sticky_methods.js
@@ -1,6 +1,6 @@
 const StickyMethods = {
 
-  initializeSticky: function() {
+  initializeSticky() {
     this.isSticky = false;
     this.questionSticky();
 
@@ -8,11 +8,11 @@ const StickyMethods = {
     $(window).on('resize', () => this.questionSticky());
   },
 
-  isMobile: function() {
+  isMobile() {
     return $('.mobile-indicator').is(':visible');
   },
 
-  makeSticky: function() {
+  makeSticky() {
     if(!this.isSticky) {
       this.$el.sticky({topSpacing:0});
       if (this.$el.hasClass('fundraiser-bar')) {
@@ -24,14 +24,14 @@ const StickyMethods = {
     }
   },
 
-  unmakeSticky: function() {
+  unmakeSticky() {
     if(this.isSticky) {
       this.$el.unstick();
       this.isSticky = false;
     }
   },
 
-  questionSticky: function() {
+  questionSticky() {
     if(this.isMobile()) {
       this.unmakeSticky();
     } else {

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -56,6 +56,7 @@ class PagesController < ApplicationController
     recognized_member = Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
     renderer = LiquidRenderer.new(@page, request_country: request_country, member: recognized_member, layout: layout, url_params: params)
     @rendered = renderer.render
+    @data = renderer.data
     render :show, layout: 'sumofus'
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -54,7 +54,7 @@ class PagesController < ApplicationController
   def render_liquid(layout)
     raise ActiveRecord::RecordNotFound unless @page.active? || user_signed_in?
     recognized_member = Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
-    renderer = LiquidRenderer.new(@page, request_country: request_country, member: recognized_member, layout: layout, url_params: params)
+    renderer = LiquidRenderer.new(@page, location: request.location, member: recognized_member, layout: layout, url_params: params)
     @rendered = renderer.render
     @data = renderer.data
     render :show, layout: 'sumofus'
@@ -62,11 +62,6 @@ class PagesController < ApplicationController
 
   def get_page
     @page = Page.find(params[:id])
-  end
-
-  def request_country
-    # when geocoder location API times out, request.location is blank
-    request.location.blank? ? nil : request.location.country_code
   end
 
   def page_params

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -9,6 +9,10 @@ module PagesHelper
     end
   end
 
+  def serialize(data, field)
+    (data[field.to_s] || {}).to_json.html_safe
+  end
+
   def prefill_link(new_variant)
     new_variant.description = "{LINK}" if new_variant.name == 'twitter'
     new_variant.body = "{LINK}" if new_variant.name == 'email'

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -10,7 +10,8 @@ module PagesHelper
   end
 
   def serialize(data, field)
-    (data.stringify_keys[field.to_s] || {}).to_json.html_safe
+    hash = HashWithIndifferentAccess.new(data)
+    (hash[field].blank? ? {} : hash[field]).to_json.html_safe
   end
 
   def prefill_link(new_variant)

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -10,7 +10,7 @@ module PagesHelper
   end
 
   def serialize(data, field)
-    (data[field.to_s] || {}).to_json.html_safe
+    (data.stringify_keys[field.to_s] || {}).to_json.html_safe
   end
 
   def prefill_link(new_variant)

--- a/app/liquid/liquid_helper.rb
+++ b/app/liquid/liquid_helper.rb
@@ -1,8 +1,4 @@
 class LiquidHelper
-  # TODO: Move constants to `Donations`
-  EURO_COUNTRY_CODES = [:AL, :AD, :AT, :BY, :BE, :BA, :BG, :HR, :CY, :CZ, :DK, :EE, :FO, :FI, :FR, :DE, :GI, :GR, :HU, :IS, :IE, :IT, :LV, :LI, :LT, :LU, :MK, :MT, :MD, :MC, :NL, :NO, :PL, :PT, :RO, :RU, :SM, :RS, :SK, :SI, :ES, :SE, :CH, :UA, :VA, :RS, :IM, :RS, :ME]
-  DEFAULT_CURRENCY = 'USD'
-
   class << self
 
     # when possible, I think we should try to make this match with
@@ -33,27 +29,7 @@ class LiquidHelper
       actions.map(&:target).reject(&:blank?).first
     end
 
-    # TODO: 'Country code to currency' probably better served by +Donations::Utils+
-    def guess_currency(request_country)
-      return 'EUR' if EURO_COUNTRY_CODES.include?(request_country.try(:to_sym))
-
-      {
-        US: 'USD',
-        GB: 'GBP',
-        NZ: 'NZD',
-        AU: 'AUD',
-        CA: 'CAD'
-      }[request_country.try(:to_sym)] || DEFAULT_CURRENCY
-    end
-
     private
-
-    def preferred(names_with_codes)
-      # currently unused
-      codes = ['US', 'GB', 'CA', 'FR', 'DE']
-      preferred = names_with_codes.select{|name, code| codes.include? code }
-      preferred + names_with_codes # better ux to have it twice than hard to find
-    end
 
     def member_hash(member)
       return nil if member.blank?

--- a/app/liquid/liquid_helper.rb
+++ b/app/liquid/liquid_helper.rb
@@ -4,12 +4,10 @@ class LiquidHelper
     # when possible, I think we should try to make this match with
     # helpers in liquid docs to be more intuitive for people familiar with liquid
     # https://docs.shopify.com/themes/liquid-documentation/objects
-    def globals(request_country: nil, member: nil, page: nil)
+    def globals(page: nil)
       {
-        country_option_tags: country_option_tags(selected_country(request_country, member)),
-        member: member_hash(member),
-        petition_target: petition_target(page),
-        guessed_currency: guess_currency(request_country)
+        country_option_tags: country_option_tags,
+        petition_target: petition_target(page)
       }
     end
 
@@ -27,20 +25,6 @@ class LiquidHelper
       return nil unless page.present?
       actions = page.plugins.select{ |p| p.name == "Petition" && p.active? }
       actions.map(&:target).reject(&:blank?).first
-    end
-
-    private
-
-    def member_hash(member)
-      return nil if member.blank?
-      values = member.attributes.symbolize_keys
-      values[:welcome_name] = [values[:first_name], values[:last_name]].join(' ')
-      values[:welcome_name] = values[:email] if values[:welcome_name].blank?
-      values
-    end
-
-    def selected_country(request_country, member)
-      member.present? && member.country.present? ? member.country : request_country
     end
   end
 end

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -73,10 +73,10 @@ class LiquidRenderer
 
   def location
     return @location if @location.blank?
-    if @member.present? && @member.country.present? && @member.country.length == 2
-      country_code = @member.country
+    country_code = if @member.try(:country) && @member.country.length == 2
+      @member.country
     else
-      country_code = @location.country_code
+      @location.country_code
     end
     return @location.data if country_code.blank?
     currency = Donations::Utils.currency_from_country_code(country_code)

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -40,6 +40,7 @@ class LiquidRenderer
                 merge( member: member_hash ).
                 merge( location: location).
                 merge( outstanding_fields: outstanding_fields(plugin_data) ).
+                merge( donation_bands: donation_bands(plugin_data) ).
                 deep_stringify_keys
   end
 
@@ -58,8 +59,16 @@ class LiquidRenderer
   end
 
   def outstanding_fields(plugin_data)
+    isolate_from_plugin_data(plugin_data, :outstanding_fields)
+  end
+
+  def donation_bands(plugin_data)
+    isolate_from_plugin_data(plugin_data, :donation_bands).first
+  end
+
+  def isolate_from_plugin_data(plugin_data, field)
     plugin_values = plugin_data.deep_symbolize_keys[:plugins].values().map(&:values).flatten
-    plugin_values.map{|plugin| plugin[:outstanding_fields]}.flatten.compact
+    plugin_values.map{|plugin| plugin[field]}.flatten.compact
   end
 
   def location

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -1,7 +1,7 @@
 <form action='/api/pages/{{id}}/actions{{form_url_postscript}}' data-remote='true' method='post' class='form--big action'>
   <div class="petition-bar__welcome-text hidden-irrelevant">
     {{ 'form.welcome_back' | t }},
-    <span class="petition-bar__welcome-name">{{member.welcome_name}}</span>! <br />
+    <span class="petition-bar__welcome-name"></span>! <br />
     <a href="javascript:;" class=" petition-bar__clear-form">{{ 'form.switch_user' | t }}</a>
   </div>
   <input type='hidden' name='form_id' value='{{ form_id }}' />

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -9,17 +9,17 @@
       <div class="form__group petition-bar__field-container">
         {% case field.data_type %}
         {% when 'text' %}
-          <input type="text" name="{{field.name}}" class="form-control" id="" placeholder="{{ field.label }}" />
+          <input type="text" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" />
         {% when 'email' %}
-          <input type="email" name="{{field.name}}" class="form-control mailcheck" id="" placeholder="{{ field.label }}" />
+          <input type="email" name="{{field.name}}" class="form-control mailcheck form__content" id="" placeholder="{{ field.label }}" />
         {% when 'phone' %}
-          <input type="tel" name="{{field.name}}" class="form-control" id="" placeholder="{{ field.label }}" />
+          <input type="tel" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" />
         {% when 'checkbox' %}
           <label class="checkbox-label">
-            <input type="checkbox" name="{{field.name}}" /> {{ field.label }}
+            <input type="checkbox" name="{{field.name}}" class="form__content" /> {{ field.label }}
           </label>
         {% when 'country' %}
-          <select name="{{field.name}}" class="petition-bar__country-selector" placeholder="{{field.label}}">
+          <select name="{{field.name}}" class="petition-bar__country-selector form__content" placeholder="{{field.label}}">
             <option></option>
             {{ country_option_tags }}
           </select>

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -1,7 +1,12 @@
 <form action='/api/pages/{{id}}/actions{{form_url_postscript}}' data-remote='true' method='post' class='form--big action'>
+  <div class="petition-bar__welcome-text hidden-irrelevant">
+    {{ 'form.welcome_back' | t }},
+    <span class="petition-bar__welcome-name">{{member.welcome_name}}</span>! <br />
+    <a href="javascript:;" class=" petition-bar__clear-form">{{ 'form.switch_user' | t }}</a>
+  </div>
   <input type='hidden' name='form_id' value='{{ form_id }}' />
     {% for field in fields %}
-      <div class="form__group {% if prefilled %}form__group--prefilled{% endif %}">
+      <div class="form__group petition-bar__field-container">
         {% case field.data_type %}
         {% when 'text' %}
           <input type="text" name="{{field.name}}" class="form-control" id="" placeholder="{{ field.label }}" />

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -1,41 +1,25 @@
 <form action='/api/pages/{{id}}/actions{{form_url_postscript}}' data-remote='true' method='post' class='form--big action'>
-  {% if member %}
-      <div class="petition-bar__welcome-text">
-        {{ 'form.welcome_back' | t }}, {{member.welcome_name}}!
-        <br />
-        <a href="javascript:;" class="petition-bar__clear-form">{{ 'form.switch_user' | t }}</a>
-      </div>
-  {% endif %}
   <input type='hidden' name='form_id' value='{{ form_id }}' />
-  {% for field in fields %}
-    {% if outstanding_fields contains field.name %}
-      {% assign prefilled = false %}
-    {% elsif member[field.name] %}
-      {% assign prefilled = true %}
-    {% elsif member and field.required == false %}
-      {% assign prefilled = true %}
-    {% else %}
-      {% assign prefilled = false %}
-    {% endif %}
-    <div class="form__group {% if prefilled %}form__group--prefilled{% endif %}">
-      {% case field.data_type %}
-      {% when 'text' %}
-        <input type="text" name="{{field.name}}" class="form-control" id="" placeholder="{{ field.label }}" value="{{member[field.name]}}"/>
-      {% when 'email' %}
-        <input type="email" name="{{field.name}}" class="form-control mailcheck" id="" placeholder="{{ field.label }}" value="{{member[field.name]}}" />
-      {% when 'phone' %}
-        <input type="tel" name="{{field.name}}" class="form-control" id="" placeholder="{{ field.label }}" value="{{member[field.name]}}" />
-      {% when 'checkbox' %}
-        <label class="checkbox-label">
-          <input type="checkbox" name="{{field.name}}" /> {{ field.label }}
-        </label>
-      {% when 'country' %}
-        <select name="{{field.name}}" class="petition-bar__country-selector" placeholder="{{field.label}}">
-          <option></option>
-          {{ country_option_tags }}
-        </select>
-      {% endcase %}
-    </div>
-  {% endfor %}
+    {% for field in fields %}
+      <div class="form__group {% if prefilled %}form__group--prefilled{% endif %}">
+        {% case field.data_type %}
+        {% when 'text' %}
+          <input type="text" name="{{field.name}}" class="form-control" id="" placeholder="{{ field.label }}" />
+        {% when 'email' %}
+          <input type="email" name="{{field.name}}" class="form-control mailcheck" id="" placeholder="{{ field.label }}" />
+        {% when 'phone' %}
+          <input type="tel" name="{{field.name}}" class="form-control" id="" placeholder="{{ field.label }}" />
+        {% when 'checkbox' %}
+          <label class="checkbox-label">
+            <input type="checkbox" name="{{field.name}}" /> {{ field.label }}
+          </label>
+        {% when 'country' %}
+          <select name="{{field.name}}" class="petition-bar__country-selector" placeholder="{{field.label}}">
+            <option></option>
+            {{ country_option_tags }}
+          </select>
+        {% endcase %}
+      </div>
+    {% endfor %}
   <button type="submit" class="button petition-bar__submit-button">{{ cta }}</button>
 </form>

--- a/app/liquid/views/partials/_personalization.liquid
+++ b/app/liquid/views/partials/_personalization.liquid
@@ -1,8 +1,0 @@
-<script type="text/javascript">
-  window.sumofus = window.sumofus || {};
-  window.sumofus.personalization = {
-    currency: "{{ guessed_currency }}",
-    donationAmount: {% if url_params['amount'] == blank %} 0 {% else %} {{ url_params['amount'] }}{% endif %},
-    outstandingFields: {{ plugins.fundraiser[ref].outstanding_fields.size }}
-  }
-</script>

--- a/app/liquid/views/partials/_personalization.liquid
+++ b/app/liquid/views/partials/_personalization.liquid
@@ -1,0 +1,8 @@
+<script type="text/javascript">
+  window.sumofus = window.sumofus || {};
+  window.sumofus.personalization = {
+    currency: "{{ guessed_currency }}",
+    donationAmount: {% if url_params['amount'] == blank %} 0 {% else %} {{ url_params['amount'] }}{% endif %},
+    outstandingFields: {{ plugins.fundraiser[ref].outstanding_fields.size }}
+  }
+</script>

--- a/app/models/plugins/fundraiser.rb
+++ b/app/models/plugins/fundraiser.rb
@@ -10,7 +10,7 @@ class Plugins::Fundraiser < ActiveRecord::Base
     donation_band_name = supplemental_data[:donation_band]
     backup_id = donation_band.try(:id)
     bands = Donations::BandFinder.find_band(donation_band_name, backup_id)
-    bands = bands.present? ? bands.internationalize.to_json : 'null'
+    bands = bands.present? ? bands.internationalize : {}
     attributes.merge(form_liquid_data(supplemental_data)).merge(donation_bands: bands)
   end
 end

--- a/app/views/pages/_campaigner_overlay.slim
+++ b/app/views/pages/_campaigner_overlay.slim
@@ -20,5 +20,5 @@
 
   javascript:
     $(document).ready(function(){
-      var myCampaignerOverlay = new window.CampaignerOverlay();
+      window.sumofus.myCampaignerOverlay = new window.sumofus.CampaignerOverlay();
     });

--- a/app/views/pages/_personalization.slim
+++ b/app/views/pages/_personalization.slim
@@ -2,7 +2,8 @@ javascript:
   window.sumofus = window.sumofus || {};
   window.sumofus.personalization = {
     outstandingFields: #{serialize(data, 'outstanding_fields')},
+    donationBands: #{serialize(data, 'donation_bands')},
     urlParams: #{ serialize(data, 'url_params') },
     location: #{ serialize(data, 'location') },
-    member: #{serialize(data, 'member')}
+    member: #{serialize(data, 'member') }
   }

--- a/app/views/pages/_personalization.slim
+++ b/app/views/pages/_personalization.slim
@@ -1,0 +1,8 @@
+javascript:
+  window.sumofus = window.sumofus || {};
+  window.sumofus.personalization = {
+    outstandingFields: #{serialize(data, 'outstandingFields')},
+    urlParams: #{ serialize(data, 'url_params') },
+    location: #{ serialize(data, 'location') },
+    member: #{serialize(data, 'member')}
+  }

--- a/app/views/pages/_personalization.slim
+++ b/app/views/pages/_personalization.slim
@@ -1,7 +1,7 @@
 javascript:
   window.sumofus = window.sumofus || {};
   window.sumofus.personalization = {
-    outstandingFields: #{serialize(data, 'outstandingFields')},
+    outstandingFields: #{serialize(data, 'outstanding_fields')},
     urlParams: #{ serialize(data, 'url_params') },
     location: #{ serialize(data, 'location') },
     member: #{serialize(data, 'member')}

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -1,2 +1,3 @@
 = @rendered
+= render 'personalization', data: @data
 = render 'campaigner_overlay', page: @page

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -107,7 +107,7 @@
       window.sumofus.myFundraiserBar = new window.sumofus.FundraiserBar({
         pageId:           "{{ id }}",
         followUpUrl:      "{{ follow_up_url }}",
-        currency:         window.sumofus.personalization.location.currency,
+        currency:         window.sumofus.personalization.urlParams.currency || window.sumofus.personalization.location.currency,
         donationBands:    {{ plugins.fundraiser[ref].donation_bands }},
         amount:           window.sumofus.personalization.urlParams.amount,
         outstandingFields:window.sumofus.personalization.outstandingFields

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -1,4 +1,6 @@
 {% if plugins.fundraiser[ref].active %}
+  {% include 'Pandering' %}
+
   <div class="fundraiser-bar fundraiser-bar--elevated fundraiser-bar--mobile-view--closed">
     <div class="fundraiser-bar__content">
       <div class="fundraiser-bar__top">
@@ -103,13 +105,13 @@
 
   <script type="text/javascript">
     $(document).ready(function(){
-      var myFundraiserBar = new window.FundraiserBar({
+      window.sumofus.myFundraiserBar = new window.sumofus.FundraiserBar({
         pageId:           "{{ id }}",
         followUpUrl:      "{{ follow_up_url }}",
-        currency:         "{{ guessed_currency }}",
+        currency:         window.sumofus.pandering.currency,
         donationBands:    {{ plugins.fundraiser[ref].donation_bands }},
-        amount:           {% if url_params['amount'] == blank %} 0 {% else %} {{ url_params['amount'] }}{% endif %},
-        outstandingFields:{{ plugins.fundraiser[ref].outstanding_fields.size }}
+        amount:           window.sumofus.pandering.donationAmount,
+        outstandingFields:window.sumofus.pandering.outstandingFields
       });
     });
   </script>

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -1,6 +1,4 @@
 {% if plugins.fundraiser[ref].active %}
-  {% include 'Personalization' %}
-
   <div class="fundraiser-bar fundraiser-bar--elevated fundraiser-bar--mobile-view--closed">
     <div class="fundraiser-bar__content">
       <div class="fundraiser-bar__top">
@@ -108,9 +106,9 @@
       window.sumofus.myFundraiserBar = new window.sumofus.FundraiserBar({
         pageId:           "{{ id }}",
         followUpUrl:      "{{ follow_up_url }}",
-        currency:         window.sumofus.personalization.currency,
+        currency:         window.sumofus.personalization.location.currency,
         donationBands:    {{ plugins.fundraiser[ref].donation_bands }},
-        amount:           window.sumofus.personalization.donationAmount,
+        amount:           window.sumofus.personalization.urlParams.amount,
         outstandingFields:window.sumofus.personalization.outstandingFields
       });
     });

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -110,6 +110,7 @@
         currency:         window.sumofus.personalization.urlParams.currency || window.sumofus.personalization.location.currency,
         donationBands:    window.sumofus.personalization.donationBands,
         amount:           window.sumofus.personalization.urlParams.amount,
+        member:           window.sumofus.personalization.member,
         outstandingFields:window.sumofus.personalization.outstandingFields
       });
     });

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -61,6 +61,11 @@
             fields: plugins.fundraiser[ref].fields %}
         </div>
         <div class="fundraiser-bar__step-panel form--big" data-step="3">
+          <div class="fundraiser-bar__welcome-text hidden-irrelevant">
+            {{ 'form.welcome_back' | t }},
+            <span class="fundraiser-bar__welcome-name">{{member.welcome_name}}</span>! <br />
+            <a href="javascript:;" class=" fundraiser-bar__clear-form">{{ 'form.switch_user' | t }}</a>
+          </div>
           <form action='/' id="hosted-fields">
             <div class="form__group">
               <div id="hosted-fields__paypal"></div>

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -63,7 +63,7 @@
         <div class="fundraiser-bar__step-panel form--big" data-step="3">
           <div class="fundraiser-bar__welcome-text hidden-irrelevant">
             {{ 'form.welcome_back' | t }},
-            <span class="fundraiser-bar__welcome-name">{{member.welcome_name}}</span>! <br />
+            <span class="fundraiser-bar__welcome-name"></span>! <br />
             <a href="javascript:;" class=" fundraiser-bar__clear-form">{{ 'form.switch_user' | t }}</a>
           </div>
           <form action='/' id="hosted-fields">

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -1,5 +1,5 @@
 {% if plugins.fundraiser[ref].active %}
-  {% include 'Pandering' %}
+  {% include 'Personalization' %}
 
   <div class="fundraiser-bar fundraiser-bar--elevated fundraiser-bar--mobile-view--closed">
     <div class="fundraiser-bar__content">
@@ -108,10 +108,10 @@
       window.sumofus.myFundraiserBar = new window.sumofus.FundraiserBar({
         pageId:           "{{ id }}",
         followUpUrl:      "{{ follow_up_url }}",
-        currency:         window.sumofus.pandering.currency,
+        currency:         window.sumofus.personalization.currency,
         donationBands:    {{ plugins.fundraiser[ref].donation_bands }},
-        amount:           window.sumofus.pandering.donationAmount,
-        outstandingFields:window.sumofus.pandering.outstandingFields
+        amount:           window.sumofus.personalization.donationAmount,
+        outstandingFields:window.sumofus.personalization.outstandingFields
       });
     });
   </script>

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -61,10 +61,6 @@
             fields: plugins.fundraiser[ref].fields %}
         </div>
         <div class="fundraiser-bar__step-panel form--big" data-step="3">
-          <div class="fundraiser-bar__welcome-text hidden-irrelevant">
-            {{ 'form.welcome_back' | t }}, {{member.welcome_name}}! <br />
-            <a href="javascript:;" class=" fundraiser-bar__clear-form">{{ 'form.switch_user' | t }}</a>
-          </div>
           <form action='/' id="hosted-fields">
             <div class="form__group">
               <div id="hosted-fields__paypal"></div>
@@ -88,7 +84,7 @@
                 </label>
               </div>
             </div>
-            <button type="submit" class="button fundraiser-bar__submit-button">Submit</button>
+            <button type="submit" class="button fundraiser-bar__submit-button">{{ 'form.submit' | t }}</button>
           </form>
         </div>
       </div>

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -108,7 +108,7 @@
         pageId:           "{{ id }}",
         followUpUrl:      "{{ follow_up_url }}",
         currency:         window.sumofus.personalization.urlParams.currency || window.sumofus.personalization.location.currency,
-        donationBands:    {{ plugins.fundraiser[ref].donation_bands }},
+        donationBands:    window.sumofus.personalization.donationBands,
         amount:           window.sumofus.personalization.urlParams.amount,
         outstandingFields:window.sumofus.personalization.outstandingFields
       });

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -1,4 +1,5 @@
 {% if plugins.petition[ref].active %}
+  {% include 'Pandering' %}
   <div class="petition-bar petition-bar--elevated petition-bar--mobile-view--closed">
     <div class="petition-bar__content">
       <div class="petition-bar__top">
@@ -39,7 +40,7 @@
 
   <script type="text/javascript">
     $(document).ready(function(){
-      var myPetitionBar = new window.PetitionBar();
+      window.sumofus.myPetitionBar = new window.sumofus.PetitionBar();
     });
   </script>
 {% endif %}

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -1,5 +1,5 @@
 {% if plugins.petition[ref].active %}
-  {% include 'Pandering' %}
+  {% include 'Personalization' %}
   <div class="petition-bar petition-bar--elevated petition-bar--mobile-view--closed">
     <div class="petition-bar__content">
       <div class="petition-bar__top">

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -1,5 +1,4 @@
 {% if plugins.petition[ref].active %}
-  {% include 'Personalization' %}
   <div class="petition-bar petition-bar--elevated petition-bar--mobile-view--closed">
     <div class="petition-bar__content">
       <div class="petition-bar__top">

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -39,7 +39,10 @@
 
   <script type="text/javascript">
     $(document).ready(function(){
-      window.sumofus.myPetitionBar = new window.sumofus.PetitionBar();
+      window.sumofus.myPetitionBar = new window.sumofus.PetitionBar({
+        member:           window.sumofus.personalization.member,
+        outstandingFields:window.sumofus.personalization.outstandingFields
+      });
     });
   </script>
 {% endif %}

--- a/lib/donations/utils.rb
+++ b/lib/donations/utils.rb
@@ -1,6 +1,8 @@
 module Donations
   module Utils
     extend self
+    EURO_COUNTRY_CODES = [:AL, :AD, :AT, :BY, :BE, :BA, :BG, :HR, :CY, :CZ, :DK, :EE, :FO, :FI, :FR, :DE, :GI, :GR, :HU, :IS, :IE, :IT, :LV, :LI, :LT, :LU, :MK, :MT, :MD, :MC, :NL, :NO, :PL, :PT, :RO, :RU, :SM, :RS, :SK, :SI, :ES, :SE, :CH, :UA, :VA, :RS, :IM, :RS, :ME]
+    DEFAULT_CURRENCY = 'USD'
 
     def round_and_dedup(values)
       deduplicate(round(values))
@@ -30,6 +32,17 @@ module Donations
         safe << misfit
       end
       safe.sort
+    end
+
+    def currency_from_country_code(country_code)
+      return 'EUR' if EURO_COUNTRY_CODES.include?(country_code.to_s.to_sym)
+      {
+        US: 'USD',
+        GB: 'GBP',
+        NZ: 'NZD',
+        AU: 'AUD',
+        CA: 'CAD'
+      }[country_code.to_s.to_sym] || DEFAULT_CURRENCY
     end
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 describe PagesController do
   let(:user) { instance_double('User', id: '1') }
   let(:page) { instance_double('Page', active?: true, featured?: true, id: '1', liquid_layout: '3', secondary_liquid_layout: '4') }
-  let(:renderer) { instance_double('LiquidRenderer', render: 'my rendered html') }
+  let(:renderer) { instance_double('LiquidRenderer', render: 'my rendered html', data: {'some' => 'data'}) }
 
   before do
     allow(request.env['warden']).to receive(:authenticate!) { user }
     allow(controller).to receive(:current_user) { user }
+    allow_any_instance_of(ActionController::TestRequest).to receive(:location).and_return({})
   end
 
   describe 'GET #index' do
@@ -90,7 +91,6 @@ describe PagesController do
   end
 
   describe 'GET #show' do
-
     before do
       allow(Page).to receive(:find){ page }
       allow(page).to receive(:update)
@@ -105,7 +105,7 @@ describe PagesController do
     it 'instantiates a LiquidRenderer and calls render' do
       get :show, id: '1'
       expect(LiquidRenderer).to have_received(:new).with(page,
-        request_country: "RD",
+        location: {},
         member: nil,
         layout: page.liquid_layout,
         url_params: {"id"=>"1", "controller"=>"pages", "action"=>"show"}
@@ -163,7 +163,7 @@ describe PagesController do
 
     it 'instantiates a LiquidRenderer and calls render' do
       expect(LiquidRenderer).to have_received(:new).with(page,
-        request_country: "RD",
+        location: {},
         member: nil,
         layout: page.secondary_liquid_layout,
         url_params: {"id"=>"1", "controller"=>"pages", "action"=>"follow_up"}

--- a/spec/factories/donation_bands.rb
+++ b/spec/factories/donation_bands.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :donation_band do
-    name 'Wyld Stallyns'
-    amounts [100, 500, 1000, 2000, 5000]
+    name { Faker::Internet.slug }
+    amounts { [rand(20), rand(300), rand(300), rand(300), rand(300)].map{|fl| fl.to_i * 100}.sort }
   end
 
 end

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -24,6 +24,15 @@ FactoryGirl.define do
       end
     end
 
+   factory :form_with_all_except_check do
+     after :create do |form, evaluator|
+       create :form_element, form: form, name: 'email', label: 'Email', data_type: 'email', required: true
+       create :form_element, form: form, name: 'name', label: 'Full name', data_type: 'text', required: true
+       create :form_element, form: form, name: 'country', label: 'Country', data_type: 'country', required: true
+       create :form_element, form: form, name: 'phone', label: 'Phone number', data_type: 'phone', required: true
+     end
+   end
+
     factory :form_with_fields do
       after(:create) do |form, evaluator|
         create_list(:form_element, 2, form: form)

--- a/spec/factories/forms.rb
+++ b/spec/factories/forms.rb
@@ -17,6 +17,13 @@ FactoryGirl.define do
       end
     end
 
+    factory :form_with_phone_and_country do
+      after(:create) do |form, evaluator|
+        create :form_element, form: form, name: 'country', label: 'Country', data_type: 'country', required: true
+        create :form_element, form: form, name: 'phone', label: 'Phone number', data_type: 'phone', required: true
+      end
+    end
+
     factory :form_with_fields do
       after(:create) do |form, evaluator|
         create_list(:form_element, 2, form: form)

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :page do
     title { Faker::Company.bs }
-    slug { Faker::Internet.slug }
+    slug { Faker::Internet.slug(Faker::Lorem.sentence(10), '-') }
     active true
     featured false
     liquid_layout

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -42,4 +42,32 @@ describe PagesHelper do
       expect(prefill_link(variant).attributes).to eq Share::Facebook.new.attributes
     end
   end
+
+  describe "serialize" do
+
+    it 'can serialize with a symbol keys and symbol query' do
+      expect(serialize({foo: 'bar'}, :foo)).to eq '"bar"'
+    end
+
+    it 'can serialize with a symbol keys and string query' do
+      expect(serialize({foo: 'bar'}, 'foo')).to eq '"bar"'
+    end
+
+    it 'can serialize with a string keys and symbol query' do
+      expect(serialize({'foo' => 'bar'}, :foo)).to eq '"bar"'
+    end
+
+    it 'can serialize with a string keys and string query' do
+      expect(serialize({'foo' => 'bar'}, 'foo')).to eq '"bar"'
+    end
+
+    it 'renders empty object if key is missing' do
+      expect(serialize({foo: 'bar'}, :baz)).to eq '{}'
+    end
+
+    it 'serializes a subhash into appropriate json' do
+      expect(serialize({foo: {bar: 'baz', quu: 'ray'}}, :foo)).to eq '{"bar":"baz","quu":"ray"}'
+    end
+  end
+
 end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -65,6 +65,14 @@ describe PagesHelper do
       expect(serialize({foo: 'bar'}, :baz)).to eq '{}'
     end
 
+    it 'renders empty object if key is nil' do
+      expect(serialize({foo: nil}, :foo)).to eq '{}'
+    end
+
+    it 'renders empty object if key is blank' do
+      expect(serialize({foo: ' '}, :foo)).to eq '{}'
+    end
+
     it 'serializes a subhash into appropriate json' do
       expect(serialize({foo: {bar: 'baz', quu: 'ray'}}, :foo)).to eq '{"bar":"baz","quu":"ray"}'
     end

--- a/spec/javascripts/fixtures/magic_lamp.rb
+++ b/spec/javascripts/fixtures/magic_lamp.rb
@@ -11,7 +11,7 @@ end
 MagicLamp.define(controller: PagesController) do
   fixture(name: 'pages/petition') do
     @page = FactoryGirl.create :page, liquid_layout: LiquidLayout.find_by(title: 'Standard Petition')
-    form = FactoryGirl.create :form_with_email_and_name
+    form = FactoryGirl.create :form_with_all_except_check
     @page.plugins.each { |pl| if pl.name == 'Petition' then pl.update_attributes(form: form) end }
     params[:id] = @page.id
     show

--- a/spec/javascripts/member-ui/form_error_spec.js
+++ b/spec/javascripts/member-ui/form_error_spec.js
@@ -16,7 +16,7 @@ describe("Inline form errors", function() {
     suite.server.respondWith("GET", '/api/braintree/token',
                             [200, { "Content-Type": "application/json" },
                             '{ "token": "'+helpers.btClientToken+'" }' ]);
-    suite.petitionBar = new window.PetitionBar(); // binds the form events
+    suite.petitionBar = new window.sumofus.PetitionBar(); // binds the form events
   });
 
   afterEach(function(){

--- a/spec/javascripts/member-ui/form_error_spec.js
+++ b/spec/javascripts/member-ui/form_error_spec.js
@@ -13,9 +13,6 @@ describe("Inline form errors", function() {
   beforeEach(function(){
     MagicLamp.wish("pages/petition");
     suite.server = sinon.fakeServer.create();
-    suite.server.respondWith("GET", '/api/braintree/token',
-                            [200, { "Content-Type": "application/json" },
-                            '{ "token": "'+helpers.btClientToken+'" }' ]);
     suite.petitionBar = new window.sumofus.PetitionBar(); // binds the form events
   });
 

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -83,18 +83,18 @@ describe("Fundraiser", function() {
         expect($('input[name="email"]').val()).to.eql('neal@test.com');
       });
 
+      it('does not display the clearer when form has no fields', function(){
+        $('.fundraiser-bar .petition-bar__field-container').remove();
+        expect($('.fundraiser-bar .petition-bar__field-container').length).to.equal(0);
+        suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], member: {email: 'neal@test.com'} });
+        expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+        expect($('.fundraiser-bar__welcome-text')).to.have.class('hidden-irrelevant');
+      });
+
       describe('member is passed', function(){
 
         beforeEach(function(){
           suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], member: {email: 'neal@test.com'} });
-        });
-
-        it('does not display the clearer when form has no fields', function(){
-          $('.fundraiser-bar .petition-bar__field-container').remove();
-          expect($('.fundraiser-bar .petition-bar__field-container').length).to.equal(0);
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [] });
-          expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
-          expect($('.fundraiser-bar__welcome-text')).to.have.class('hidden-irrelevant');
         });
 
         it('displays the clearer when form has fields', function(){
@@ -109,9 +109,9 @@ describe("Fundraiser", function() {
 
         it('hides the form fields', function(){
             var classed = $('.petition-bar__field-container').map(function(ii, el){
-              return $(el).hasClass('form__group--prefilled')
+              return $(el).hasClass('form__group--prefilled');
             }).toArray();
-            expect(classed).to.eql([false]);
+            expect(classed).to.eql([true]);
         });
 
         it('displays the second step when user requests', function(){
@@ -125,8 +125,7 @@ describe("Fundraiser", function() {
         it('clears prefilled fields when second step displayed', function(){
           var input = $('.fundraiser-bar__step-panel[data-step="2"] input').last();
           input.parents('.form__group').addClass('form__group--prefilled');
-          input.attr('value', 'cheerio!');
-          expect(input.val()).to.equal('cheerio!');
+          expect(input.val()).to.equal('neal@test.com');
           $('.fundraiser-bar__amount-button').first().click();
           $('.fundraiser-bar__clear-form').click();
           expect(input.val()).to.equal('');
@@ -136,7 +135,7 @@ describe("Fundraiser", function() {
       describe('amount is greater than zero', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], amount: 11 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], amount: 11, member: {} });
         });
 
         it('skips to the third step', function(){

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -32,7 +32,7 @@ describe("Fundraiser", function() {
       expect($('.fundraiser-bar__currency-selector').val()).to.equal('GBP');
     });
 
-    it('displays the values from the correct passed donation band', function(){
+    it('displays the values from the correct passed currency band', function(){
       var donationBands = {
         EUR: [1, 2, 3, 4, 5],
         USD: [6, 7, 8, 9, 10],
@@ -43,12 +43,12 @@ describe("Fundraiser", function() {
       expect(displayedAmounts).to.include.members(donationBands['EUR']);
     });
 
-    describe('outstanding fields is zero', function(){
+    describe('outstanding fields is empty', function(){
 
       describe('amount is not passed', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 0 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [] });
         });
 
         it('starts on the first step', function(){
@@ -84,7 +84,7 @@ describe("Fundraiser", function() {
       describe('amount is greater than zero ', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 0, amount: 11 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], amount: 11 });
         });
 
         it('skips to the third step', function(){
@@ -155,12 +155,12 @@ describe("Fundraiser", function() {
       });
     });
 
-    describe('outstanding fields is greater than zero', function(){
+    describe('outstanding fields has elements', function(){
 
       describe('amount is not passed', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 2 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: ['email', 'name'] });
         });
 
         it('starts on the first step', function(){
@@ -231,8 +231,8 @@ describe("Fundraiser", function() {
           suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: null });
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
-        it('is an array', function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: ['email'] });
+        it('is a number', function(){
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 0 });
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
         it('is a string', function(){
@@ -243,11 +243,6 @@ describe("Fundraiser", function() {
           suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: '5' });
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
-      });
-
-      it ('hides second step when outstandingFields is zero string', function(){
-        suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: "0" });
-        expect($('.fundraiser-bar__step-label[data-step="2"]')).to.have.css('visibility', 'hidden');
       });
     });
 

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -172,23 +172,67 @@ describe("Fundraiser", function() {
 
       describe('amount is not passed', function(){
 
-        beforeEach(function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({});
+        describe('member is not passed', function(){
+
+          beforeEach(function(){
+            suite.fundraiserBar = new window.sumofus.FundraiserBar({});
+          });
+
+          it('starts on the first step', function(){
+            expect(helpers.currentStepOf(3)).to.eq(1);
+          });
+
+          it('displays the second step', function(){
+            expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
+          });
+
+          it('does not display the clearer', function(){
+            expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+            expect($('.fundraiser-bar__welcome-text')).to.have.class('hidden-irrelevant');
+          });
+
+          it('does not prefill', function(){
+            expect($('input[name="email"]').val()).to.eql('');
+          });
+
+          it('does not hide the form fields', function(){
+            var classed = $('.petition-bar__field-container').map(function(ii, el){
+              return $(el).hasClass('form__group--prefilled');
+            }).toArray();
+            expect(classed).to.eql([false]);
+          });
         });
 
-        it('starts on the first step', function(){
-          expect(helpers.currentStepOf(3)).to.eq(1);
-        });
+        describe('member is passed', function(){
 
-        it('displays the second step', function(){
-          expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
-        });
+          beforeEach(function(){
+            suite.fundraiserBar = new window.sumofus.FundraiserBar({member: {email: 'neal@test.com'}});
+          });
 
-        it('does not display the clearer');
-        it('prefills with values of member');
-        it('ignores extraneous member values');
-        it('does not prefill if member is not passed');
-        it('does not hide hides the form fields');
+          it('starts on the first step', function(){
+            expect(helpers.currentStepOf(3)).to.eq(1);
+          });
+
+          it('displays the second step', function(){
+            expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
+          });
+
+          it('does not display the clearer', function(){
+            expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+            expect($('.fundraiser-bar__welcome-text')).to.have.class('hidden-irrelevant');
+          });
+
+          it('prefills with values of member', function(){
+            expect($('input[name="email"]').val()).to.eql('neal@test.com');
+          });
+
+          it('does not hide the form fields', function(){
+            var classed = $('.petition-bar__field-container').map(function(ii, el){
+              return $(el).hasClass('form__group--prefilled');
+            }).toArray();
+            expect(classed).to.eql([false]);
+          });
+        });
       });
 
       describe('amount is greater than zero ', function(){
@@ -216,7 +260,7 @@ describe("Fundraiser", function() {
       describe('amount is not passed', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: ['email', 'name'] });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: ['email'] });
         });
 
         it('starts on the first step', function(){
@@ -226,19 +270,12 @@ describe("Fundraiser", function() {
         it('displays the second step', function(){
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
-
-        it('does not display the clearer');
-        it('prefills with values of member');
-        it('does not prefill if value is in outstandingFields');
-        it('ignores extraneous member values');
-        it('does not prefill if member is not passed');
-        it('does not hide the form fields');
       });
 
-      describe('amount is greater than zero ', function(){
+      describe('amount is greater than zero', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 1, amount: 17 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: ['email'], amount: 17 });
         });
 
         it('skips to the second step', function(){
@@ -252,6 +289,24 @@ describe("Fundraiser", function() {
         it('displays the second step', function(){
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
+      });
+
+      it('prefills with values of member', function(){
+        suite.fundraiserBar = new window.sumofus.FundraiserBar({ member: {email: 'neal@test.com'}, outstandingFields: ['name'], amount: 17 });
+        expect($('input[name="email"]').val()).to.eql('neal@test.com');
+      });
+
+      it('does not prefill if value is in outstandingFields', function(){
+        suite.fundraiserBar = new window.sumofus.FundraiserBar({ member: {email: 'neal@test.com'}, outstandingFields: ['email'], amount: 17 });
+        expect($('input[name="email"]').val()).to.eql('');
+      });
+
+      it('does not hide the form fields', function(){
+        suite.fundraiserBar = new window.sumofus.FundraiserBar({ member: {email: 'neal@test.com'}, outstandingFields: ['name'], amount: 17 });
+        var classed = $('.petition-bar__field-container').map(function(ii, el){
+          return $(el).hasClass('form__group--prefilled');
+        }).toArray();
+        expect(classed).to.eql([false]);
       });
     });
 

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -45,20 +45,73 @@ describe("Fundraiser", function() {
 
     describe('outstanding fields is empty', function(){
 
-      describe('amount is not passed', function(){
+      describe('member is not passed', function(){
 
-        beforeEach(function(){
+        it('hides the second step if there are no fields', function(){
+          $('.fundraiser-bar .petition-bar__field-container').remove();
+          expect($('.fundraiser-bar .petition-bar__field-container').length).to.equal(0);
           suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [] });
-        });
-
-        it('starts on the first step', function(){
-          expect(helpers.currentStepOf(3)).to.eq(1);
-        });
-
-        it('hides the second step', function(){
           expect($('.fundraiser-bar__step-label[data-step="2"]')).to.have.css('visibility', 'hidden');
           $('.fundraiser-bar__amount-button').first().click();
           expect(helpers.currentStepOf(3)).to.eq(3);
+        });
+
+        describe('amount is not passed', function(){
+
+          beforeEach(function(){
+            suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [] });
+          });
+
+          it('does not prefill values', function(){
+            var vals = $('.petition-bar__field-container').map(function(ii, el){ return $(el).val() }).toArray();
+            expect(vals).to.eql([""]);
+          });
+
+          it('does not hide the second step if there are fields', function(){
+            expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
+          });
+
+          it('starts on the first step', function(){
+            expect(helpers.currentStepOf(3)).to.eq(1);
+          });
+        });
+
+      });
+
+      it('ignores extraneous member values', function(){
+        suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], member: {email: 'neal@test.com', oogle: 'boogle'} });
+        expect($('input[name="email"]').val()).to.eql('neal@test.com');
+      });
+
+      describe('member is passed', function(){
+
+        beforeEach(function(){
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], member: {email: 'neal@test.com'} });
+        });
+
+        it('does not display the clearer when form has no fields', function(){
+          $('.fundraiser-bar .petition-bar__field-container').remove();
+          expect($('.fundraiser-bar .petition-bar__field-container').length).to.equal(0);
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [] });
+          expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+          expect($('.fundraiser-bar__welcome-text')).to.have.class('hidden-irrelevant');
+        });
+
+        it('displays the clearer when form has fields', function(){
+          expect($('.fundraiser-bar .petition-bar__field-container').length).to.be.at.least(1);
+          expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+          expect($('.fundraiser-bar__welcome-text')).not.to.have.class('hidden-irrelevant');
+        });
+
+        it('prefills with values of member', function(){
+          expect($('input[name="email"]').val()).to.eql('neal@test.com');
+        });
+
+        it('hides the form fields', function(){
+            var classed = $('.petition-bar__field-container').map(function(ii, el){
+              return $(el).hasClass('form__group--prefilled')
+            }).toArray();
+            expect(classed).to.eql([false]);
         });
 
         it('displays the second step when user requests', function(){
@@ -78,16 +131,9 @@ describe("Fundraiser", function() {
           $('.fundraiser-bar__clear-form').click();
           expect(input.val()).to.equal('');
         });
-
-        it('displays the clearer when form has fields');
-        it('does not display the clearer when form has no fields');
-        it('prefills with values of member');
-        it('ignores extraneous member values');
-        it('does not prefill if member is not passed');
-        it('hides the form fields');
       });
 
-      describe('amount is greater than zero ', function(){
+      describe('amount is greater than zero', function(){
 
         beforeEach(function(){
           suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], amount: 11 });

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -94,13 +94,14 @@ describe("Fundraiser", function() {
       describe('member is passed', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], member: {email: 'neal@test.com'} });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: [], member: {email: 'neal@test.com', welcome_name: 'Neal'} });
         });
 
         it('displays the clearer when form has fields', function(){
           expect($('.fundraiser-bar .petition-bar__field-container').length).to.be.at.least(1);
           expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
           expect($('.fundraiser-bar__welcome-text')).not.to.have.class('hidden-irrelevant');
+          expect($('.fundraiser-bar__welcome-name')).to.have.text('Neal');
         });
 
         it('prefills with values of member', function(){

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -28,7 +28,7 @@ describe("Fundraiser", function() {
   describe('instantiation', function(){
 
     it('sets the default currency if currency passed', function(){
-      suite.fundraiserBar = new window.FundraiserBar({ currency: 'GBP'});
+      suite.fundraiserBar = new window.sumofus.FundraiserBar({ currency: 'GBP'});
       expect($('.fundraiser-bar__currency-selector').val()).to.equal('GBP');
     });
 
@@ -38,7 +38,7 @@ describe("Fundraiser", function() {
         USD: [6, 7, 8, 9, 10],
         GBP: [7, 14, 21, 28, 35]
       };
-      suite.fundraiserBar = new window.FundraiserBar({ currency: 'EUR', donationBands: donationBands});
+      suite.fundraiserBar = new window.sumofus.FundraiserBar({ currency: 'EUR', donationBands: donationBands});
       var displayedAmounts = $('.fundraiser-bar__amount-button').map(function(ii, a){ return $(a).data('amount'); }).toArray();
       expect(displayedAmounts).to.include.members(donationBands['EUR']);
     });
@@ -48,7 +48,7 @@ describe("Fundraiser", function() {
       describe('amount is not passed', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: 0 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 0 });
         });
 
         it('starts on the first step', function(){
@@ -84,7 +84,7 @@ describe("Fundraiser", function() {
       describe('amount is greater than zero ', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: 0, amount: 11 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 0, amount: 11 });
         });
 
         it('skips to the third step', function(){
@@ -123,7 +123,7 @@ describe("Fundraiser", function() {
       describe('amount is not passed', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.FundraiserBar({});
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({});
         });
 
         it('starts on the first step', function(){
@@ -138,7 +138,7 @@ describe("Fundraiser", function() {
       describe('amount is greater than zero ', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.FundraiserBar({amount: 17});
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({amount: 17});
         });
 
         it('skips to the second step', function(){
@@ -160,7 +160,7 @@ describe("Fundraiser", function() {
       describe('amount is not passed', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: 2 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 2 });
         });
 
         it('starts on the first step', function(){
@@ -175,7 +175,7 @@ describe("Fundraiser", function() {
       describe('amount is greater than zero ', function(){
 
         beforeEach(function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: 1, amount: 17 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 1, amount: 17 });
         });
 
         it('skips to the second step', function(){
@@ -196,57 +196,57 @@ describe("Fundraiser", function() {
 
       describe('it starts on first step when amount', function(){
         it('is negative', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ amount: -1 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: -1 });
           expect(helpers.currentStepOf(3)).to.eq(1)
         });
         it('is zero', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ amount: 0 });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: 0 });
           expect(helpers.currentStepOf(3)).to.eq(1)
         });
         it('is a string', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ amount: "hi" });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: "hi" });
           expect(helpers.currentStepOf(3)).to.eq(1)
         });
         it('is null', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ amount: null });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: null });
           expect(helpers.currentStepOf(3)).to.eq(1)
         });
         it('is an array', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ amount: [3, 4, 5] });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: [3, 4, 5] });
           expect(helpers.currentStepOf(3)).to.eq(1)
         });
       });
 
       it ('starts on second step when amount is numeric string', function(){
-        suite.fundraiserBar = new window.FundraiserBar({ amount: "3" });
+        suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: "3" });
         expect(helpers.currentStepOf(3)).to.eq(2)
       });
 
       describe('shows second step when outstandingFields', function(){
         it('is an object', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: {first: 'second'} });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: {first: 'second'} });
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
         it('is null', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: null });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: null });
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
         it('is an array', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: ['email'] });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: ['email'] });
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
         it('is a string', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: 'yooo' });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: 'yooo' });
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
         it('is a numeric string', function(){
-          suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: '5' });
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: '5' });
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
       });
 
       it ('hides second step when outstandingFields is zero string', function(){
-        suite.fundraiserBar = new window.FundraiserBar({ outstandingFields: "0" });
+        suite.fundraiserBar = new window.sumofus.FundraiserBar({ outstandingFields: "0" });
         expect($('.fundraiser-bar__step-label[data-step="2"]')).to.have.css('visibility', 'hidden');
       });
     });
@@ -258,7 +258,7 @@ describe("Fundraiser", function() {
     beforeEach(function() {
 
       suite.follow_up_url = "/pages/636/follow-up";
-      suite.fundraiserBar = new window.FundraiserBar({ pageId: '1', followUpUrl: suite.follow_up_url });
+      suite.fundraiserBar = new window.sumofus.FundraiserBar({ pageId: '1', followUpUrl: suite.follow_up_url });
       sinon.stub(suite.fundraiserBar, 'redirectTo');
       suite.server.respond(); // respond to request for token
     });

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -79,6 +79,12 @@ describe("Fundraiser", function() {
           expect(input.val()).to.equal('');
         });
 
+        it('displays the clearer when form has fields');
+        it('does not display the clearer when form has no fields');
+        it('prefills with values of member');
+        it('ignores extraneous member values');
+        it('does not prefill if member is not passed');
+        it('hides the form fields');
       });
 
       describe('amount is greater than zero ', function(){
@@ -114,7 +120,6 @@ describe("Fundraiser", function() {
           $('.fundraiser-bar__clear-form').click();
           expect(input.val()).to.equal('');
         });
-
       });
     });
 
@@ -133,6 +138,12 @@ describe("Fundraiser", function() {
         it('displays the second step', function(){
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
+
+        it('does not display the clearer');
+        it('prefills with values of member');
+        it('ignores extraneous member values');
+        it('does not prefill if member is not passed');
+        it('does not hide hides the form fields');
       });
 
       describe('amount is greater than zero ', function(){
@@ -170,6 +181,13 @@ describe("Fundraiser", function() {
         it('displays the second step', function(){
           expect($('.fundraiser-bar__step-label[data-step="2"]')).not.to.have.css('visibility', 'hidden');
         });
+
+        it('does not display the clearer');
+        it('prefills with values of member');
+        it('does not prefill if value is in outstandingFields');
+        it('ignores extraneous member values');
+        it('does not prefill if member is not passed');
+        it('does not hide the form fields');
       });
 
       describe('amount is greater than zero ', function(){

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -159,7 +159,7 @@ describe("Fundraiser", function() {
         it('clears prefilled fields when second step displayed', function(){
           var input = $('.fundraiser-bar__step-panel[data-step="2"] input').last();
           input.parents('.form__group').addClass('form__group--prefilled');
-          input.attr('value', 'cheerio!');
+          input.val('cheerio!');
           expect(input.val()).to.equal('cheerio!');
           $('.fundraiser-bar__amount-button').first().click();
           $('.fundraiser-bar__clear-form').click();

--- a/spec/javascripts/member-ui/petition_spec.js
+++ b/spec/javascripts/member-ui/petition_spec.js
@@ -17,6 +17,7 @@ describe("Petition", function() {
       email: 'starman@bowie.com',
       name: 'David Bowie',
       country: 'GB',
+      welcome_name: 'David Bowie',
       phone: "213-7212-9087",
       voter: true,
       hair_color: 'dyed'
@@ -71,6 +72,7 @@ describe("Petition", function() {
           expect($('.petition-bar .petition-bar__field-container').length).to.be.at.least(1);
           suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: [], member: suite.fullVals });
           expect($('.petition-bar__welcome-text')).not.to.have.class('hidden-irrelevant');
+          expect($('.petition-bar__welcome-name')).to.have.text('David Bowie');
         });
 
         it('does not display the clearer when form has no fields', function(){

--- a/spec/javascripts/member-ui/petition_spec.js
+++ b/spec/javascripts/member-ui/petition_spec.js
@@ -1,0 +1,194 @@
+//= require sumofus
+
+describe("Petition", function() {
+  var suite = this;
+  suite.timeout(20000);
+
+  before(function() {
+    window.onbeforeunload = function(){
+      // the javascript has redirects, this prevents them firing if you view the tests in browser
+      return 'Are you sure you want to leave?';
+    };
+  });
+
+  beforeEach(function(){
+    MagicLamp.wish("pages/petition");
+    suite.fullVals = {
+      email: 'starman@bowie.com',
+      name: 'David Bowie',
+      country: 'GB',
+      phone: "213-7212-9087",
+      voter: true,
+      hair_color: 'dyed'
+    };
+    suite.inputs = $('.petition-bar__field-container').find('input.form__content, select.form__content');
+  });
+
+  describe('instantiation', function(){
+
+    it ('selectizes the dropdown', function(){
+      expect($('select')).not.to.have.class('selectized');
+      suite.petitionBar = new window.sumofus.PetitionBar();
+      expect($('select')).to.have.class('selectized');
+    });
+
+    describe('outstanding fields is empty', function(){
+
+      describe('member is not passed', function(){
+
+        beforeEach(function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: []});
+        });
+
+        it('does not prefill values', function(){
+          var vals = suite.inputs.map(function(ii, el){ return $(el).val() }).toArray();
+          expect(vals).to.eql(['', '', '', '']);
+        });
+
+        it('does not display the clearer', function(){
+          expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+        });
+      });
+
+      describe('member is passed', function(){
+
+        it('ignores extraneous member values', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: [], member: {email: 'neal@test.com', oogle: 'boogle'} });
+          expect($('input[name="email"]').val()).to.eql('neal@test.com');
+        });
+
+        it('displays the clearer when form has fields', function(){
+          expect($('.petition-bar .petition-bar__field-container').length).to.be.at.least(1);
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: [], member: suite.fullVals });
+          expect($('.petition-bar__welcome-text')).not.to.have.class('hidden-irrelevant');
+        });
+
+        it('does not display the clearer when form has no fields', function(){
+          $('.petition-bar__field-container').remove();
+          expect($('.petition-bar .petition-bar__field-container').length).to.eq(0);
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: [], member: suite.fullVals });
+          expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+        });
+
+        it('prefills with values of member', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: [], member: suite.fullVals });
+          var vals = suite.inputs.map(function(ii, el){ return $(el).val(); }).toArray();
+          expect(vals).to.eql( ['starman@bowie.com', 'David Bowie', 'GB', "213-7212-9087"]);
+        });
+
+        it('hides the form fields', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: [], member: {email: 'neal@test.com'} });
+          var classed = $('.petition-bar__field-container').map(function(ii, el){
+            return $(el).hasClass('form__group--prefilled');
+          }).toArray();
+          expect(classed).to.eql([true, true, true, true]);
+        });
+
+        it('reveals the form fields properly', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: [], member: {email: 'neal@test.com'} });
+          $('.petition-bar__clear-form').click();
+          var classed = $('.petition-bar__field-container').map(function(ii, el){
+            return $(el).hasClass('form__group--prefilled');
+          }).toArray();
+          expect(classed).to.eql([false, false, false, false]);
+        });
+
+        it('clears prefilled fields properly', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: [], member: suite.fullVals });
+          $('.petition-bar__clear-form').click();
+          var vals = suite.inputs.map(function(ii, el){ return $(el).val(); }).toArray();
+          expect(vals).to.eql( ['', '', '', '']);
+        });
+      });
+    });
+
+    describe('outstanding fields has elements', function(){
+
+      describe('member is passed', function(){
+
+        it('does not prefill if value is in outstandingFields', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ outstandingFields: ['email'], member: suite.fullVals});
+          var vals = suite.inputs.map(function(ii, el){ return $(el).val(); }).toArray();
+          expect(vals).to.eql( ['', 'David Bowie', 'GB', "213-7212-9087"]);
+        });
+
+        it('does not hide the form fields', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ member: {email: 'neal@test.com'}, outstandingFields: ['name'], amount: 17 });
+          var classed = $('.petition-bar__field-container').map(function(ii, el){
+            return $(el).hasClass('form__group--prefilled');
+          }).toArray();
+          expect(classed).to.eql([false, false, false, false]);
+        });
+      });
+
+      describe('member is not passed', function(){
+
+        it('does not prefill', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ member: {email: 'neal@test.com'}, outstandingFields: ['email'], amount: 17 });
+          expect($('input[name="email"]').val()).to.eql('');
+        });
+
+        it('does not hide the form fields', function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({ member: {email: 'neal@test.com'}, outstandingFields: ['name'], amount: 17 });
+          var classed = $('.petition-bar__field-container').map(function(ii, el){
+            return $(el).hasClass('form__group--prefilled');
+          }).toArray();
+          expect(classed).to.eql([false, false, false, false]);
+        });
+      });
+    });
+
+    describe('outstanding fields is not passed', function(){
+
+      describe('member is not passed', function(){
+
+        beforeEach(function(){
+          suite.petitionBar = new window.sumofus.PetitionBar();
+        });
+
+        it('does not display the clearer', function(){
+          expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+        });
+
+        it('does not prefill', function(){
+          expect($('input[name="email"]').val()).to.eql('');
+        });
+
+        it('does not hide the form fields', function(){
+          var classed = $('.petition-bar__field-container').map(function(ii, el){
+            return $(el).hasClass('form__group--prefilled');
+          }).toArray();
+          expect(classed).to.eql([false, false, false, false]);
+        });
+      });
+
+      describe('member is passed', function(){
+
+        beforeEach(function(){
+          suite.petitionBar = new window.sumofus.PetitionBar({member: suite.fullVals});
+        });
+
+        it('does not display the clearer', function(){
+          expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+          expect($('.petition-bar__welcome-text')).to.have.class('hidden-irrelevant');
+        });
+
+        it('prefills with values of member', function(){
+          var vals = suite.inputs.map(function(ii, el){ return $(el).val(); }).toArray();
+          expect(vals).to.eql( ['starman@bowie.com', 'David Bowie', 'GB', "213-7212-9087"]);
+        });
+
+        it('does not hide the form fields', function(){
+          var classed = $('.petition-bar__field-container').map(function(ii, el){
+            return $(el).hasClass('form__group--prefilled');
+          }).toArray();
+          expect(classed).to.eql([false, false, false, false]);
+        });
+      });
+    });
+
+
+  });
+});
+
+

--- a/spec/javascripts/member-ui/petition_spec.js
+++ b/spec/javascripts/member-ui/petition_spec.js
@@ -26,10 +26,20 @@ describe("Petition", function() {
 
   describe('instantiation', function(){
 
-    it ('selectizes the dropdown', function(){
-      expect($('select')).not.to.have.class('selectized');
-      suite.petitionBar = new window.sumofus.PetitionBar();
-      expect($('select')).to.have.class('selectized');
+    describe('selective', function(){
+      it ('selectizes the dropdown when not on mobile', function(){
+        expect($('select')).not.to.have.class('selectized');
+        $('.mobile-indicator').css('display', 'none');
+        suite.petitionBar = new window.sumofus.PetitionBar();
+        expect($('select')).to.have.class('selectized');
+      });
+
+      it ('does not selectize the dropdown when on mobile', function(){
+        expect($('select')).not.to.have.class('selectized');
+        $('.mobile-indicator').css('display', 'block');
+        suite.petitionBar = new window.sumofus.PetitionBar();
+        expect($('select')).not.to.have.class('selectized');
+      });
     });
 
     describe('outstanding fields is empty', function(){

--- a/spec/javascripts/support/spec_helper.js
+++ b/spec/javascripts/support/spec_helper.js
@@ -26,6 +26,13 @@
 // spec path and it'll be included in the default suite automatically. If you want to customize suites, check out the
 // configuration in teaspoon_env.rb
 
+
+////// Requiring tests
+//= require member-ui/petition_spec
+//= require member-ui/form_error_spec
+//= require member-ui/fundraiser_spec
+
+
 jQuery.fx.off = true;
 window.expect = chai.expect;
 

--- a/spec/lib/donations/utils_spec.rb
+++ b/spec/lib/donations/utils_spec.rb
@@ -75,5 +75,44 @@ describe Donations::Utils do
       ).to eq [16.7, 17.7, 20.0, 25.1, 30.1]
     end
   end
+
+  describe '.currency_from_country_code' do
+    it 'maps european countries to euro' do
+      expect(subject.currency_from_country_code('CZ')).to eq 'EUR'
+      expect(subject.currency_from_country_code('DE')).to eq 'EUR'
+    end
+
+    it 'maps nil to USD' do
+      expect(subject.currency_from_country_code(nil)).to eq 'USD'
+    end
+
+    it 'maps unknown country to USD' do
+      expect(subject.currency_from_country_code('NI')).to eq 'USD'
+    end
+
+    it 'maps US to USD' do
+      expect(subject.currency_from_country_code('US')).to eq 'USD'
+    end
+
+    it 'maps GB to GBP' do
+      expect(subject.currency_from_country_code('GB')).to eq 'GBP'
+    end
+
+    it 'maps NZ to NZD' do
+      expect(subject.currency_from_country_code('NZ')).to eq 'NZD'
+    end
+
+    it 'maps AU to AUD' do
+      expect(subject.currency_from_country_code('AU')).to eq 'AUD'
+    end
+
+    it 'maps CA to CAD' do
+      expect(subject.currency_from_country_code('CA')).to eq 'CAD'
+    end
+
+    it 'works with symbols' do
+      expect(subject.currency_from_country_code(:CA)).to eq 'CAD'
+    end
+  end
 end
 

--- a/spec/liquid/liquid_helper_spec.rb
+++ b/spec/liquid/liquid_helper_spec.rb
@@ -2,28 +2,6 @@ require 'rails_helper'
 
 describe LiquidHelper do
 
-  describe 'member' do
-
-    it 'returns nil if no member given' do
-      expect(LiquidHelper.globals[:member]).to eq nil
-    end
-
-    it 'includes all of the attributes of a given action user' do
-      au = create :member
-      expect(LiquidHelper.globals(member: au)[:member].keys).to include(*au.attributes.keys.map(&:to_sym))
-    end
-
-    it 'gives email as welcome name if no name' do
-      au = create :member, first_name: nil, last_name: "", email: 'sup@dude.com'
-      expect(LiquidHelper.globals(member: au)[:member][:welcome_name]).to eq au.email
-    end
-
-    it 'gives first name and last name if available' do
-      au = create :member, first_name: 'big', last_name: "dog", email: 'sup@dude.com'
-      expect(LiquidHelper.globals(member: au)[:member][:welcome_name]).to eq 'big dog'
-    end
-  end
-
   describe 'country_option_tags' do
 
     it 'gives a long html by default' do
@@ -41,16 +19,11 @@ describe LiquidHelper do
     end
 
     it 'selects a country if passed request_country as a code' do
-      expect(LiquidHelper.globals(request_country: 'AF')[:country_option_tags]).to include('selected')
+      expect(LiquidHelper.country_option_tags('AF')).to include('selected')
     end
 
     it 'does not select a country if passed request_country as a country name' do
-      expect(LiquidHelper.globals(request_country: 'Afghanistan')[:country_option_tags]).not_to include('selected')
-    end
-
-    it 'selects a country if passed member has a country code' do
-      au = create :member, country: 'AF'
-      expect(LiquidHelper.globals(member: au)[:country_option_tags]).to include('selected')
+      expect(LiquidHelper.country_option_tags('Afganistan')).not_to include('selected')
     end
   end
 
@@ -88,19 +61,4 @@ describe LiquidHelper do
       expect(LiquidHelper.globals(page: page)[:petition_target]).to eq 'koch brothers'
     end
   end
-
-  describe '.guess_currency' do
-    it 'returns appropraite currency for country' do
-      expect(LiquidHelper.guess_currency('GB') ).to eq('GBP')
-    end
-
-    it 'returns USD as default' do
-      expect(LiquidHelper.guess_currency('MX') ).to eq('USD')
-    end
-
-    it 'returns EUR for european nation' do
-      expect(LiquidHelper.guess_currency('AD') ).to eq('EUR')
-    end
-  end
-
 end

--- a/spec/liquid/liquid_renderer_spec.rb
+++ b/spec/liquid/liquid_renderer_spec.rb
@@ -10,7 +10,7 @@ describe LiquidRenderer do
   describe 'new' do
     it 'receives the correct arguments' do
       expect{
-        LiquidRenderer.new(page, layout: liquid_layout, request_country: 'RD', member: {}, url_params: {hi: 'a'})
+        LiquidRenderer.new(page, layout: liquid_layout, location: {}, member: {}, url_params: {hi: 'a'})
       }.not_to raise_error
     end
 
@@ -120,12 +120,89 @@ describe LiquidRenderer do
     end
 
     it "should have expected keys" do
-      expected_keys = ['plugins', 'ref', 'title', 'content', 'images', 'shares', 'country_option_tags', 'url_params', 'primary_image', 'follow_up_url']
+      expected_keys = ['plugins', 'ref', 'images', 'shares', 'country_option_tags',
+                      'url_params', 'primary_image', 'follow_up_url', 'outstanding_fields',
+                      'petition_target', 'location', 'member']
+      expected_keys += page.liquid_data.keys.map(&:to_s)
       actual_keys = renderer.data.keys
-      expected_keys.each do |expected_key|
-        expect(actual_keys).to include(expected_key)
+      expect(actual_keys).to match_array(expected_keys)
+    end
+
+    describe 'outstanding_fields' do
+      it 'is [] if it has no plugins' do
+        expect(page.plugins.size).to eq 0
+        expect(LiquidRenderer.new(page).data['outstanding_fields']).to eq []
+      end
+
+      it "is [] if it's plugins don't have forms" do
+        create :plugins_thermometer, page: page
+        expect(LiquidRenderer.new(page).data['outstanding_fields']).to eq []
+      end
+
+      it 'has the fields from one plugin form' do
+        form = create :form_with_email_and_name
+        create :plugins_fundraiser, page: page, form: form
+        expect(LiquidRenderer.new(page).data['outstanding_fields']).to eq ['email', 'name']
+      end
+
+      it 'has from both plugin forms' do
+        p1 = create :plugins_fundraiser, page: page
+        p2 = create :plugins_petition, page: page
+        p1.update_attributes(form: create(:form_with_email_and_name))
+        p2.update_attributes(form: create(:form_with_phone_and_country))
+        expect(LiquidRenderer.new(page).data['outstanding_fields']).to match_array ['email', 'name', 'phone', 'country']
       end
     end
+
+    describe 'location' do
+
+      let(:location) { instance_double('Geocoder::Result::Freegeoip', data: {country_code: 'US'}, country_code: 'US') }
+
+      before :each do
+        allow(Donations::Utils).to receive(:currency_from_country_code){ 'USD' }
+      end
+
+      it 'returns the location its passed' do
+        allow(location).to receive(:data){ {region: 'USA' } }
+        allow(location).to receive(:country_code){ nil }
+        renderer = LiquidRenderer.new(page, location: location)
+        expect(renderer.data['location']).to eq location.data.stringify_keys
+        expect(Donations::Utils).not_to have_received(:currency_from_country_code).with('DE')
+      end
+
+      it 'calls currency_from_country_code with member country' do
+        member = build :member, country: 'DE'
+        allow(location).to receive(:country_code){ 'GB' }
+        allow(location).to receive(:data){ {country_code: 'GB' } }
+        renderer = LiquidRenderer.new(page, member: member, location: location)
+        expect(renderer.data['location']).to eq({'country_code' => 'GB', 'currency' => 'USD'})
+        expect(Donations::Utils).to have_received(:currency_from_country_code).with('DE')
+      end
+
+      it 'calls currency_from_country_code with location country if member has none' do
+        member = build :member, country: nil
+        allow(location).to receive(:country_code){ 'GB' }
+        allow(location).to receive(:data){ {country_code: 'GB' } }
+        renderer = LiquidRenderer.new(page, member: member, location: location)
+        expect(renderer.data['location']).to eq({'country_code' => 'GB', 'currency' => 'USD'})
+        expect(Donations::Utils).to have_received(:currency_from_country_code).with('GB')
+      end
+    end
+
+    describe 'member' do
+      it 'gives email as welcome name if no name' do
+        member = build :member, first_name: nil, last_name: "", email: 'sup@dude.com'
+        renderer = LiquidRenderer.new(page, member: member)
+        expect(renderer.data['member']['welcome_name']).to eq 'sup@dude.com'
+      end
+
+      it 'gives first name and last name if available' do
+        member = build :member, first_name: 'big', last_name: "dog", email: 'sup@dude.com'
+        renderer = LiquidRenderer.new(page, member: member)
+        expect(renderer.data['member']['welcome_name']).to eq 'big dog'
+      end
+    end
+
   end
 
 end

--- a/spec/models/plugins/fundraiser_spec.rb
+++ b/spec/models/plugins/fundraiser_spec.rb
@@ -23,12 +23,12 @@ describe Plugins::Fundraiser do
     fundraiser.donation_band = band
     serialized = fundraiser.liquid_data
     expect(serialized.keys).to include(:form_id, :fields, :donation_bands)
-    expect(serialized[:donation_bands].class).to eq String
+    expect(serialized[:donation_bands].class).to eq Hash
   end
 
   it 'serializes without a currency band' do
     expect{ fundraiser.liquid_data }.not_to raise_error
-    expect( fundraiser.liquid_data[:donation_bands]).to eq "null"
+    expect( fundraiser.liquid_data[:donation_bands]).to eq Hash.new
   end
 
   it 'serializes a named donation band' do
@@ -37,7 +37,7 @@ describe Plugins::Fundraiser do
     second_band = DonationBand.create!(name: 'Test Band', amounts: [100, 200])
 
     # The converted values of the second band.
-    expected_converted_values = second_band.internationalize.to_json
+    expected_converted_values = second_band.internationalize
     serialized = fundraiser.liquid_data({donation_band: 'Test Band'})
     expect(serialized[:donation_bands]).to eq(expected_converted_values)
   end

--- a/spec/teaspoon_env.rb
+++ b/spec/teaspoon_env.rb
@@ -38,7 +38,8 @@ Teaspoon.configure do |config|
 
     # Specify a file matcher as a regular expression and all matching files will be loaded when the suite is run. These
     # files need to be within an asset path. You can add asset paths using the `config.asset_paths`.
-    suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
+    # Currently all tests are required in spec_helper to allow specification of execution order
+    # suite.matcher = "{spec/javascripts,app/assets}/**/*_spec.{js,js.coffee,coffee}"
 
     # Load additional JS files, but requiring them in your spec helper is the preferred way to do this.
     #suite.javascripts = []


### PR DESCRIPTION
This PR rearranges our templating to isolate the elements of the page that are unique to the user. This allows them to be serialized separately and allows everything that actually goes through the liquid renderer to be cached, which will make the code on the cache_invalidation branch viable.

It also fixes some personalization that previously didn't work properly
- if a currency was passed as a URL param, it was previously ignored. It now overrides the geolocation currency.
- if a fundraiser didn't have a form, we used to still offer "Not you? click here" to reveal an empty form. This fixes that bug.

I still need to adjust the petition band to use this serialization. That should be pretty quick cause it uses the same mixed-in methods, they just need to get called in the initializer. It's definitely ready for code review (looking at you @osahyoun - this was your idea :P)