### PR TITLE
Page short links

### DIFF
--- a/app/services/page_follower.rb
+++ b/app/services/page_follower.rb
@@ -26,11 +26,11 @@ class PageFollower
   private
 
   def path_to_follow_up_page
-    page_path(@follow_up_page_slug) unless @follow_up_page_slug.blank?
+    member_facing_page_path(@follow_up_page_slug) unless @follow_up_page_slug.blank?
   end
 
   def path_to_follow_up_layout
-    follow_up_page_path(@page_slug) unless @page_slug.blank? || @follow_up_liquid_layout_id.blank?
+    follow_up_member_facing_page_path(@page_slug) unless @page_slug.blank? || @follow_up_liquid_layout_id.blank?
   end
 end
 

--- a/app/views/pages/_sidebar.slim
+++ b/app/views/pages/_sidebar.slim
@@ -24,7 +24,7 @@
           = link_to analytics_page_path(page), class: "sidebar__secondary-link #{other_class}"
             i.fa.fa-area-chart
             | Analyze
-          = link_to page, class: "sidebar__secondary-link"
+          = link_to member_facing_page_path(page), class: "sidebar__secondary-link"
             i.fa.fa-eye
             | View
 

--- a/app/views/pages/edit.slim
+++ b/app/views/pages/edit.slim
@@ -25,10 +25,10 @@ section.page-edit-step#sources data-icon='link'
   h1.page-edit-step__title = t('.sources')
   = render 'link_form', page: @page
 
-section.page-edit-step.page-edit-step--just-title#review data-icon='eye' data-link-to=page_url(@page)
+section.page-edit-step.page-edit-step--just-title#review data-icon='eye' data-link-to=member_facing_page_url(@page)
   h1.page-edit-step__title
     = t('.view')
-    = link_to @page, target: "_blank"  do
+    = link_to member_facing_page_path(@page), target: "_blank"  do
       button.btn-primary.btn.pull-right
         = t('.show')
 

--- a/app/views/pages/index.slim
+++ b/app/views/pages/index.slim
@@ -30,7 +30,7 @@
               td = page.created_at.strftime('%Y-%b-%d')
               td = page.updated_at.strftime('%Y-%b-%d')
               td = page.actions.count
-              td = link_to t('pages.edit.view'), page
+              td = link_to t('pages.edit.view'), member_facing_page_path(page)
               td = link_to t('common.edit'), edit_page_path(page)
               td = link_to t('.stats'), analytics_page_path(page)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,10 @@ Rails.application.routes.draw do
     get 'plugins/:type/:id', to: 'plugins#show', as: 'plugin'
   end
 
+  resources :pages, path: 'a', as: 'member_facing_page', only: [:edit, :show] do
+    get 'follow-up', on: :member, action: 'follow_up'
+  end
+
   resources :forms do
     resources :form_elements do
       post :sort, on: :collection

--- a/spec/liquid/liquid_renderer_spec.rb
+++ b/spec/liquid/liquid_renderer_spec.rb
@@ -134,7 +134,7 @@ describe LiquidRenderer do
     end
 
     it 'has a follow_up_url' do
-      expect(subject.fetch('follow_up_url')).to match(/pages\/[a-z0-9\-]+\/follow\-up/)
+      expect(subject.fetch('follow_up_url')).to match(/a\/[a-z0-9\-]+\/follow\-up/)
     end
   end
 

--- a/spec/routing/pages_routing_spec.rb
+++ b/spec/routing/pages_routing_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+describe PagesController, type: :routing do
+  describe "routing" do
+
+    describe 'with /pages' do
+      it "routes to #index" do
+        expect(:get => "/pages").to route_to("pages#index")
+      end
+
+      it "routes to #new" do
+        expect(:get => "/pages/new").to route_to("pages#new")
+      end
+
+      it "routes to #edit" do
+        expect(:get => "/pages/my-slug/edit").to route_to("pages#edit", :id => "my-slug")
+      end
+
+      it "routes to #follow_up" do
+        expect(:get => "/pages/my-slug/follow-up").to route_to("pages#follow_up", :id => "my-slug")
+      end
+
+      it 'routes to #show' do
+        expect(:get => "/pages/my-slug").to route_to("pages#show", id: 'my-slug')
+      end
+
+      it "routes to #create" do
+        expect(:post => "/pages").to route_to("pages#create")
+      end
+
+      it "routes to #update via PUT" do
+        expect(:put => "/pages/my-slug").to route_to("pages#update", :id => "my-slug")
+      end
+
+      it "routes to #update via PATCH" do
+        expect(:patch => "/pages/my-slug").to route_to("pages#update", :id => "my-slug")
+      end
+
+      it "routes to #destroy" do
+        expect(:delete => "/pages/my-slug").to route_to("pages#destroy", :id => "my-slug")
+      end
+    end
+
+    describe 'with /a' do
+
+      describe 'route helpers' do
+        it "routes to #edit" do
+          expect(:get => edit_member_facing_page_path('my-slug')).to route_to("pages#edit", :id => "my-slug")
+        end
+
+        it "routes to #follow_up" do
+          expect(:get => follow_up_member_facing_page_path('my-slug')).to route_to("pages#follow_up", :id => "my-slug")
+        end
+
+        it 'routes to #show' do
+          expect(:get => member_facing_page_path('my-slug')).to route_to("pages#show", id: 'my-slug')
+        end
+      end
+
+      it "routes to #edit" do
+        expect(:get => "/a/my-slug/edit").to route_to("pages#edit", :id => "my-slug")
+      end
+
+      it "routes to #follow_up" do
+        expect(:get => "/a/my-slug/follow-up").to route_to("pages#follow_up", :id => "my-slug")
+      end
+
+      it 'routes to #show' do
+        expect(:get => "/a/my-slug").to route_to("pages#show", id: 'my-slug')
+      end
+
+      it "does not routes to #new" do
+        expect(:get => "/a/new").to route_to("pages#show", id: 'new')
+      end
+
+      it "does not route to #index" do
+        expect(:get => "/a" ).not_to be_routable
+      end
+
+      it "does not route to #create" do
+        expect(:post => "/a").not_to be_routable
+      end
+
+      it "does not route to #update via PUT" do
+        expect(:put => "/a/my-slug").not_to be_routable
+      end
+
+      it "does not route to #update via PATCH" do
+        expect(:patch => "/a/my-slug").not_to be_routable
+      end
+
+      it "does not route to #destroy" do
+        expect(:delete => "/a/my-slug").not_to be_routable
+      end
+    end
+
+  end
+end

--- a/spec/services/page_follower_spec.rb
+++ b/spec/services/page_follower_spec.rb
@@ -16,7 +16,7 @@ describe PageFollower do
       describe 'while liquid_layout is blank' do
         it 'returns page path when page is passed' do
           result = PageFollower.new(plan, page_id, nil, follow_up_page_id).follow_up_path
-          expect(result).to eq page_path(follow_up_page_id)
+          expect(result).to eq member_facing_page_path(follow_up_page_id)
         end
 
         it 'returns nil when page is blank' do
@@ -29,12 +29,12 @@ describe PageFollower do
       describe 'while liquid_layout is passed' do
         it 'returns liquid_layout path when page is passed' do
           result = PageFollower.new(plan, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
-          expect(result).to eq follow_up_page_path(page_id)
+          expect(result).to eq follow_up_member_facing_page_path(page_id)
         end
 
         it 'returns liquid_layout path when page is blank' do
           result = PageFollower.new(plan, page_id, follow_up_layout_id, nil).follow_up_path
-          expect(result).to eq follow_up_page_path(page_id)
+          expect(result).to eq follow_up_member_facing_page_path(page_id)
         end
 
       end
@@ -53,7 +53,7 @@ describe PageFollower do
 
         it 'returns liquid_layout path when liquid_layout is passed' do
           result = PageFollower.new(plan, page_id, follow_up_layout_id, nil).follow_up_path
-          expect(result).to eq follow_up_page_path(page_id)
+          expect(result).to eq follow_up_member_facing_page_path(page_id)
         end
 
       end
@@ -61,17 +61,17 @@ describe PageFollower do
       describe 'while page is passed' do
         it 'returns page path when liquid_layout is passed' do
           result = PageFollower.new(plan, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
-          expect(result).to eq page_path(follow_up_page_id)
+          expect(result).to eq member_facing_page_path(follow_up_page_id)
         end
 
         it 'returns page path when liquid_layout is passed and plan is a string' do
           result = PageFollower.new(plan.to_s, page_id, follow_up_layout_id, follow_up_page_id).follow_up_path
-          expect(result).to eq page_path(follow_up_page_id)
+          expect(result).to eq member_facing_page_path(follow_up_page_id)
         end
 
         it 'returns page path when liquid_layout is blank' do
           result = PageFollower.new(plan, page_id, nil, follow_up_page_id).follow_up_path
-          expect(result).to eq page_path(follow_up_page_id)
+          expect(result).to eq member_facing_page_path(follow_up_page_id)
         end
       end
     end
@@ -104,7 +104,7 @@ describe PageFollower do
     end
 
     it 'returns the instance for call chaining' do
-      expect(PageFollower.new_from_page(page).follow_up_path).to eq follow_up_page_path('astro-droid')
+      expect(PageFollower.new_from_page(page).follow_up_path).to eq follow_up_member_facing_page_path('astro-droid')
     end
   end
 


### PR DESCRIPTION
@edubsky suggested it would be better to use `/a/my-slug` instead of `/pages/my-slug` for member-facing pages, and it seemed like it was worth getting out before launch so we wouldn't have to deal with changing links after we sent them out.