### PR TITLE
German

### DIFF
--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -129,7 +129,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
       let currencySymbol = this.CURRENCY_SYMBOLS[this.currency];
       let digits = (this.donationAmount === Math.floor(this.donationAmount)) ? 0 : 2;
       let donationAmount = `${currencySymbol}${this.donationAmount.toFixed(digits)}`;
-      this.buttonText = `<span class="fa fa-lock"></span><span>${I18n.t('fundraiser.donate')} ${donationAmount}</span>`;
+      this.buttonText = `<span class="fa fa-lock"></span><span>${I18n.t('fundraiser.donate', {amount: donationAmount})}</span>`;
       this.$('.fundraiser-bar__display-amount').text(donationAmount);
       this.$('.fundraiser-bar__submit-button').html(this.buttonText);
     } else {

--- a/app/liquid/liquid_i18n.rb
+++ b/app/liquid/liquid_i18n.rb
@@ -8,7 +8,21 @@
 #
 #   I18n.t('fundraiser.thank_you')
 #
-# The only logic here serves to ensure aggressive reporting of missing
+# The parsing logic parses interpolation arguments using a regex, which
+# is how liquid parse all its tags. It expects values of the form:
+#
+#   {{ 'fundraiser.donate, amount: $15, foo: bar' | t }}
+#
+# The +val+ method serves to facilitate variable interpolation in liquid.
+# If the string "$15" is stored in a variable called my_amount, the above
+# can be re-written as
+#
+#   {{ 'fundraiser.donate' | val: 'amount', my_amount | val: 'foo','bar' | t }}
+#
+# Because we don't have a proof that there's no degenerate case that makes
+# the iterative regex loop forever, it limits to 10 interpolations per translation.
+#
+# The error logic here serves to ensure aggressive reporting of missing
 # translations when in development and test mode. In those environments,
 # if a template is rendered and a translation is missing, an exception
 # will be raised. In production, it will show a fallback message.

--- a/app/liquid/liquid_i18n.rb
+++ b/app/liquid/liquid_i18n.rb
@@ -38,9 +38,8 @@ module LiquidI18n
 
   def t(query)
     translation_key, interpolation_vals = parse_interpolation(query)
-    return I18n.t(translation_key, **interpolation_vals) unless Rails.env.development? || Rails.env.test?
     begin
-      I18n.t(translation_key, **interpolation_vals.merge(:raise => true))
+      I18n.t(translation_key, **interpolation_vals.merge(:raise => !Rails.env.production?))
     rescue I18n::MissingTranslationData => e
       raise I18n::TranslationMissing.new(e.message)
     end

--- a/app/liquid/views/layouts/post-action-share.liquid
+++ b/app/liquid/views/layouts/post-action-share.liquid
@@ -1,5 +1,5 @@
 {% comment %} Description: A follow-up page thanking for signing a petition and asking to share {% endcomment %}
 
-{% capture message %}{{ 'petition.thank_you' | t }} "{{ title }}"!{% endcapture %}
+{% capture message %}{{ 'petition.thank_you' | val: 'petition_title', title | t }}!{% endcapture %}
 {% include 'Share Page', message: message %}
 {% include 'Simple Footer', extra_class: 'simple-footer--stuck-to-bottom' %}

--- a/app/views/plugins/thermometers/_thermometer.liquid
+++ b/app/views/plugins/thermometers/_thermometer.liquid
@@ -6,8 +6,8 @@
       </div>
       <div class="thermometer__remaining">
         {{ 'thermometer.signatures_until_goal' |
-            v: 'goal', plugins.thermometer[ref].goal_k |
-            v: 'remaining', plugins.thermometer[ref].remaining | t }}
+            val: 'goal', plugins.thermometer[ref].goal_k |
+            val: 'remaining', plugins.thermometer[ref].remaining | t }}
       </div>
     </div>
     <div class="thermometer__bg">

--- a/app/views/plugins/thermometers/_thermometer.liquid
+++ b/app/views/plugins/thermometers/_thermometer.liquid
@@ -5,7 +5,9 @@
         {{ plugins.thermometer[ref].signatures }} {{ 'thermometer.signatures' | t }}
       </div>
       <div class="thermometer__remaining">
-        {{ plugins.thermometer[ref].remaining }} {{ 'thermometer.until' | t }} {{ plugins.thermometer[ref].goal_k }}
+        {{ 'thermometer.signatures_until_goal' |
+            v: 'goal', plugins.thermometer[ref].goal_k |
+            v: 'remaining', plugins.thermometer[ref].remaining | t }}
       </div>
     </div>
     <div class="thermometer__bg">

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module Champaign
     config.assets.enabled = true
     config.assets.version = '1.0'
 
-    config.i18n.available_locales = [:en, :fr]
+    config.i18n.available_locales = [:en, :fr, :de]
     config.i18n.enforce_available_locales = true
 
     # We're using Redis as our cache. Configure that here.

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -1,6 +1,6 @@
 require './app/liquid/liquid_file_system'
 require './app/liquid/liquid_i18n'
 
-Liquid::Template.register_filter(LiquidI18nRails)
+Liquid::Template.register_filter(LiquidI18n)
 Liquid::Template.file_system = LiquidFileSystem
 Liquid::Template.error_mode = Rails.env.production? ? :lax : :strict

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -1,6 +1,6 @@
 require './app/liquid/liquid_file_system'
 require './app/liquid/liquid_i18n'
 
-Liquid::Template.register_filter LiquidI18nRails
+Liquid::Template.register_filter(LiquidI18nRails)
 Liquid::Template.file_system = LiquidFileSystem
 Liquid::Template.error_mode = Rails.env.production? ? :lax : :strict

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -1,0 +1,54 @@
+de:
+  page:
+    more_info: Mehr Informationen
+  basics:
+    or: oder
+  branding:
+    tagline: Menschen vor Profit!
+    license: Creative Commons Namensnennung 3.0 Unported Lizenz
+  fundraiser:
+    amount: Summe
+    details: Kontaktdaten
+    payment: Zahlung
+    donate: "%{amount} Spenden"
+    error_intro: Leider konnten wir Ihre Zahlung nicht bearbeiten!
+    currency_in: Beträge werden in Euro angezeigt.
+    switch_currency: Währung ändern
+    proceed_to_details: Weiter zu Kontaktdaten
+    proceed_to_payment: Weiter zur Zahlung
+    other_amount: Anderer Betrag
+    make_recurring: Monatlich spenden
+    thank_you: Vielen Dank für Ihre Spende!
+    card_declined: Der Zahlungsdienst hat Ihre Kreditkarte nicht akzeptiert. Bitte wählen Sie eine andere Zahlungsmethode.
+    unknown_error: Unbekannter Fehler. Unser Team wurde benachrichtigt. Bitte überprüfen Sie Ihre Eingaben oder wählen Sie eine andere Zahlungsmethode.
+    fine_print: "SumOfUs ist eine eingetragene Non-Profit-Organisation (501(c)4) mit Sitz in Washington DC, USA. Spenden an SumOfUs können nicht von der Steuer abgesetzt werden. Für mehr Informationen schreiben Sie uns bitte eine E-Mail an info@sumofus.org."
+    fields:
+      cvv: Kartenprüfnummer
+      number: Kreditkartennummer
+      expiration: Ablaufdatum
+      expiration_format: MM/JJ
+      postalCode: Postleitzahl
+  petition:
+    sign_it: Unterschreiben Sie die Petition
+    target_prefix: AN
+    confirmation: Ihr Name wurde übermittelt
+    thank_you: "Vielen Dank, dass Sie %{petition_title} mit Ihrer Unterschrift unterstützen."
+  form:
+    welcome_back: Willkommen zurück!
+    switch_user: Das sind nicht Sie?
+    processing: In Bearbeitung...
+    submit: Abschicken
+  thermometer:
+    signatures_until_goal: "Noch %{remaining} Unterschriften bis zur Zielmarke %{goal}"
+    signatures: Unterschriften
+  share:
+    cta: Teilen Sie die Kampagne mit Ihren Freunden und verdreifachen Sie Ihre Wirkung!
+  errors:
+    probably_invalid: Das sieht nicht richtig aus.
+    is_invalid: ist ungültig
+    this_field: Dieses Feld
+  validation:
+    is_required: wird benötigt
+    is_invalid_email: ist keine gültige E-Mail-Adresse
+    is_invalid_phone: "kann nur Nummern, Schrägstriche, Pluszeichen und Klammern enthalten"
+    is_invalid_country: muss eine gültige Ländervorwahl sein

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -32,7 +32,7 @@ de:
     sign_it: Unterschreiben Sie die Petition
     target_prefix: AN
     confirmation: Ihr Name wurde übermittelt
-    thank_you: "Vielen Dank, dass Sie %{petition_title} mit Ihrer Unterschrift unterstützen."
+    thank_you: 'Vielen Dank, dass Sie "%{petition_title}" mit Ihrer Unterschrift unterstützen.'
   form:
     welcome_back: Willkommen zurück!
     switch_user: Das sind nicht Sie?

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -10,7 +10,7 @@ en:
     amount: Amount
     details: Details
     payment: Payment
-    donate: Donate # used on the submit button, eg 'Donate $15'
+    donate: "Donate %{amount}" # used on the submit button, eg 'Donate $15'
     error_intro: We were unable to process your donation!
     currency_in: Values shown in # USD
     switch_currency: Switch currency
@@ -32,15 +32,15 @@ en:
     sign_it: Sign the petition
     target_prefix: TO
     confirmation: Name submitted
-    thank_you: Thanks for adding your name to # <petition title>
+    thank_you: "Thanks for adding your name to %{petition_title}"
   form:
     welcome_back: Welcome back
     switch_user: Not you?
     processing: Processing...
     submit: Submit
   thermometer:
+    signatures_until_goal: "%{remaining} signatures until %{goal}"
     signatures: signatures # as in '225 signatures'
-    until: until # as in '25 signatures until 250'
   share:
     cta: Share the campaign with your friends to triple your impact!
   errors:

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -32,7 +32,7 @@ en:
     sign_it: Sign the petition
     target_prefix: TO
     confirmation: Name submitted
-    thank_you: "Thanks for adding your name to %{petition_title}"
+    thank_you: 'Thanks for adding your name to "%{petition_title}"'
   form:
     welcome_back: Welcome back
     switch_user: Not you?

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -10,7 +10,7 @@ fr:
     amount: Montant
     details: Détails
     payment: Paiement
-    donate: Donner # utilisé dans le bouton de validation, eg 'Donner 15€'
+    donate: "Donner %{amount}" # utilisé dans le bouton de validation, eg 'Donner 15€'
     error_intro: Votre don n’a pas pu être effectué!
     currency_in: Monnaie en # USD
     switch_currency: Changer de monnaie
@@ -32,15 +32,15 @@ fr:
     sign_it: Signez la pétition
     target_prefix: Pétition adressée à
     confirmation: Nom envoyé
-    thank_you: Merci d’avoir ajouté votre nom à la pétition # <petition title>
+    thank_you: "Merci d’avoir ajouté votre nom à la pétition %{petition_title}"
   form:
     welcome_back: Bienvenue
     switch_user: Ce n’est pas vous?
     processing: En cours de traitement...
     submit: Envoyer
   thermometer:
+    signatures_until_goal: "%{remaining} signatures jusqu'à %{goal}"
     signatures: signatures #, par exemple '225 signatures'
-    until: jusqu'à #, par exemple '25 signatures jusqu'à 250'
   share:
     cta: Partagez la pétition avec vos ami(e)s afin de tripler votre impact!
   errors:

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -32,7 +32,7 @@ fr:
     sign_it: Signez la pétition
     target_prefix: Pétition adressée à
     confirmation: Nom envoyé
-    thank_you: "Merci d’avoir ajouté votre nom à la pétition %{petition_title}"
+    thank_you: 'Merci d’avoir ajouté votre nom à la pétition "%{petition_title}"'
   form:
     welcome_back: Bienvenue
     switch_user: Ce n’est pas vous?

--- a/spec/liquid/liquid_i18n_spec.rb
+++ b/spec/liquid/liquid_i18n_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+describe LiquidI18n do
+
+  # to define a liquid filter, you make a module with instance methods that
+  # gets included by liquid. You can't make them module_functions, so here
+  # we extend a generic class to call the filter
+  subject { Class.new.extend(LiquidI18n) }
+
+  before :all do
+    translations = {
+      'liquidi18nspec' => {
+        'basic' => 'Super simple',
+        'temperature' => 'It is %{temp} degrees',
+        'two'  => 'First you %{one} then you %{two}',
+        'ten' => '%{a} - %{b} - %{c} - %{d} - %{e} - %{f} - %{g} - %{h} - %{i} - %{j}',
+        'eleven' => '%{a} - %{b} - %{c} - %{d} - %{e} - %{f} - %{g} - %{h} - %{i} - %{j} - %{k}',
+        'variety' => '%{one} for the %{money}, %{two} for the %{show}, %{three} to get ready and four to go!',
+      }
+    }
+    I18n.backend.store_translations('en', translations)
+  end
+
+  describe 't' do
+    it 'translates without interpolation' do
+      expect(subject.t('liquidi18nspec.basic')).to eq 'Super simple'
+    end
+
+    it 'correctly interpolates one value with spaces' do
+      expect(
+        subject.t('liquidi18nspec.temperature, temp: 15')
+      ).to eq 'It is 15 degrees'
+    end
+
+    it 'correctly interpolates one value without spaces' do
+      expect(
+        subject.t('liquidi18nspec.temperature,temp:15')
+      ).to eq 'It is 15 degrees'
+    end
+
+    it 'correctly interpolates two values' do
+      expect(
+        subject.t('liquidi18nspec.two, one: :) and ;), two: smile and wink')
+      ).to eq 'First you :) and ;) then you smile and wink'
+    end
+
+    it 'correctly interpolates ten values' do
+      expect(
+        subject.t('liquidi18nspec.ten, a: q, b: w, c: e, d: r, e: t, f: y, g: u, h: i, i: o, j: p')
+      ).to eq 'q - w - e - r - t - y - u - i - o - p'
+    end
+
+    it 'will not interpolate more than ten values' do
+      expect{
+        subject.t('liquidi18nspec.ten, a: q, b: w, c: e, d: r, e: t, f: y, g: u, h: i, i: o, j: p, k: p')
+      }.to raise_error I18n::TooMuchInterpolation
+    end
+
+    it 'can interpolate punctuation, numbers, and accents'do
+      expect(
+        subject.t('liquidi18nspec.variety, one: In it, money: $$ dollas $$, two: ráce, show: finish, three: 3')
+      ).to eq 'In it for the $$ dollas $$, ráce for the finish, 3 to get ready and four to go!'
+    end
+
+    it 'handles a case with no commas' do
+      expect{
+        subject.t('liquidi18nspec.temperature temp: 15')
+      }.to raise_error I18n::TranslationMissing
+    end
+
+    it 'handles a case with too many commas and colons' do
+      expect(
+        subject.t('liquidi18nspec.temperature, ,womp, temp:15, ::15, womp:temp')
+      ).to eq 'It is 15 degrees'
+    end
+
+    describe 'handles a missing translation' do
+
+      it 'by raising an error in test' do
+        expect(Rails.env.test?).to eq true
+        expect{ subject.t('fundraiser.lunacy') }.to raise_error I18n::TranslationMissing
+      end
+
+      it 'by raising an error in development' do
+        allow(Rails).to receive(:env).and_return "development".inquiry
+        expect(Rails.env.development?).to eq true
+        expect{ subject.t('fundraiser.lunacy') }.to raise_error I18n::TranslationMissing
+      end
+
+      it 'by showing the best effort on production' do
+        allow(Rails).to receive(:env).and_return "production".inquiry
+        expect(Rails.env.production?).to eq true
+        expect{ subject.t('fundraiser.lunacy') }.not_to raise_error
+        expect( subject.t('fundraiser.lunacy') ).to eq "translation missing: en.fundraiser.lunacy"
+      end
+    end
+  end
+
+  describe 'val' do
+    it 'can append one value pair' do
+      expect(subject.val('rebel-bass', 'king', 'pin')).to eq "rebel-bass, king: pin"
+    end
+
+    it 'nests nicely' do
+      expect(subject.val(subject.val('rebel-bass', 'king', 'pin'), 'time', 'flies')).to eq "rebel-bass, king: pin, time: flies"
+    end
+  end
+end
+


### PR DESCRIPTION
This PR adds German localization to the member facing UI. It's more elaborate because several of the German translations require proper interpolation, rather than simple concatenation. (for example: `'Vielen Dank, dass Sie "%{petition_title}" mit Ihrer Unterschrift unterstützen.'` rather than `Thanks for adding your name to # <petition title>`)

When I started I18n, I had to create a liquid filter to patch the `I18n.t` through to liquid. Here, I've done it again to allow interpolation. If you're curious, the `LiquidI18n` class is well documented by a big comment  explaining usage and a spec.