### PR TITLE
Pass akid through to donations

### DIFF
--- a/app/services/action_queue.rb
+++ b/app/services/action_queue.rb
@@ -71,6 +71,7 @@ module ActionQueue
           last_name:  member.last_name,
           email:      member.email,
           country:    member.country,
+          akid:       data[:akid],
           postal:     data[:postal],
           address1:   data[:address1],
           source:     data[:source]

--- a/spec/requests/api/braintree_spec.rb
+++ b/spec/requests/api/braintree_spec.rb
@@ -13,6 +13,7 @@ describe "Braintree API" do
       email: "itsme@feelthebern.org",
       postal: "11225",
       address1: '25 Elm Drive',
+      akid: '1234.5678.9910',
       source: 'fb',
       country: "US"
     }
@@ -124,6 +125,7 @@ describe "Braintree API" do
                     country: "US",
                     postal: "11225",
                     address1: '25 Elm Drive',
+                    akid: '1234.5678.9910',
                     source: 'fb',
                     first_name: 'Bernie',
                     last_name: 'Sanders'
@@ -334,6 +336,7 @@ describe "Braintree API" do
                     email: "itsme@feelthebern.org",
                     country: "US",
                     postal: "11225",
+                    akid: '1234.5678.9910',
                     source: 'fb',
                     address1: '25 Elm Drive',
                     first_name: 'Bernie',
@@ -640,6 +643,7 @@ describe "Braintree API" do
                     country: "US",
                     postal: "11225",
                     address1: '25 Elm Drive',
+                    akid: '1234.5678.9910',
                     source: 'fb',
                     first_name: 'Bernie',
                     last_name: 'Sanders'
@@ -888,6 +892,7 @@ describe "Braintree API" do
                     address1: '25 Elm Drive',
                     first_name: 'Bernie',
                     last_name: 'Sanders',
+                    akid: '1234.5678.9910',
                     source: 'fb'
                   },
                   action: {

--- a/spec/requests/api/braintree_webhook_spec.rb
+++ b/spec/requests/api/braintree_webhook_spec.rb
@@ -13,6 +13,7 @@ describe "Braintree API" do
       email: "itsme@feelthebern.org",
       postal: "11225",
       address1: '25 Elm Drive',
+      akid: '1234.5678.9910',
       source: 'fb',
       country: "US"
     }
@@ -108,6 +109,7 @@ describe "Braintree API" do
                 postal: "11225",
                 address1: '25 Elm Drive',
                 source: 'fb',
+                akid: '1234.5678.9910',
                 first_name: 'Bernie',
                 last_name: 'Sanders'
               },
@@ -160,6 +162,7 @@ describe "Braintree API" do
                 postal: "11225",
                 address1: '25 Elm Drive',
                 source: 'fb',
+                akid: '1234.5678.9910',
                 first_name: 'Bernie',
                 last_name: 'Sanders'
               },

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -4,7 +4,6 @@ describe ActionBuilder do
   let(:page) { create :page }
   let(:member) { create :member }
   let(:found_action) { Action.where(member: member, page: page).first }
-  let(:test_params) { {test: 'yes', foo: 'bar'}}
 
   # Create a class which includes the ActionBuilder.
   class MockActionBuilder
@@ -111,7 +110,7 @@ describe ActionBuilder do
 
     describe 'filters irrelevant' do
 
-      let(:porky_params) { params.merge(page_id: page.id, form_id: '3', blerg: false) }
+      let(:porky_params) { params.merge(page_id: page.id, form_id: '3', blerg: false, akid: '1234.514.lQVxcW') }
 
       it 'keys as symbols' do
         mab = MockActionBuilder.new(porky_params)
@@ -131,6 +130,12 @@ describe ActionBuilder do
       it 'keys as action parameters' do
         mab = MockActionBuilder.new(ActionController::Parameters.new(porky_params))
         expect(mab.filtered_params).to eq params
+      end
+
+      it 'but passes them through to form_data' do
+        mab = MockActionBuilder.new(porky_params)
+        expect{ mab.build_action }.to change{ Action.count }.by 1
+        expect(Action.last.form_data).to match a_hash_including(params.stringify_keys)
       end
     end
   end


### PR DESCRIPTION
We weren't passing the akid through on donations, so the mailing ID was missing and our tracking in AK was messed up. This is a one-line fix.