### PR TITLE
Don't hide monthly subscription box when hiding credit card fields

### DIFF
--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -85,10 +85,12 @@
                 </div>
                 <div class="form__group">
                   <hr class="fundraiser-bar__step-connector fundraiser-bar__step-connector--static" />
-                  <label class="checkbox-label">
-                    <input class="fundraiser-bar__recurring" type="checkbox" name="recurring" /> {{ 'fundraiser.make_recurring' | t }}
-                  </label>
                 </div>
+              </div>
+              <div class="form__group">
+                <label class="checkbox-label">
+                  <input class="fundraiser-bar__recurring" type="checkbox" name="recurring" /> {{ 'fundraiser.make_recurring' | t }}
+                </label>
               </div>
               <button type="submit" class="button fundraiser-bar__submit-button">{{ 'form.submit' | t }}</button>
             </form>


### PR DESCRIPTION
There was a bug where going through the Paypal flow hid the recurring donation checkbox, so we couldn't upsell people. 

Before:
![paypal-subscription](https://cloud.githubusercontent.com/assets/102218/13261168/83a361dc-da24-11e5-88fd-8466ef35cf4d.gif)

After:
<img width="359" alt="screenshot 2016-02-23 11 54 17" src="https://cloud.githubusercontent.com/assets/102218/13261180/92da6362-da24-11e5-99e3-57d8ce2ca053.png">
