### PR TITLE
Daisy chain

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,6 +41,7 @@ require("plugins_toggle");
 require("sidebar");
 require("collection_editor");
 require('shares_editor');
+require('layout_picker');
 
 window.PageEditBar =  require("page_edit_bar");
 window.Analytics   =  require('analytics');

--- a/app/assets/javascripts/layout_picker.js
+++ b/app/assets/javascripts/layout_picker.js
@@ -1,0 +1,36 @@
+const setupOnce = require('setup_once');
+
+(function(){
+
+  let LayoutPicker = Backbone.View.extend({
+
+    events: {
+      'click .radio-group__option': 'updateSelected',
+    },
+
+    updateSelected(e) {
+      let $target = $(e.target);
+      if (!$target.hasClass('radio-group__option')) {
+        // for bubbling
+        $target = $target.parents('.radio-group__option')
+      }
+      const name = $target.find('.layout-settings__title').text();
+      $target.parents('.layout-settings').find('.layout-settings__current').text(name);
+      $target.parents('.layout-settings').find('.radio-group__option').removeClass('active');
+      $target.addClass('active');
+      this.updatePlan($target);
+    },
+
+    updatePlan($target) {
+      const $input = $target.find(`#${$target.attr('for')}`);
+      if ($input.attr('name') === 'page[follow_up_liquid_layout_id]') {
+        this.$('#page_follow_up_plan_with_liquid').prop('checked', true);
+      }
+    },
+
+  });
+
+  $.subscribe("layout:edit", function(){
+    setupOnce('.layout-settings', LayoutPicker);
+  });
+}());

--- a/app/assets/javascripts/selectize_config.js
+++ b/app/assets/javascripts/selectize_config.js
@@ -3,12 +3,4 @@ $(function(){
     plugins: ['remove_button'],
     closeAfterSelect: true
   });
-
-  $('.radio-group input[type="radio"]').on('change', function(e){
-    var $target = $(e.target);
-    var name = $target.parents('.radio-group__option').find('.layout-settings__title').text();
-    $target.parents('.layout-settings').find('.layout-settings__current').text(name);
-    $target.parents('.radio-group').find('.radio-group__option').removeClass('active');
-    $target.parents('.radio-group__option').addClass('active');
-  });
 });

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -212,7 +212,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
         this.redirectTo(this.followUpUrl);
       } else {
         // this should never happen, but just in case.
-        alert(I18n.t('fundraiser.thank_you')+'!');
+        alert(I18n.t('fundraiser.thank_you'));
       }
     }
   },

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -208,7 +208,12 @@ const FundraiserBar = Backbone.View.extend(_.extend(
 
   transactionSuccess () {
     return (data, status) => {
-      this.redirectTo(this.followUpUrl);
+      if (this.followUpUrl) {
+        this.redirectTo(this.followUpUrl);
+      } else {
+        // this should never happen, but just in case.
+        alert(I18n.t('fundraiser.thank_you')+'!');
+      }
     }
   },
 

--- a/app/assets/javascripts/sumofus/backbone/petition_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/petition_bar.js
@@ -46,7 +46,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
       window.location.href = this.followUpUrl;
     } else {
       // this should never happen, but just in case.
-      alert(I18n.t('petition.confirmation')+'!');
+      alert(I18n.t('petition.excited_confirmation'));
     }
   },
 

--- a/app/assets/javascripts/sumofus/backbone/petition_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/petition_bar.js
@@ -14,6 +14,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
   },
 
   // options: object with any of the following keys
+  //    followUpUrl: the url to redirect to after success
   //    outstandingFields: the names of step 2 form fields that can't be prefilled
   //    member: an object with fields that will prefill the form
   initialize(options = {}) {
@@ -21,6 +22,7 @@ const PetitionBar = Backbone.View.extend(_.extend(
     this.handleFormErrors();
     this.initializePrefill(options);
     this.expandBlurb();
+    this.followUpUrl = options.followUpUrl;
     this.initializeSticky();
     if (!this.isMobile()) {
       this.selectizeCountry();
@@ -40,11 +42,11 @@ const PetitionBar = Backbone.View.extend(_.extend(
 
   handleSuccess(e, data) {
     this.clearFormErrors();
-    if (data.follow_up_url) {
-      window.location.href = data.follow_up_url
+    if (this.followUpUrl) {
+      window.location.href = this.followUpUrl;
     } else {
       // this should never happen, but just in case.
-      alert("You've signed the petition! Thanks so much!");
+      alert(I18n.t('petition.confirmation')+'!');
     }
   },
 

--- a/app/assets/javascripts/sumofus/backbone/petition_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/petition_bar.js
@@ -21,9 +21,9 @@ const PetitionBar = Backbone.View.extend(_.extend(
     this.petitionTextMinHeight = 120; // pixels
     this.handleFormErrors();
     this.initializePrefill(options);
+    this.initializeSticky();
     this.expandBlurb();
     this.followUpUrl = options.followUpUrl;
-    this.initializeSticky();
     if (!this.isMobile()) {
       this.selectizeCountry();
     }
@@ -73,6 +73,10 @@ const PetitionBar = Backbone.View.extend(_.extend(
     } else if(!this.$el.hasClass('stuck-right')){
       this.$el.css('top', `-${height}px`);
     }
+
+    // german is so damn long the absolute position title wraps
+    const $title = $('.petition-bar__title-bar');
+    $title.css('top', `-${$title.outerHeight()}px`);
   },
 
 }));

--- a/app/assets/stylesheets/page-edit.scss
+++ b/app/assets/stylesheets/page-edit.scss
@@ -370,7 +370,7 @@ body.page-edit-body {
 }
 
 .layout-settings {
-  &--primary, &--secondary {
+  &--primary, &--follow_up {
     padding-top: 15px;
   }
   &__title {

--- a/app/assets/stylesheets/sumofus/components/petition.scss
+++ b/app/assets/stylesheets/sumofus/components/petition.scss
@@ -76,6 +76,9 @@
 
     background: $teal;
     color: white;
+    &.petition-bar__title {
+      max-width: 280px;
+    }
   }
 
   &__content {

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -11,7 +11,7 @@ class Api::ActionsController < ApplicationController
         value: action.member.id,
         expires: 1.hour.from_now
       }
-      render json: { follow_up_url: follow_up_page_path(@action_params[:page_id]) }
+      render json: {}, status: 200
     else
       render json: {errors: validator.errors}, status: 422
     end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -36,7 +36,7 @@ class PagesController < ApplicationController
   end
 
   def follow_up
-    render_liquid(@page.secondary_liquid_layout)
+    render_liquid(@page.follow_up_liquid_layout)
   end
 
   def update
@@ -83,7 +83,7 @@ class PagesController < ApplicationController
       :campaign_id,
       :language_id,
       :liquid_layout_id,
-      :secondary_liquid_layout_id,
+      :follow_up_liquid_layout_id,
       {:tag_ids => []} )
   end
 end

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -29,7 +29,7 @@ class LiquidRenderer
                 merge( LiquidHelper.globals(page: @page) ).
                 merge( shares: Shares.get_all(@page) ).
                 merge( url_params: @url_params ).
-                merge( follow_up_url: follow_up_page_path(@page.id)).
+                merge( follow_up_url: follow_up_url).
                 merge( member: @member.try(:liquid_data) ).
                 merge( location: location).
                 merge( outstanding_fields: outstanding_fields(plugin_data) ).
@@ -85,6 +85,10 @@ class LiquidRenderer
 
   def cache_key
     "rendered_liquid:#{@page.cache_key}:#{@layout.cache_key}"
+  end
+
+  def follow_up_url
+    PageFollower.new_from_page(@page).follow_up_path
   end
 end
 

--- a/app/liquid/views/layouts/post-action-share.liquid
+++ b/app/liquid/views/layouts/post-action-share.liquid
@@ -1,5 +1,5 @@
 {% comment %} Description: A follow-up page thanking for signing a petition and asking to share {% endcomment %}
 
-{% capture message %}{{ 'petition.thank_you' | val: 'petition_title', title | t }}!{% endcapture %}
+{% capture message %}{{ 'petition.thank_you' | val: 'petition_title', title | t }}{% endcapture %}
 {% include 'Share Page', message: message %}
 {% include 'Simple Footer', extra_class: 'simple-footer--stuck-to-bottom' %}

--- a/app/liquid/views/layouts/post-donation-share.liquid
+++ b/app/liquid/views/layouts/post-donation-share.liquid
@@ -1,4 +1,4 @@
 {% comment %} Description: A follow-up page thanking for donating money and asking to share {% endcomment %}
-{% capture message %}{{ 'fundraiser.thank_you' | t }}!{% endcapture %}
+{% capture message %}{{ 'fundraiser.thank_you' | t }}{% endcapture %}
 {% include 'Share Page', message: message %}
 {% include 'Simple Footer', extra_class: 'simple-footer--stuck-to-bottom' %}

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -2,9 +2,12 @@ class Page < ActiveRecord::Base
   extend FriendlyId
   has_paper_trail
 
+  enum follow_up_plan: [:with_liquid, :with_page] # todo - :with_link
+
   belongs_to :language
   belongs_to :campaign # Note that some pages do not necessarily belong to campaigns
   belongs_to :liquid_layout
+  belongs_to :follow_up_page, class_name: 'Page'
   belongs_to :follow_up_liquid_layout, class_name: 'LiquidLayout'
   belongs_to :primary_image, class_name: 'Image'
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -5,7 +5,7 @@ class Page < ActiveRecord::Base
   belongs_to :language
   belongs_to :campaign # Note that some pages do not necessarily belong to campaigns
   belongs_to :liquid_layout
-  belongs_to :secondary_liquid_layout, class_name: 'LiquidLayout'
+  belongs_to :follow_up_liquid_layout, class_name: 'LiquidLayout'
   belongs_to :primary_image, class_name: 'Image'
 
   has_many :tags, through: :pages_tags

--- a/app/services/page_follower.rb
+++ b/app/services/page_follower.rb
@@ -1,0 +1,32 @@
+class PageFollower
+  include Rails.application.routes.url_helpers
+
+  def initialize(plan, page_id, follow_up_liquid_layout_id, follow_up_page_id)
+    @plan = plan
+    @page_id = page_id
+    @follow_up_page_id = follow_up_page_id
+    @follow_up_liquid_layout_id = follow_up_liquid_layout_id
+  end
+
+  def follow_up_path
+    case @plan
+    when :with_page
+      path_to_follow_up_page || path_to_follow_up_layout
+    when :with_liquid
+      path_to_follow_up_layout || path_to_follow_up_page
+    else
+      raise ArgumentError, "follow up plan '#{@plan}' is not a valid plan"
+    end
+  end
+
+  private
+
+  def path_to_follow_up_page
+    page_path(@follow_up_page_id) unless @follow_up_page_id.blank?
+  end
+
+  def path_to_follow_up_layout
+    follow_up_page_path(@page_id) unless @page_id.blank? || @follow_up_liquid_layout_id.blank?
+  end
+end
+

--- a/app/services/page_follower.rb
+++ b/app/services/page_follower.rb
@@ -1,6 +1,10 @@
 class PageFollower
   include Rails.application.routes.url_helpers
 
+  def self.new_from_page(page)
+    new(page.follow_up_plan, page.id, page.follow_up_liquid_layout_id, page.follow_up_page_id)
+  end
+
   def initialize(plan, page_id, follow_up_liquid_layout_id, follow_up_page_id)
     @plan = plan
     @page_id = page_id
@@ -9,7 +13,7 @@ class PageFollower
   end
 
   def follow_up_path
-    case @plan
+    case @plan.try(:to_sym)
     when :with_page
       path_to_follow_up_page || path_to_follow_up_layout
     when :with_liquid

--- a/app/views/pages/_collapsing_layout_select.slim
+++ b/app/views/pages/_collapsing_layout_select.slim
@@ -1,6 +1,6 @@
--# association: `:liquid_layout` or `:secondary_liquid_layout`
--# field: `:liquid_layout_id` or `:secondary_liquid_layout_id`
--# dom_name: CSS class extension, should be `primary` or `secondary`
+-# association: `:liquid_layout` or `:follow_up_liquid_layout`
+-# field: `:liquid_layout_id` or `:follow_up_liquid_layout_id`
+-# dom_name: CSS class extension, should be `primary` or `follow_up`
 -# f: form builder
 br
 .layout-settings

--- a/app/views/pages/_collapsing_layout_select.slim
+++ b/app/views/pages/_collapsing_layout_select.slim
@@ -1,16 +1,21 @@
 -# association: `:liquid_layout` or `:follow_up_liquid_layout`
 -# field: `:liquid_layout_id` or `:follow_up_liquid_layout_id`
 -# dom_name: CSS class extension, should be `primary` or `follow_up`
+-# offer_redirect: boolean, whether to show option for follow up redirect
 -# f: form builder
+- offer_redirect ||= false
 br
-.layout-settings
+.layout-settings id="layout-settings--#{dom_name}"
   span.layout-settings__current
-    - if f.object.send(association).present?
+    - if offer_redirect && f.object.with_page? && f.object.follow_up_page.present?
+      = "Redirect to \"#{f.object.follow_up_page.title}\""
+    - elsif f.object.send(association).present?
       = f.object.send(association).title
     - else
       span.layout-settings__no-layout = t('pages.edit.no_layout')
   = " - "
   a data-toggle="collapse" data-target=".layout-settings--#{dom_name}" aria-expanded="false"
-    = t('pages.edit.change_layout')
+    = field == :follow_up_liquid_layout_id ? t('pages.edit.change_follow_up') : t('pages.edit.change_layout')
   .collapse class="layout-settings--#{dom_name}"
-    = render 'layout_select', f: f, field: field
+    = render 'layout_select', f: f, field: field, offer_redirect: offer_redirect
+

--- a/app/views/pages/_layout_select.slim
+++ b/app/views/pages/_layout_select.slim
@@ -1,9 +1,20 @@
 -# field: `:liquid_layout_id` or `:follow_up_liquid_layout_id`
 -# f: form builder
+-# offer_redirect: boolean, whether to offer a redirect
+- offer_redirect ||= false
 .radio-group.btn-group-vertical.layout-settings__button-group role="group"
   - LiquidLayout.campaigner_friendly.sort_by(&:title).each do |ll|
-    - active_class = (ll.id == f.object.send(field)) ? 'active' : ''
+    - liquid_matters = (!offer_redirect || f.object.follow_up_plan.to_sym == :with_liquid)
+    - active_class = (ll.id == f.object.send(field) && liquid_matters) ? 'active' : ''
     = f.label field, value: ll.id, class: "btn btn-default radio-group__option #{active_class}"
       = f.radio_button field, ll.id, class: 'hidden-irrelevant'
       span.layout-settings__title= ll.title
       span.layout-settings__description= ll.description
+  - if offer_redirect
+    - active_class = (f.object.follow_up_plan.to_sym == :with_page) ? 'active' : ''
+    = f.label :follow_up_plan, value: :with_page, class: "btn btn-default radio-group__option #{active_class}"
+      = f.radio_button :follow_up_plan, :with_page, class: 'hidden-irrelevant'
+      = f.radio_button :follow_up_plan, :with_liquid, class: 'hidden-irrelevant'
+      span.layout-settings__title Redirect to another page
+      span.layout-settings__description
+        = f.select :follow_up_page_id, options_from_collection_for_select(Page.all, 'id', 'title', f.object.follow_up_page_id), {}, html_options= {class: 'selectize-container', multiple: false}

--- a/app/views/pages/_layout_select.slim
+++ b/app/views/pages/_layout_select.slim
@@ -1,4 +1,4 @@
--# field: `:liquid_layout_id` or `:secondary_liquid_layout_id`
+-# field: `:liquid_layout_id` or `:follow_up_liquid_layout_id`
 -# f: form builder
 .radio-group.btn-group-vertical.layout-settings__button-group role="group"
   - LiquidLayout.campaigner_friendly.sort_by(&:title).each do |ll|

--- a/app/views/pages/_settings_form.slim
+++ b/app/views/pages/_settings_form.slim
@@ -14,17 +14,8 @@
       = render 'collapsing_layout_select', f: f, field: :liquid_layout_id, dom_name: 'primary', association: :liquid_layout
 
     .form-group
+      = f.label :liquid_layout_preview, t('pages.edit.follow_up_layout_select')
+      = render 'collapsing_layout_select', f: f, field: :follow_up_liquid_layout_id, dom_name: 'follow_up', association: :follow_up_liquid_layout, offer_redirect: true
 
-      = f.label :follow_up_plan, value: :with_liquid do
-        = f.radio_button :follow_up_plan, :with_liquid
-        | Render a post-action layout, like a share page
-
-      = f.label :follow_up_liquid_layout_id, t('pages.edit.follow_up_layout_select')
-      = render 'collapsing_layout_select', f: f, field: :follow_up_liquid_layout_id, dom_name: 'follow_up', association: :follow_up_liquid_layout
-
-      = f.label :follow_up_plan, value: :with_page do
-        = f.radio_button :follow_up_plan, :with_page
-        | Redirect to a different page on Champaign
-
-      = f.label :follow_up_page_id
-      = f.select :follow_up_page_id, options_from_collection_for_select(Page.all, 'id', 'title', page.follow_up_page_id), {}, html_options= {class: 'selectize-container', multiple: false}
+    javascript:
+      $.publish('layout:edit');

--- a/app/views/pages/_settings_form.slim
+++ b/app/views/pages/_settings_form.slim
@@ -14,5 +14,5 @@
       = render 'collapsing_layout_select', f: f, field: :liquid_layout_id, dom_name: 'primary', association: :liquid_layout
 
     .form-group
-      = f.label :secondary_liquid_layout_id, t('pages.edit.secondary_layout_select')
-      = render 'collapsing_layout_select', f: f, field: :secondary_liquid_layout_id, dom_name: 'secondary', association: :secondary_liquid_layout
+      = f.label :follow_up_liquid_layout_id, t('pages.edit.follow_up_layout_select')
+      = render 'collapsing_layout_select', f: f, field: :follow_up_liquid_layout_id, dom_name: 'follow_up', association: :follow_up_liquid_layout

--- a/app/views/pages/_settings_form.slim
+++ b/app/views/pages/_settings_form.slim
@@ -14,5 +14,17 @@
       = render 'collapsing_layout_select', f: f, field: :liquid_layout_id, dom_name: 'primary', association: :liquid_layout
 
     .form-group
+
+      = f.label :follow_up_plan, value: :with_liquid do
+        = f.radio_button :follow_up_plan, :with_liquid
+        | Render a post-action layout, like a share page
+
       = f.label :follow_up_liquid_layout_id, t('pages.edit.follow_up_layout_select')
       = render 'collapsing_layout_select', f: f, field: :follow_up_liquid_layout_id, dom_name: 'follow_up', association: :follow_up_liquid_layout
+
+      = f.label :follow_up_plan, value: :with_page do
+        = f.radio_button :follow_up_plan, :with_page
+        | Redirect to a different page on Champaign
+
+      = f.label :follow_up_page_id
+      = f.select :follow_up_page_id, options_from_collection_for_select(Page.all, 'id', 'title', page.follow_up_page_id), {}, html_options= {class: 'selectize-container', multiple: false}

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -42,7 +42,8 @@
       $(document).ready(function(){
         window.sumofus.myPetitionBar = new window.sumofus.PetitionBar({
           member:           window.sumofus.personalization.member,
-          outstandingFields:window.sumofus.personalization.outstandingFields
+          outstandingFields:window.sumofus.personalization.outstandingFields,
+          followUpUrl:      "{{ follow_up_url }}"
         });
       });
     </script>

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -87,9 +87,10 @@ en:
       extras: 'Extras'
       no_images_notice: "You haven't any photos. Drag your pics into the box below."
       layout_select: 'Page layout'
-      follow_up_layout_select: 'Page layout for follow-up page'
+      follow_up_layout_select: 'Follow-up action'
       no_layout: None selected
       change_layout: 'Change layout'
+      change_follow_up: 'Change follow up'
       add_link: 'Add source'
       language_label: "Language"
       primary_image: 'Which is the main image for the page?'

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -87,7 +87,7 @@ en:
       extras: 'Extras'
       no_images_notice: "You haven't any photos. Drag your pics into the box below."
       layout_select: 'Page layout'
-      secondary_layout_select: 'Page layout for follow-up page'
+      follow_up_layout_select: 'Page layout for follow-up page'
       no_layout: None selected
       change_layout: 'Change layout'
       add_link: 'Add source'

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -32,6 +32,7 @@ de:
     sign_it: Petition Unterschreiben
     target_prefix: AN
     confirmation: Ihr Name wurde übermittelt
+    excited_confirmation: Ihr Name wurde übermittelt!
     thank_you: 'Vielen Dank, dass Sie "%{petition_title}" mit Ihrer Unterschrift unterstützen.'
   form:
     welcome_back: Willkommen zurück

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -18,7 +18,7 @@ en:
     proceed_to_payment: Proceed to payment
     other_amount: Other
     make_recurring: Make my donation monthly
-    thank_you: Thank you for your donation
+    thank_you: Thank you for your donation!
     card_declined: Your card was declined by the payment processor. Please try a different payment method.
     unknown_error: Our technical team has been notified. Please double check your info or try a different payment method.
     fine_print: "SumOfUs is a registered 501(c)4 non-profit incorporated in Washington, DC, United States. Contributions or gifts to SumOfUs are not tax deductible. For further information, please contact info@sumofus.org."
@@ -32,7 +32,8 @@ en:
     sign_it: Sign the petition
     target_prefix: TO
     confirmation: Name submitted
-    thank_you: 'Thanks for adding your name to "%{petition_title}"'
+    excited_confirmation: Name submitted!
+    thank_you: 'Thanks for adding your name to "%{petition_title}"!'
   form:
     welcome_back: Welcome back
     switch_user: Not you?

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -32,7 +32,8 @@ fr:
     sign_it: Signez la pétition
     target_prefix: Pétition adressée à
     confirmation: Nom envoyé
-    thank_you: 'Merci d’avoir ajouté votre nom à la pétition "%{petition_title}"'
+    excited_confirmation: Nom envoyé!
+    thank_you: 'Merci d’avoir ajouté votre nom à la pétition "%{petition_title}"!'
   form:
     welcome_back: Bienvenue
     switch_user: Ce n’est pas vous?

--- a/db/migrate/20160125205126_rename_secondary_liquid_layout.rb
+++ b/db/migrate/20160125205126_rename_secondary_liquid_layout.rb
@@ -1,0 +1,5 @@
+class RenameSecondaryLiquidLayout < ActiveRecord::Migration
+  def change
+    rename_column :pages, :secondary_liquid_layout_id, :follow_up_liquid_layout_id
+  end
+end

--- a/db/migrate/20160125211650_add_follow_up_plan.rb
+++ b/db/migrate/20160125211650_add_follow_up_plan.rb
@@ -1,0 +1,6 @@
+class AddFollowUpPlan < ActiveRecord::Migration
+  def change
+    add_column :pages, :follow_up_plan, :integer, default: 0, null: false
+    add_reference :pages, :follow_up_page, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160118124847) do
+ActiveRecord::Schema.define(version: 20160125205126) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,16 +182,16 @@ ActiveRecord::Schema.define(version: 20160118124847) do
     t.boolean  "featured",                   default: false
     t.boolean  "active",                     default: false
     t.integer  "liquid_layout_id"
-    t.integer  "secondary_liquid_layout_id"
+    t.integer  "follow_up_liquid_layout_id"
     t.integer  "action_count",               default: 0
     t.integer  "primary_image_id"
     t.string   "ak_petition_resource_uri"
     t.string   "ak_donation_resource_uri"
   end
 
+  add_index "pages", ["follow_up_liquid_layout_id"], name: "index_pages_on_follow_up_liquid_layout_id", using: :btree
   add_index "pages", ["liquid_layout_id"], name: "index_pages_on_liquid_layout_id", using: :btree
   add_index "pages", ["primary_image_id"], name: "index_pages_on_primary_image_id", using: :btree
-  add_index "pages", ["secondary_liquid_layout_id"], name: "index_pages_on_secondary_liquid_layout_id", using: :btree
 
   create_table "pages_tags", force: :cascade do |t|
     t.integer "page_id"
@@ -394,7 +394,7 @@ ActiveRecord::Schema.define(version: 20160118124847) do
   add_foreign_key "pages", "images", column: "primary_image_id"
   add_foreign_key "pages", "languages"
   add_foreign_key "pages", "liquid_layouts"
-  add_foreign_key "pages", "liquid_layouts", column: "secondary_liquid_layout_id"
+  add_foreign_key "pages", "liquid_layouts", column: "follow_up_liquid_layout_id"
   add_foreign_key "payment_braintree_customers", "members"
   add_foreign_key "payment_braintree_subscriptions", "pages"
   add_foreign_key "payment_braintree_transactions", "pages"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160125205126) do
+ActiveRecord::Schema.define(version: 20160125211650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -187,9 +187,12 @@ ActiveRecord::Schema.define(version: 20160125205126) do
     t.integer  "primary_image_id"
     t.string   "ak_petition_resource_uri"
     t.string   "ak_donation_resource_uri"
+    t.integer  "follow_up_plan",             default: 0,         null: false
+    t.integer  "follow_up_page_id"
   end
 
   add_index "pages", ["follow_up_liquid_layout_id"], name: "index_pages_on_follow_up_liquid_layout_id", using: :btree
+  add_index "pages", ["follow_up_page_id"], name: "index_pages_on_follow_up_page_id", using: :btree
   add_index "pages", ["liquid_layout_id"], name: "index_pages_on_liquid_layout_id", using: :btree
   add_index "pages", ["primary_image_id"], name: "index_pages_on_primary_image_id", using: :btree
 

--- a/spec/controllers/api/actions_controller_spec.rb
+++ b/spec/controllers/api/actions_controller_spec.rb
@@ -42,8 +42,8 @@ describe Api::ActionsController do
         )
       end
 
-      it "responds with the follow-up url" do
-        expect(response.body).to eq({ follow_up_url: follow_up_page_path(2) }.to_json)
+      it "responds with an empty hash" do
+        expect(response.body).to eq({}.to_json)
       end
 
       it 'sets the cookie' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -4,7 +4,7 @@ describe PagesController do
   let(:user) { instance_double('User', id: '1') }
   let(:default_language) { instance_double(Language, code: :en) }
   let(:language) { instance_double(Language, code: :fr) }
-  let(:page) { instance_double('Page', active?: true, featured?: true, id: '1', liquid_layout: '3', secondary_liquid_layout: '4', language: default_language) }
+  let(:page) { instance_double('Page', active?: true, featured?: true, id: '1', liquid_layout: '3', follow_up_liquid_layout: '4', language: default_language) }
   let(:renderer) { instance_double('LiquidRenderer', render: 'my rendered html', data: { some: 'data'}) }
 
   before do
@@ -204,7 +204,7 @@ describe PagesController do
       expect(LiquidRenderer).to have_received(:new).with(page,
         location: {},
         member: nil,
-        layout: page.secondary_liquid_layout,
+        layout: page.follow_up_liquid_layout,
         url_params: {"id"=>"1", "controller"=>"pages", "action"=>"follow_up"}
       )
       expect(renderer).to have_received(:render)

--- a/spec/liquid/liquid_renderer_spec.rb
+++ b/spec/liquid/liquid_renderer_spec.rb
@@ -22,7 +22,7 @@ describe LiquidRenderer do
 
     it 'does not receive arbitrary keyword arguments' do
       expect{
-        LiquidRenderer.new(page, layout: liquid_layout, secondary_layout: liquid_layout)
+        LiquidRenderer.new(page, layout: liquid_layout, follow_up_layout: liquid_layout)
       }.to raise_error(ArgumentError)
     end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -23,11 +23,17 @@ describe Page do
   it { is_expected.to respond_to :pages_tags }
   it { is_expected.to respond_to :campaign }
   it { is_expected.to respond_to :liquid_layout }
-  it { is_expected.to respond_to :secondary_liquid_layout }
+  it { is_expected.to respond_to :follow_up_liquid_layout }
+  it { is_expected.to respond_to :follow_up_page }
+  it { is_expected.to respond_to :follow_up_plan }
+  it { is_expected.to respond_to :with_liquid? }
+  it { is_expected.to respond_to :with_page? }
   it { is_expected.to respond_to :primary_image }
   it { is_expected.to respond_to :plugins }
   it { is_expected.to respond_to :shares }
   it { is_expected.to respond_to :action_count }
+
+  it { is_expected.not_to respond_to :secondary_liquid_layout }
 
   describe 'tags' do
 
@@ -299,5 +305,13 @@ describe Page do
       end
     end
   end
+
+  describe 'follow_up_plan' do
+    it 'defaults to :with_liquid' do
+      new_page = create :page
+      expect(page.follow_up_plan).to eq 'with_liquid'
+    end
+  end
+
 end
 

--- a/spec/services/page_follower_spec.rb
+++ b/spec/services/page_follower_spec.rb
@@ -64,6 +64,11 @@ describe PageFollower do
           expect(result).to eq page_path(follow_up_page_id)
         end
 
+        it 'returns page path when liquid_layout is passed and plan is a string' do
+          result = PageFollower.new(plan.to_s, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
+          expect(result).to eq page_path(follow_up_page_id)
+        end
+
         it 'returns page path when liquid_layout is blank' do
           result = PageFollower.new(plan, page_id, nil, follow_up_page_id).follow_up_path
           expect(result).to eq page_path(follow_up_page_id)
@@ -84,6 +89,21 @@ describe PageFollower do
           PageFollower.new(nil, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
         }.to raise_error ArgumentError
       end
+    end
+  end
+
+  describe 'new_from_page' do
+
+    let(:page) { instance_double('Page', follow_up_plan: 'with_liquid', id: 2, follow_up_liquid_layout_id: 3, follow_up_page_id: 4) }
+
+    it 'calls with page attributes' do
+      allow(PageFollower).to receive(:new)
+      PageFollower.new_from_page(page)
+      expect(PageFollower).to have_received(:new).with('with_liquid', 2, 3, 4)
+    end
+
+    it 'returns the instance for call chaining' do
+      expect(PageFollower.new_from_page(page).follow_up_path).to eq follow_up_page_path(2)
     end
   end
 

--- a/spec/services/page_follower_spec.rb
+++ b/spec/services/page_follower_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+describe PageFollower do
+  include Rails.application.routes.url_helpers
+
+  let(:page_id) { 1 }
+  let(:follow_up_page_id) { 2 }
+  let(:follow_up_layout_id) { 3 }
+
+  describe "follow_up_path" do
+
+    describe 'plan is :with_liquid' do
+
+      let(:plan) { :with_liquid }
+
+      describe 'while liquid_layout is blank' do
+        it 'returns page path when page is passed' do
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id).follow_up_path
+          expect(result).to eq page_path(follow_up_page_id)
+        end
+
+        it 'returns nil when page is blank' do
+          result = PageFollower.new(plan, page_id, nil, nil).follow_up_path
+          expect(result).to eq nil
+        end
+
+      end
+
+      describe 'while liquid_layout is passed' do
+        it 'returns liquid_layout path when page is passed' do
+          result = PageFollower.new(plan, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
+          expect(result).to eq follow_up_page_path(page_id)
+        end
+
+        it 'returns liquid_layout path when page is blank' do
+          result = PageFollower.new(plan, page_id, follow_up_layout_id, nil).follow_up_path
+          expect(result).to eq follow_up_page_path(page_id)
+        end
+
+      end
+
+    end
+
+    describe 'plan is :with_page' do
+
+      let(:plan) { :with_page }
+
+      describe 'while page is blank' do
+        it 'returns nil when liquid_layout is blank' do
+          result = PageFollower.new(plan, page_id, nil, nil).follow_up_path
+          expect(result).to eq nil
+        end
+
+        it 'returns liquid_layout path when liquid_layout is passed' do
+          result = PageFollower.new(plan, page_id, follow_up_layout_id, nil).follow_up_path
+          expect(result).to eq follow_up_page_path(page_id)
+        end
+
+      end
+
+      describe 'while page is passed' do
+        it 'returns page path when liquid_layout is passed' do
+          result = PageFollower.new(plan, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
+          expect(result).to eq page_path(follow_up_page_id)
+        end
+
+        it 'returns page path when liquid_layout is blank' do
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id).follow_up_path
+          expect(result).to eq page_path(follow_up_page_id)
+        end
+      end
+    end
+
+    describe 'plan is anything else' do
+
+      it 'raises error if plan is :with_link' do
+        expect{
+          PageFollower.new(nil, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
+        }.to raise_error ArgumentError
+      end
+
+      it 'raises error if plan is blank' do
+        expect{
+          PageFollower.new(nil, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
+        }.to raise_error ArgumentError
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This PR completes @paulaferris's long requested feature to be able to daisy-chain pages together. it allows a campaigner to pick the name of a page that it should redirect to after the action is completed.

![daisy-chain](https://cloud.githubusercontent.com/assets/102218/12597898/d23af1e0-c44c-11e5-8045-b16bfd6b390b.gif)

It also has a fix for a UI bug where the petition stickiness would jump and german "Sign the petition" would wrap in an awkward way.