### PR TITLE
Make member_id cookie last two years

### DIFF
--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -9,7 +9,7 @@ class Api::ActionsController < ApplicationController
       action = ManageAction.create(@action_params)
       cookies.signed[:member_id] = {
         value: action.member.id,
-        expires: 1.hour.from_now
+        expires: 2.years.from_now
       }
       render json: {}, status: 200
     else


### PR DESCRIPTION
I had set it to an hour at the beginning, so it expired much too fast.