### PR TITLE
Translate share buttons

### DIFF
--- a/app/liquid/views/partials/_share_page.liquid
+++ b/app/liquid/views/partials/_share_page.liquid
@@ -1,3 +1,16 @@
+<style type="text/css">
+  .button--facebook a::before{
+    content: "{{ 'share.share' | t }}";
+  }
+  .button--twitter a::before{
+    content: "{{ 'share.tweet' | t }}";
+  }
+  .share-buttons__simple-email-link.sp_em_small a::before, .share-buttons__simple-email-link.sp_em_large a::before {
+    content: "{{ 'share.send_email' | t }}";
+  }
+</style>
+
+
 <div class="header-logo header-logo--light">
   <a href="http://sumofus.org/">
     <div class="header-logo__logo sumofus-logo--positive"></div>

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -23,7 +23,7 @@ de:
     card_declined: Der Zahlungsdienst hat Ihre Kreditkarte nicht akzeptiert. Bitte wählen Sie eine andere Zahlungsmethode.
     unknown_error: Unbekannter Fehler. Unser Team wurde benachrichtigt. Bitte überprüfen Sie Ihre Eingaben oder wählen Sie eine andere Zahlungsmethode.
     fine_print: "SumOfUs ist eine eingetragene Non-Profit-Organisation (501(c)4) mit Sitz in Washington DC, USA. Spenden an SumOfUs können nicht von der Steuer abgesetzt werden. Für mehr Informationen schreiben Sie uns bitte eine E-Mail an info@sumofus.org."
-    confirmation: Donation received # FIXME - STILL IN ENGLISH!
+    confirmation: Spende erhalten
     fields:
       cvv: Kartenprüfnummer
       number: Kreditkartennummer
@@ -51,8 +51,8 @@ de:
   share:
     cta: Teilen Sie die Kampagne mit Ihren Freunden und verdreifachen Sie Ihre Wirkung!
     send_email: E-Mail senden
-    share: Teilen
-    tweet: Twittern
+    share: Facebook
+    tweet: Twitter
   errors:
     probably_invalid: sieht nicht richtig aus
     is_invalid: ist ungültig

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -50,6 +50,9 @@ de:
     signatures: Unterschriften
   share:
     cta: Teilen Sie die Kampagne mit Ihren Freunden und verdreifachen Sie Ihre Wirkung!
+    send_email: E-Mail senden
+    share: Teilen
+    tweet: Twittern
   errors:
     probably_invalid: sieht nicht richtig aus
     is_invalid: ist ungültig

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -50,6 +50,9 @@ en:
     signatures: signatures # as in '225 signatures'
   share:
     cta: Share the campaign with your friends to triple your impact!
+    send_email: Send Email
+    share: Share
+    tweet: Tweet
   errors:
     probably_invalid: doesn't look right
     is_invalid: is invalid

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -50,6 +50,9 @@ fr:
     signatures: signatures #, par exemple '225 signatures'
   share:
     cta: Partagez la pétition avec vos ami(e)s afin de tripler votre impact!
+    send_email: Envoyer un courriel
+    share: Partager
+    tweet: Tweet
   errors:
     probably_invalid: semble invalide
     is_invalid: est invalide


### PR DESCRIPTION
Previously, our share buttons were all in English, and this fixes that. I'm waiting on Languages team for final translations, but this is ready for code-review / sign-off.

<img width="735" alt="screenshot 2016-02-24 14 35 01" src="https://cloud.githubusercontent.com/assets/102218/13304623/5e4cc160-db1b-11e5-8558-b6441978477b.png">
