### PR TITLE
[PRE DEPLOY] Move some assets to bottom of page

### DIFF
--- a/app/views/layouts/sumofus.slim
+++ b/app/views/layouts/sumofus.slim
@@ -2,18 +2,21 @@ doctype html
 html
   head
     title  = @page.title
-    = render partial: 'shared/optimizely_snippet'
     meta name="viewport" content="width=device-width, initial-scale=1.0"
     meta name="description" content=t('branding.description')
     = stylesheet_link_tag "sumofus"
     = javascript_include_tag "sumofus"
+    = render partial: 'shared/optimizely_snippet'
     = render partial: 'shared/js_locale'
-    script type="text/javascript" charset="utf-8" async=true src="//c.shpg.org/99/sp.js"
     = csrf_meta_tags
     = favicon_link_tag 'sumofus/favicon.ico'
     = metamagic
+
 
   body
     = yield
 
     .mobile-indicator
+
+    script type="text/javascript" charset="utf-8" async=true src="//c.shpg.org/99/sp.js"
+

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-staging' 'champaign-assets-staging' 'logs3.papertrailapp.com:34848' 'action-staging.sumofus.org'
   testing:
     # Change the branch value to your branch name to push up your branch to the testing server automatically.
-    branch: customize-nginx
+    branch: google_site_speed
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web


### PR DESCRIPTION
Tiny PR. I had hoped to move our sumofus js asset file also, but the json object we print half way down the body is dependent on `jquery` and `PetitionBar` (it's a bigger job for another day).