### PR TITLE
Fixes bug with sticky localization - sets locale on a request-per-request basis

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,11 +24,7 @@ class ApplicationController < ActionController::Base
       # if it's one explicitly registered under +i18n.available_locales+
     end
   end
-
-  # if @page.present? && @page.language.present? && @page.language.code.present?
-  #   I18n.locale = @page.language.code
-  # end
-
+  
   def localize_from_page_id
     page = Page.find_by(id: params[:page_id])
     localize_by_page_language(page)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  before_filter :set_locale
+
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
@@ -13,16 +15,35 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def localize_from_page_id
-    page = Page.find_by(id: params[:page_id])
-    if page.present? && page.language.present? && page.language.code.present?
-      set_locale(page.language.code)
+  def localize_from_page_id(id)
+    @page = Page.find_by(id: id)
+    if @page.present? && @page.language.present? && @page.language.code.present?
+      I18n.locale = @page.language.code
     end
   end
 
-  def set_locale(code)
+  def set_locale
+    # I18n doesn't work on a per-request basis on a multi-threaded server, so what I'm doing is forcing it to
+    # check what localization should be use on a per-request basis. This gets called on all requests, and the
+    # case goes through different controllers, checks whether it could be a controller where internalization
+    # would be required (for api/actions and pages), and then sets the locality if appropriate.
+    #
+    # Note that this has broken form validation right now - I'm not exactly sure why that would be, but I get
+    # a 500 for the jquery request.
     begin
-      I18n.locale = code
+      controller = params[:controller]
+      case controller
+        when 'api/actions'
+          localize_from_page_id(params[:page_id])
+        when 'pages'
+          if params[:id].blank?
+            I18n.locale = I18n.default_locale
+          else
+            localize_from_page_id(params[:id])
+          end
+        else
+          I18n.locale = I18n.default_locale
+      end
     rescue I18n::InvalidLocale
       # by setting the +i18n.enforce_available_locales+ flag to true but
       # catching the resulting error, it allows us to only set the locale

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,10 @@ class ApplicationController < ActionController::Base
 
   def localize_from_page_id
     page = Page.find_by(id: params[:page_id])
+    localize_by_page_language(page)
+  end
+
+  def localize_by_page_language(page)
     if page.present? && page.language.present? && page.language.code.present?
       set_locale(page.language.code)
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_filter :set_locale
+  before_filter :set_default_locale
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -15,39 +15,28 @@ class ApplicationController < ActionController::Base
 
   private
 
-  def localize_from_page_id(id)
-    @page = Page.find_by(id: id)
-    if @page.present? && @page.language.present? && @page.language.code.present?
-      I18n.locale = @page.language.code
-    end
-  end
-
-  def set_locale
-    # I18n doesn't work on a per-request basis on a multi-threaded server, so what I'm doing is forcing it to
-    # check what localization should be use on a per-request basis. This gets called on all requests, and the
-    # case goes through different controllers, checks whether it could be a controller where internalization
-    # would be required (for api/actions and pages), and then sets the locality if appropriate.
-    #
-    # Note that this has broken form validation right now - I'm not exactly sure why that would be, but I get
-    # a 500 for the jquery request.
+  def set_locale(code)
     begin
-      controller = params[:controller]
-      case controller
-        when 'api/actions'
-          localize_from_page_id(params[:page_id])
-        when 'pages'
-          if params[:id].blank?
-            I18n.locale = I18n.default_locale
-          else
-            localize_from_page_id(params[:id])
-          end
-        else
-          I18n.locale = I18n.default_locale
-      end
+      I18n.locale = code
     rescue I18n::InvalidLocale
       # by setting the +i18n.enforce_available_locales+ flag to true but
       # catching the resulting error, it allows us to only set the locale
       # if it's one explicitly registered under +i18n.available_locales+
     end
+  end
+
+  # if @page.present? && @page.language.present? && @page.language.code.present?
+  #   I18n.locale = @page.language.code
+  # end
+
+  def localize_from_page_id
+    page = Page.find_by(id: params[:page_id])
+    if page.present? && page.language.present? && page.language.code.present?
+      set_locale(page.language.code)
+    end
+  end
+
+  def set_default_locale
+    I18n.locale = I18n.default_locale
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -52,8 +52,8 @@ class PagesController < ApplicationController
   private
 
   def render_liquid(layout)
-    localize_by_page_language(@page)
     raise ActiveRecord::RecordNotFound unless @page.active? || user_signed_in?
+    localize_by_page_language(@page)
     recognized_member = Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
     renderer = LiquidRenderer.new(@page, request_country: request_country, member: recognized_member, layout: layout, url_params: params)
     @rendered = renderer.render

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -52,6 +52,9 @@ class PagesController < ApplicationController
   private
 
   def render_liquid(layout)
+    if @page.present? && @page.language.present? && @page.language.code.present?
+      set_locale(@page.language.code)
+    end
     raise ActiveRecord::RecordNotFound unless @page.active? || user_signed_in?
     recognized_member = Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
     renderer = LiquidRenderer.new(@page, request_country: request_country, member: recognized_member, layout: layout, url_params: params)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -52,9 +52,7 @@ class PagesController < ApplicationController
   private
 
   def render_liquid(layout)
-    if @page.present? && @page.language.present? && @page.language.code.present?
-      set_locale(@page.language.code)
-    end
+    localize_by_page_language(@page)
     raise ActiveRecord::RecordNotFound unless @page.active? || user_signed_in?
     recognized_member = Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
     renderer = LiquidRenderer.new(@page, request_country: request_country, member: recognized_member, layout: layout, url_params: params)

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -7,7 +7,6 @@ class LiquidRenderer
     @request_country = request_country
     @member = member
     @url_params = url_params
-    set_locale
   end
 
   def render
@@ -43,16 +42,6 @@ class LiquidRenderer
   end
 
   private
-
-  def set_locale
-    begin
-      I18n.locale = @page.language.code if @page.language.present?
-    rescue I18n::InvalidLocale
-      # by setting the +i18n.enforce_available_locales+ flag to true but
-      # catching the resulting error, it allows us to only set the locale
-      # if it's one explicitly registered under +i18n.available_locales+
-    end
-  end
 
   def image_urls(img)
     return { urls: { large: '', small: '' } } if img.blank? || img.content.blank?

--- a/spec/liquid/liquid_renderer_spec.rb
+++ b/spec/liquid/liquid_renderer_spec.rb
@@ -54,13 +54,6 @@ describe LiquidRenderer do
           expect(I18n.t('common.save')).to eq 'Save'
         end
       end
-
-      it "changes the locale when it's supported" do
-        page.language = build :language, code: 'fr'
-        LiquidRenderer.new(page, layout: liquid_layout)
-        expect(I18n.locale).to eq :fr
-        expect(I18n.t('common.save')).to eq 'Enregistrer'
-      end
     end
   end
 

--- a/spec/requests/localization_spec.rb
+++ b/spec/requests/localization_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe 'Localization for pages' do
+
+  Champaign::Application.config.i18n.available_locales.each do |locale|
+
+    it "sets localization for a page in #{locale}" do
+      page = create :page, language: (create :language, code: locale)
+      get "/pages/#{page.id}"
+      expect(response).to be_successful
+      expect(I18n.locale).to eq locale
+    end
+
+    it "resets localization back from #{locale} to default if a non-localized page is requested afterwards" do
+      page = create :page, language: (create :language, code: locale)
+      get "/pages/#{page.id}"
+      expect(response).to be_successful
+      expect(I18n.locale).to eq locale
+      get "/"
+      expect(response).to be_successful
+      expect(I18n.locale).to eq I18n.default_locale
+    end
+
+  end
+
+  it "uses default locale for a page where localization isn't required" do
+    get "/"
+    expect(response).to be_successful
+    expect(I18n.locale).to eq I18n.default_locale
+  end
+
+  it "uses the correct locale if two localized pages are requested in a row" do
+    english_page = create :page, language: (create :language, code: :en)
+    french_page = create :page, language: (create :language, code: :fr)
+    get "/pages/#{english_page.id}"
+    expect(response).to be_successful
+    expect(I18n.locale).to eq :en
+
+    get "/pages/#{french_page.id}"
+    expect(response).to be_successful
+    expect(I18n.locale).to eq :fr
+  end
+
+end


### PR DESCRIPTION
I18n doesn't work on a per-request basis on a multi-threaded server, so what I'm doing is forcing it to
check what localization should be use on a per-request basis. This gets called on all requests, and the
case goes through different controllers, checks whether it could be a controller where internalization
would be required (for api/actions and pages), and then sets the locality if appropriate.

This has broken form validation right now - I'm not exactly sure why that would be, but I get a 500 for the jquery request. @NealJMD perhaps you have an idea as to why that would happen. I also don't think this has to stay as-is - I'm just sharing ideas. This fixes the problem and breaks a bunch of specs. If you're OK with the outline of how this might work and would like to implement this your own way, you can go your own way and discard this PR.