### PR TITLE
[Pre-release] Webhook

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -82,13 +82,17 @@ module Payment
   class BraintreeTransactionBuilder
     #
     # Stores and associates a Braintree transaction as +Payment::BraintreeTransaction+. Builder will also
-    # create an instance of +Payment::BraintreeCustomer+, if it doesn't already exist.
+    # create or update an instance of +Payment::BraintreeCustomer+, if save_customer is passed
     #
     # === Options
     #
-    # * +:action+      - The ActiveRecord model of the corresponding action.
     # * +:bt_result+   - A Braintree::Transaction response object or a Braintree::Subscription response
     #                    (see https://developers.braintreepayments.com/reference/response/transaction/ruby)
+    #                    or a Braintree::WebhookNotification
+    # * +:page_id+     - the id of the Page to associate with the transaction record
+    # * +:member_id+   - the member_id to associate with the customer record
+    # * +:existing_customer+ - if passed, this customer is updated instead of creating a new one
+    # * +:save_customer+     - optional, default true. whether to save the customer info too
     #
     #
 

--- a/app/models/payment/braintree_subscription.rb
+++ b/app/models/payment/braintree_subscription.rb
@@ -1,3 +1,4 @@
 class Payment::BraintreeSubscription < ActiveRecord::Base
   belongs_to :page
+  belongs_to :action
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,7 +108,7 @@ Rails.application.routes.draw do
     namespace :braintree do
       get 'token'
       post 'pages/:page_id/transaction',  action: 'transaction', as: 'transaction'
-      post 'braintree/webhook', action: 'webhook'
+      post 'webhook', action: 'webhook'
     end
 
     resources :pages do

--- a/db/migrate/20160219174402_add_action_id_to_subscription.rb
+++ b/db/migrate/20160219174402_add_action_id_to_subscription.rb
@@ -1,0 +1,6 @@
+class AddActionIdToSubscription < ActiveRecord::Migration
+  def change
+    add_reference :payment_braintree_subscriptions, :action, index: true
+    add_index :payment_braintree_subscriptions, :subscription_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160218130351) do
+ActiveRecord::Schema.define(version: 20160219174402) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -231,9 +231,12 @@ ActiveRecord::Schema.define(version: 20160218130351) do
     t.integer  "page_id"
     t.decimal  "amount",              precision: 10, scale: 2
     t.string   "currency"
+    t.integer  "action_id"
   end
 
+  add_index "payment_braintree_subscriptions", ["action_id"], name: "index_payment_braintree_subscriptions_on_action_id", using: :btree
   add_index "payment_braintree_subscriptions", ["page_id"], name: "index_payment_braintree_subscriptions_on_page_id", using: :btree
+  add_index "payment_braintree_subscriptions", ["subscription_id"], name: "index_payment_braintree_subscriptions_on_subscription_id", using: :btree
 
   create_table "payment_braintree_transactions", force: :cascade do |t|
     t.string   "transaction_id"

--- a/lib/payment_processor/clients/braintree/subscription.rb
+++ b/lib/payment_processor/clients/braintree/subscription.rb
@@ -74,7 +74,7 @@ module PaymentProcessor
 
           Payment.write_customer(customer_result.customer, payment_method, @action.member_id, existing_customer)
           Payment.write_transaction(subscription_result, @page_id, @action.member_id, existing_customer, false)
-          Payment.write_subscription(subscription_result, @page_id, @currency)
+          Payment.write_subscription(subscription_result, @page_id, @action.id, @currency)
         end
 
         # we make 2 or 3 requests to braintree. if any of them fails, set it as the result

--- a/lib/payment_processor/clients/braintree/webhook_handler.rb
+++ b/lib/payment_processor/clients/braintree/webhook_handler.rb
@@ -1,0 +1,60 @@
+module PaymentProcessor
+  module Clients
+    module Braintree
+      class WebhookHandler
+        # = Braintree::Transaction
+        #
+        # Wrapper around Braintree's Ruby SDK. This class essentially just stuffs parameters
+        # into the keys that are expected by Braintree's class.
+        #
+        # == Usage
+        #
+        # Call <tt>PaymentProcessor::Clients::Braintree::Transaction.make_transaction</tt>
+        #
+        # === Options
+        #
+        # * +:nonce+    - Braintree token that references a payment method provided by the client (required)
+        # * +:amount+   - Billing amount (required)
+        # * +:currency+ - Billing currency (required)
+        # * +:user+     - Hash of information describing the customer. Must include email, and name (required)
+        # * +:customer+ - Instance of existing Braintree customer. Must respond to +customer_id+ (optional)
+        def self.handle(notification)
+          new(notification).handle
+        end
+
+        def initialize(notification)
+          @notification = notification
+        end
+
+        def handle
+          case @notification.kind
+          when 'subscription_charged_successfully'
+            handle_subscription_charged
+          else
+            Rails.logger.info("Unsupported Braintree::WebhookNotification received of type #{@notification.kind}")
+          end
+        end
+
+        private
+
+        def handle_subscription_charged
+          if original_action.blank?
+            Rails.logger.info("Failed to handle Braintree::WebhookNotification for subscription_id #{@notification.subscription_id}")
+            return
+          end
+          Payment.write_transaction(@notification, original_action.page_id, original_action.member_id, nil, false)
+          ActionQueue::Pusher.push(original_action)
+        end
+
+        # this method should only be called if @notification.subscription is a subscription object
+        def original_action
+          @action ||= Action.where('form_data @> ?', {
+            is_subscription: true,
+            subscription_id: @notification.subscription.id
+          }.to_json).first
+        end
+      end
+    end
+  end
+end
+

--- a/lib/payment_processor/clients/braintree/webhook_handler.rb
+++ b/lib/payment_processor/clients/braintree/webhook_handler.rb
@@ -2,22 +2,20 @@ module PaymentProcessor
   module Clients
     module Braintree
       class WebhookHandler
-        # = Braintree::Transaction
+        # = Braintree::WebhookHandler
         #
-        # Wrapper around Braintree's Ruby SDK. This class essentially just stuffs parameters
-        # into the keys that are expected by Braintree's class.
+        # This class serves to record data passed in by Braintree's webhook service.
+        # Currently, this just means that when a subscription is charged, it will create
+        # a Payment::BraintreeTransaction and push the original action to the Queue.
         #
         # == Usage
         #
-        # Call <tt>PaymentProcessor::Clients::Braintree::Transaction.make_transaction</tt>
+        # Call <tt>PaymentProcessor::Clients::Braintree::WebhookHandler.handle</tt>
         #
         # === Options
         #
-        # * +:nonce+    - Braintree token that references a payment method provided by the client (required)
-        # * +:amount+   - Billing amount (required)
-        # * +:currency+ - Billing currency (required)
-        # * +:user+     - Hash of information describing the customer. Must include email, and name (required)
-        # * +:customer+ - Instance of existing Braintree customer. Must respond to +customer_id+ (optional)
+        # * +:notification+    - Braintree::Notification object. only those of kind 'subscription_charged_successfully'
+        #                        will be processed. All others will simply be logged to the Rails logger.l)
         def self.handle(notification)
           new(notification).handle
         end

--- a/lib/payment_processor/clients/braintree/webhook_handler.rb
+++ b/lib/payment_processor/clients/braintree/webhook_handler.rb
@@ -31,7 +31,7 @@ module PaymentProcessor
           when 'subscription_charged_successfully'
             handle_subscription_charged
           else
-            Rails.logger.info("Unsupported Braintree::WebhookNotification received of type #{@notification.kind}")
+            Rails.logger.info("Unsupported Braintree::WebhookNotification received of type '#{@notification.kind}'")
           end
         end
 
@@ -39,7 +39,7 @@ module PaymentProcessor
 
         def handle_subscription_charged
           if original_action.blank?
-            Rails.logger.info("Failed to handle Braintree::WebhookNotification for subscription_id #{@notification.subscription_id}")
+            Rails.logger.info("Failed to handle Braintree::WebhookNotification for subscription_id '#{@notification.subscription.id}'")
             return
           end
           Payment.write_transaction(@notification, original_action.page_id, original_action.member_id, nil, false)

--- a/lib/payment_processor/clients/braintree/webhook_handler.rb
+++ b/lib/payment_processor/clients/braintree/webhook_handler.rb
@@ -48,10 +48,10 @@ module PaymentProcessor
 
         # this method should only be called if @notification.subscription is a subscription object
         def original_action
-          @action ||= Action.where('form_data @> ?', {
-            is_subscription: true,
+          return @action unless @action.blank?
+          @action = Payment::BraintreeSubscription.find_by(
             subscription_id: @notification.subscription.id
-          }.to_json).first
+          ).try(:action)
         end
       end
     end

--- a/spec/controllers/api/braintree_controller_spec.rb
+++ b/spec/controllers/api/braintree_controller_spec.rb
@@ -186,15 +186,19 @@ describe Api::BraintreeController do
 
     it 'parses a supported webhook and passes it to the Webhook handler' do
       post :webhook, supported_webhook
-      expect(PaymentProcessor::Clients::Braintree::WebhookHandler).to have_received(:handle).with(
-        instance_of(Braintree::WebhookNotification::Kind::SubscriptionChargedSuccessfully)
+      expect(
+        PaymentProcessor::Clients::Braintree::WebhookHandler
+      ).to have_received(:handle).with(
+        an_instance_of(Braintree::WebhookNotification)
       )
     end
 
     it 'parse an unsupported_webhook and passes it to the Webhook handler' do
       post :webhook, unsupported_webhook
-      expect(PaymentProcessor::Clients::Braintree::WebhookHandler).to have_received(:handle).with(
-        instance_of(Braintree::WebhookNotification::Kind::SubscriptionCanceled)
+      expect(
+        PaymentProcessor::Clients::Braintree::WebhookHandler
+      ).to have_received(:handle).with(
+        an_instance_of(Braintree::WebhookNotification)
       )
     end
 

--- a/spec/lib/payment_processor/clients/braintree/subscription_spec.rb
+++ b/spec/lib/payment_processor/clients/braintree/subscription_spec.rb
@@ -19,7 +19,7 @@ module PaymentProcessor
               }
             }
           end
-          let(:action) { instance_double('Action', member_id: 654) }
+          let(:action) { instance_double('Action', member_id: 654, id: 77) }
           let(:customer_token) { 'asdfghjkl' }
           let(:payment_method_token) { 'qwertyuiop' }
           let(:customer_success) { instance_double('Braintree::SuccessResult', success?: true, customer: double(payment_methods: [double(token: customer_token)])) }
@@ -221,7 +221,7 @@ module PaymentProcessor
                   end
 
                   it 'calls Payment.write_subscription with the right params' do
-                    expect(Payment).to have_received(:write_subscription).with(subscription_success, '12', 'AUD')
+                    expect(Payment).to have_received(:write_subscription).with(subscription_success, '12', 77, 'AUD')
                   end
                 end
               end
@@ -356,7 +356,7 @@ module PaymentProcessor
                 end
 
                 it 'calls Payment.write_subscription with the right params' do
-                  expect(Payment).to have_received(:write_subscription).with(subscription_success, '12', 'AUD')
+                  expect(Payment).to have_received(:write_subscription).with(subscription_success, '12', 77, 'AUD')
                 end
               end
             end

--- a/spec/lib/payment_processor/clients/braintree/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/clients/braintree/webhook_handler_spec.rb
@@ -1,0 +1,107 @@
+require 'rails_helper'
+
+module PaymentProcessor
+  module Clients
+    module Braintree
+      describe WebhookHandler do
+        describe '.handle' do
+
+          let(:action) { build :action, page_id: 1, member_id: 2 }
+          before :each do
+            allow(Payment).to receive(:write_transaction)
+            allow(ActionQueue::Pusher).to receive(:push)
+            allow(Rails.logger).to receive(:info)
+          end
+
+          describe 'with successful subscription charge' do
+
+            let(:notification) do
+              instance_double('Braintree::WebhookNotification', kind: 'subscription_charged_successfully',
+                subscription: instance_double('Braintree::Subscription', id: 's09870')
+              )
+            end
+
+            describe 'when Action is found' do
+
+              before :each do
+                allow(Action).to receive(:where).and_return([action])
+                WebhookHandler.handle(notification)
+              end
+
+              it 'looks up action by subscription_id' do
+                expect(Action).to have_received(:where).with('form_data @> ?', {
+                  is_subscription: true,
+                  subscription_id: notification.subscription.id
+                }.to_json)
+              end
+
+              it 'pushes the action to ActionQueue::Pusher' do
+                expect(ActionQueue::Pusher).to have_received(:push).with(action)
+              end
+
+              it 'records to Payment.write_transaction' do
+                expect(Payment).to have_received(:write_transaction).with(
+                  notification, action.page_id, action.member_id, nil, false
+                )
+              end
+
+              it 'does not log anything' do
+                expect(Rails.logger).not_to have_received(:info)
+              end
+            end
+
+            describe 'when Action is not found' do
+
+              before :each do
+                allow(Action).to receive(:where).and_return([])
+                WebhookHandler.handle(notification)
+              end
+
+              it 'does not write to Payment.write_transaction' do
+                expect(Payment).not_to have_received(:write_transaction)
+              end
+
+              it 'does not push to ActionQueue::Pusher' do
+                expect(ActionQueue::Pusher).not_to have_received(:push)
+              end
+
+              it 'logs the failed handling' do
+                expect(Rails.logger).to have_received(:info).with("Failed to handle Braintree::WebhookNotification for subscription_id 's09870'")
+              end
+            end
+          end
+
+          describe 'with subscription cancelation' do
+
+            let(:notification) do
+              instance_double('Braintree::WebhookNotification', kind: 'subscription_canceled',
+                subscription: instance_double('Braintree::Subscription', id: 's09870')
+              )
+            end
+
+            before :each do
+              allow(Action).to receive(:where)
+              WebhookHandler.handle(notification)
+            end
+
+            it 'does not look up the action' do
+              expect(Action).not_to have_received(:where)
+            end
+
+            it 'does not write to Payment.write_transaction' do
+              expect(Payment).not_to have_received(:write_transaction)
+            end
+
+            it 'does not push to ActionQueue::Pusher' do
+              expect(ActionQueue::Pusher).not_to have_received(:push)
+            end
+
+            it 'logs the failed handling' do
+              expect(Rails.logger).to have_received(:info).with("Unsupported Braintree::WebhookNotification received of type 'subscription_canceled'")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/payment/braintree_subscription_spec.rb
+++ b/spec/models/payment/braintree_subscription_spec.rb
@@ -13,6 +13,8 @@ describe Payment::BraintreeSubscription do
   it { is_expected.to respond_to :updated_at }
   it { is_expected.to respond_to :page_id }
   it { is_expected.to respond_to :page }
+  it { is_expected.to respond_to :action }
+  it { is_expected.to respond_to :action_id }
 
   it { is_expected.to_not respond_to :customer_id }
   it { is_expected.to_not respond_to :price }

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -35,19 +35,20 @@ describe Payment do
     end
 
     it 'saves relevant fields when successful' do
-      Payment.write_subscription(success_result, 'my_page_id', 'my_currency')
+      Payment.write_subscription(success_result, 'my_page_id', 'my_action_id', 'my_currency')
       expect(Payment::BraintreeSubscription).to have_received(:create).with({
         subscription_id:        'lol',
         amount:                 12,
         merchant_account_id:    'EUR',
         currency:               'my_currency',
-        page_id:                'my_page_id'
+        page_id:                'my_page_id',
+        action_id:              'my_action_id'
       })
     end
 
     it 'does not record when unsuccessful' do
       expect{
-        Payment.write_subscription(failure_result, 'my_page_id', 'my_currency')
+        Payment.write_subscription(failure_result, 'my_page_id', 'my_action_id', 'my_currency')
       }.not_to change{ Payment::BraintreeSubscription.count }
       expect(Payment::BraintreeSubscription).not_to have_received(:create)
     end

--- a/spec/requests/api/braintree_spec.rb
+++ b/spec/requests/api/braintree_spec.rb
@@ -602,6 +602,7 @@ describe "Braintree API" do
               expect(subscription.merchant_account_id).to eq 'EUR'
               expect(subscription.subscription_id).to match a_string_matching(token_format)
               expect(subscription.page).to eq page
+              expect(subscription.action).to eq Action.last
             end
 
             it "updates Payment::BraintreeCustomer with new token and last_4" do
@@ -849,6 +850,7 @@ describe "Braintree API" do
               expect(subscription.merchant_account_id).to eq 'EUR'
               expect(subscription.subscription_id).to match a_string_matching(token_format)
               expect(subscription.page).to eq page
+              expect(subscription.action).to eq Action.last
             end
 
             it "creates a Payment::BraintreeCustomer with new token, customer_id, and last_4" do

--- a/spec/requests/api/braintree_webhook_spec.rb
+++ b/spec/requests/api/braintree_webhook_spec.rb
@@ -1,0 +1,122 @@
+require 'rails_helper'
+
+describe "Braintree API" do
+
+  let(:page) { create(:page, title: 'Cash rules everything around me') }
+  let(:form) { create(:form) }
+  let(:four_digits) { /[0-9]{4}/ }
+  let(:token_format) { /[a-z0-9]{1,36}/i }
+  let(:user_params) do
+    {
+      form_id: form.id,
+      name: "Bernie Sanders",
+      email: "itsme@feelthebern.org",
+      postal: "11225",
+      address1: '25 Elm Drive',
+      source: 'fb',
+      country: "US"
+    }
+  end
+  let(:setup_params) do
+    {
+      currency: 'EUR',
+      payment_method_nonce: 'fake-valid-nonce',
+      recurring: true,
+      user: user_params
+    }
+  end
+
+  before :each do
+    allow(ChampaignQueue).to receive(:push)
+    allow(Analytics::Page).to receive(:increment)
+  end
+
+  describe 'receiving a webhook' do
+    describe 'of a subscription charge' do
+      let(:notification) do
+        Braintree::WebhookTesting.sample_notification(
+          Braintree::WebhookNotification::Kind::SubscriptionChargedSuccessfully,
+          Payment::BraintreeSubscription.last.subscription_id
+        )
+      end
+      subject{ post api_braintree_webhook_path, notification }
+
+      describe 'for a credit card' do
+        let(:amount) { 813.20 }
+        let(:params) { setup_params.merge(payment_method_nonce: 'fake-valid-nonce', amount: amount ) }
+
+        before :each do
+          # rather than set up a fake testing environment, let the success test set it up for us
+          VCR.use_cassette("subscription success basic new customer") do
+            post api_braintree_transaction_path(page.id), params
+          end
+        end
+
+        it 'creates a Payment::BraintreeTransaction record with the right params' do
+          expect{ subject }.to change{ Payment::BraintreeTransaction.count }.by 1
+
+        end
+
+        it 'pushes to the queue with the right params' do
+          expect(ChampaignQueue).to receive(:push).with({
+            type: "donation",
+            params: {
+              donationpage: {
+                name: "cash-rules-everything-around-me-donation",
+                payment_account: "Braintree EUR"
+              },
+              order: {
+                amount: amount.to_s,
+                card_num: "1881",
+                card_code: "007",
+                exp_date_month: "12",
+                exp_date_year: "2020",
+                currency: "EUR"
+              },
+              user: {
+                email: "itsme@feelthebern.org",
+                country: "US",
+                postal: "11225",
+                address1: '25 Elm Drive',
+                source: 'fb',
+                first_name: 'Bernie',
+                last_name: 'Sanders'
+              },
+              action: {
+                source: 'fb'
+              }
+            }
+          })
+          subject
+        end
+
+        it 'does not create an Action' do
+          expect{ subject }.not_to change{ Action.count }
+        end
+
+        it 'does not modify the Member' do
+          member = Member.last
+          expect{ subject }.not_to change{ Member.count }
+          expect(Member.last).to eq member
+        end
+
+        it 'does not modify the Payment::BraintreeSubscription' do
+          subscription = Payment::BraintreeSubscription.last
+          expect{ subject }.not_to change{ Payment::BraintreeSubscription.count }
+          expect(Payment::BraintreeSubscription.last).to eq subscription
+        end
+
+        it 'does not modify the Payment::BraintreeCustomer' do
+          customer = Payment::BraintreeCustomer.last
+          expect{ subject }.not_to change{ Payment::BraintreeCustomer.count }
+          expect(Payment::BraintreeCustomer.last).to eq customer
+        end
+
+        it 'returns 200' do
+          expect{ subject }.not_to raise_error
+          expect(response.status).to eq 200
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/braintree_webhook_spec.rb
+++ b/spec/requests/api/braintree_webhook_spec.rb
@@ -31,6 +31,35 @@ describe "Braintree API" do
     allow(Analytics::Page).to receive(:increment)
   end
 
+  shared_examples "has no unintended consequences" do
+    it 'does not create an Action' do
+      expect{ subject }.not_to change{ Action.count }
+    end
+
+    it 'does not modify the Member' do
+      member = Member.last
+      expect{ subject }.not_to change{ Member.count }
+      expect(Member.last).to eq member
+    end
+
+    it 'does not modify the Payment::BraintreeSubscription' do
+      subscription = Payment::BraintreeSubscription.last
+      expect{ subject }.not_to change{ Payment::BraintreeSubscription.count }
+      expect(Payment::BraintreeSubscription.last).to eq subscription
+    end
+
+    it 'does not modify the Payment::BraintreeCustomer' do
+      customer = Payment::BraintreeCustomer.last
+      expect{ subject }.not_to change{ Payment::BraintreeCustomer.count }
+      expect(Payment::BraintreeCustomer.last).to eq customer
+    end
+
+    it 'returns 200' do
+      expect{ subject }.not_to raise_error
+      expect(response.status).to eq 200
+    end
+  end
+
   describe 'receiving a webhook' do
     describe 'of a subscription charge' do
       let(:notification) do
@@ -54,7 +83,7 @@ describe "Braintree API" do
 
         it 'creates a Payment::BraintreeTransaction record with the right params' do
           expect{ subject }.to change{ Payment::BraintreeTransaction.count }.by 1
-
+          expect(Payment::BraintreeTransaction.last.page_id).to eq(page.id)
         end
 
         it 'pushes to the queue with the right params' do
@@ -90,32 +119,92 @@ describe "Braintree API" do
           subject
         end
 
-        it 'does not create an Action' do
-          expect{ subject }.not_to change{ Action.count }
+        include_examples "has no unintended consequences"
+      end
+
+      describe 'for paypal' do
+
+        let(:amount) { 819.20 } # to avoid duplicate donations recording specs
+        let(:params) { setup_params.merge(user: user_params, payment_method_nonce: 'fake-paypal-future-nonce', amount: amount) }
+
+        before :each do
+          VCR.use_cassette("subscription success paypal new customer") do
+            post api_braintree_transaction_path(page.id), params
+          end
         end
 
-        it 'does not modify the Member' do
-          member = Member.last
-          expect{ subject }.not_to change{ Member.count }
-          expect(Member.last).to eq member
+        it 'creates a Payment::BraintreeTransaction record with the right params' do
+          expect{ subject }.to change{ Payment::BraintreeTransaction.count }.by 1
+          expect(Payment::BraintreeTransaction.last.page_id).to eq(page.id)
         end
 
-        it 'does not modify the Payment::BraintreeSubscription' do
-          subscription = Payment::BraintreeSubscription.last
-          expect{ subject }.not_to change{ Payment::BraintreeSubscription.count }
-          expect(Payment::BraintreeSubscription.last).to eq subscription
+        it 'pushes to the queue with the right params' do
+          expect(ChampaignQueue).to receive(:push).with({
+            type: "donation",
+            params: {
+              donationpage: {
+                name: "cash-rules-everything-around-me-donation",
+                payment_account: "PayPal EUR"
+              },
+              order: {
+                amount: amount.to_s,
+                card_num: "PYPL",
+                card_code: "007",
+                exp_date_month: Time.now.month.to_s,
+                exp_date_year: 5.years.from_now.year.to_s,
+                currency: "EUR"
+              },
+              user: {
+                email: "itsme@feelthebern.org",
+                country: "US",
+                postal: "11225",
+                address1: '25 Elm Drive',
+                source: 'fb',
+                first_name: 'Bernie',
+                last_name: 'Sanders'
+              },
+              action: {
+                source: 'fb'
+              }
+            }
+          })
+          subject
         end
 
-        it 'does not modify the Payment::BraintreeCustomer' do
-          customer = Payment::BraintreeCustomer.last
-          expect{ subject }.not_to change{ Payment::BraintreeCustomer.count }
-          expect(Payment::BraintreeCustomer.last).to eq customer
+        include_examples "has no unintended consequences"
+      end
+    end
+
+    describe 'of a subscription cancelation' do
+      let(:notification) do
+        Braintree::WebhookTesting.sample_notification(
+          Braintree::WebhookNotification::Kind::SubscriptionCanceled,
+          Payment::BraintreeSubscription.last.subscription_id
+        )
+      end
+      subject{ post api_braintree_webhook_path, notification }
+
+      describe 'for a credit card' do
+        let(:amount) { 813.20 }
+        let(:params) { setup_params.merge(payment_method_nonce: 'fake-valid-nonce', amount: amount ) }
+
+        before :each do
+          # rather than set up a fake testing environment, let the success test set it up for us
+          VCR.use_cassette("subscription success basic new customer") do
+            post api_braintree_transaction_path(page.id), params
+          end
         end
 
-        it 'returns 200' do
-          expect{ subject }.not_to raise_error
-          expect(response.status).to eq 200
+        it 'does not post to the ChampaignQueue' do
+          expect(ChampaignQueue).not_to receive(:push)
+          subject
         end
+
+        it 'does not create a transaction' do
+          expect{ subject }.not_to change{ Payment::BraintreeTransaction.count }
+        end
+
+        include_examples "has no unintended consequences"
       end
     end
   end


### PR DESCRIPTION
This PR refactors the webhook method into a service class. It also simplifies the logic quite a bit by looking up the original Action by subscription_id, then just pushing that same Action directly to the queue. It will have unit tests on the controller and class, and it has an integration spec.