### PR TITLE
Mutable petition header and i13ed plugin defaults

### DIFF
--- a/app/models/plugins.rb
+++ b/app/models/plugins.rb
@@ -27,15 +27,10 @@ module Plugins
     end
 
     def translate_defaults(defaults, locale)
-      translated = {}
-      defaults.each do |key, val|
-        if val.is_a? String
-          translated[key] = I18n.t(val, locale: locale)
-        else
-          translated[key] = val
-        end
+      defaults.inject({}) do |translated, (key, val)|
+        translated[key] = val.is_a?(String) ? I18n.t(val, locale: locale) : val
+        translated
       end
-      translated
     end
 
     def data_for_view(page, supplemental_data={})

--- a/app/models/plugins.rb
+++ b/app/models/plugins.rb
@@ -13,7 +13,7 @@ module Plugins
       plugin_class = class_from_name(plugin_name)
       existing = plugin_class.where(ref: ref, page_id: page.id)
       return true unless existing.empty?
-      plugin = plugin_class.new(plugin_class.const_get(:DEFAULTS))
+      plugin = plugin_class.new(translate_defaults(plugin_class.const_get(:DEFAULTS), page.language.try(:code)))
       plugin.page_id = page.id
       plugin.active = true
       plugin.ref = ref if ref.present?
@@ -24,6 +24,18 @@ module Plugins
       [ Plugins::Petition,
         Plugins::Thermometer,
         Plugins::Fundraiser ]
+    end
+
+    def translate_defaults(defaults, locale)
+      translated = {}
+      defaults.each do |key, val|
+        if val.is_a? String
+          translated[key] = I18n.t(val, locale: locale)
+        else
+          translated[key] = val
+        end
+      end
+      translated
     end
 
     def data_for_view(page, supplemental_data={})

--- a/app/models/plugins/fundraiser.rb
+++ b/app/models/plugins/fundraiser.rb
@@ -4,7 +4,7 @@ class Plugins::Fundraiser < ActiveRecord::Base
   belongs_to :page, touch: true
   belongs_to :donation_band
 
-  DEFAULTS = { title: 'Donate now' }
+  DEFAULTS = { title: 'fundraiser.donate_now' }
 
   def liquid_data(supplemental_data={})
     donation_band_name = supplemental_data[:donation_band]

--- a/app/models/plugins/petition.rb
+++ b/app/models/plugins/petition.rb
@@ -5,7 +5,7 @@ class Plugins::Petition < ActiveRecord::Base
 
   validates :cta, presence: true, allow_blank: false
 
-  DEFAULTS = { cta: 'Sign the Petition' }
+  DEFAULTS = { cta: 'petition.sign_it' }
 
   def liquid_data(supplemental_data={})
     attributes.merge(form_liquid_data(supplemental_data))

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -7,7 +7,7 @@
             <a class="petition-bar__close-button">&#x2715;</a>
           </div>
           <div class="petition-bar__title-bar">
-            <h2 class="petition-bar__title">{{ 'petition.sign_it' | t }}</h2>
+            <h2 class="petition-bar__title">{{ plugins.petition[ref].cta }}</h2>
           </div>
           <div class="petition-bar__target">
             {% unless plugins.petition[ref].target == blank %}

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -24,6 +24,7 @@ de:
     unknown_error: Unbekannter Fehler. Unser Team wurde benachrichtigt. Bitte überprüfen Sie Ihre Eingaben oder wählen Sie eine andere Zahlungsmethode.
     fine_print: "SumOfUs ist eine eingetragene Non-Profit-Organisation (501(c)4) mit Sitz in Washington DC, USA. Spenden an SumOfUs können nicht von der Steuer abgesetzt werden. Für mehr Informationen schreiben Sie uns bitte eine E-Mail an info@sumofus.org."
     confirmation: Donation received # FIXME - STILL IN ENGLISH!
+    donate_now: Spenden
     fields:
       cvv: Kartenprüfnummer
       number: Kreditkartennummer

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -24,7 +24,7 @@ de:
     unknown_error: Unbekannter Fehler. Unser Team wurde benachrichtigt. Bitte überprüfen Sie Ihre Eingaben oder wählen Sie eine andere Zahlungsmethode.
     fine_print: "SumOfUs ist eine eingetragene Non-Profit-Organisation (501(c)4) mit Sitz in Washington DC, USA. Spenden an SumOfUs können nicht von der Steuer abgesetzt werden. Für mehr Informationen schreiben Sie uns bitte eine E-Mail an info@sumofus.org."
     confirmation: Donation received # FIXME - STILL IN ENGLISH!
-    donate_now: Spenden
+    donate_now: Spenden Sie jetzt
     fields:
       cvv: Kartenprüfnummer
       number: Kreditkartennummer

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -24,6 +24,7 @@ en:
     unknown_error: Our technical team has been notified. Please double check your info or try a different payment method.
     fine_print: "SumOfUs is a registered 501(c)4 non-profit incorporated in Washington, DC, United States. Contributions or gifts to SumOfUs are not tax deductible. For further information, please contact info@sumofus.org."
     confirmation: Donation received
+    donate_now: Donate now
     fields:
       cvv: CVV
       number: Card number

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -24,6 +24,7 @@ fr:
     unknown_error: Notre équipe technique a été notifiée de ce problème. Veuillez revérifier vos informations ou choisir une autre méthode de paiement.
     fine_print: "SumOfUs est une ONG déclarée 501(c)4 à Washington DC, USA. Les contributions ou dons ne sont pas déductibles des impôts. Pour plus d’informations, veuillez nous contacter à cette adresse: info@sumofus.org"
     confirmation: Don reçu
+    donate_now: Don maintenant
     fields:
       cvv: CVV
       number: Numéro de votre carte

--- a/spec/models/plugins/plugins_spec.rb
+++ b/spec/models/plugins/plugins_spec.rb
@@ -56,7 +56,7 @@ describe Plugins do
 
         it 'works for fundraisers' do
           Plugins.create_for_page('fundraiser', page, nil)
-          expect(Plugins::Fundraiser.last.title).to eq 'Spenden'
+          expect(Plugins::Fundraiser.last.title).to eq 'Spenden Sie jetzt'
         end
 
         it 'works for thermometers' do

--- a/spec/models/plugins/plugins_spec.rb
+++ b/spec/models/plugins/plugins_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 describe Plugins do
 
+  let(:english) { create :language, code: 'en' }
+  let(:french) { create :language, code: 'fr' }
+  let(:german) { create :language, code: 'de' }
   let(:page){ create :page }
 
   describe "create_for_page" do
@@ -37,6 +40,104 @@ describe Plugins do
     it "attaches the ref to plugin" do
       Plugins.create_for_page('petition', page, 'zebra')
       expect(Plugins::Petition.last.ref).to eq 'zebra'
+    end
+
+    describe 'translating defaults' do
+
+      describe 'into German' do
+        before :each do
+          page.update_attributes(language: german)
+        end
+
+        it 'works for petitions' do
+          Plugins.create_for_page('petition', page, nil)
+          expect(Plugins::Petition.last.cta).to eq 'Petition Unterschreiben'
+        end
+
+        it 'works for fundraisers' do
+          Plugins.create_for_page('fundraiser', page, nil)
+          expect(Plugins::Fundraiser.last.title).to eq 'Spenden'
+        end
+
+        it 'works for thermometers' do
+          Plugins.create_for_page('thermometer', page, nil)
+          thermometer = Plugins::Thermometer.last
+          expect(thermometer.offset).to eq 0
+          expect(thermometer.goal).to eq 100
+        end
+      end
+
+      describe 'into French' do
+        before :each do
+          page.update_attributes(language: french)
+        end
+
+        it 'works for petitions' do
+          Plugins.create_for_page('petition', page, nil)
+          expect(Plugins::Petition.last.cta).to eq 'Signez la pétition'
+        end
+
+        it 'works for fundraisers' do
+          Plugins.create_for_page('fundraiser', page, nil)
+          expect(Plugins::Fundraiser.last.title).to eq 'Don maintenant'
+        end
+
+        it 'works for thermometers' do
+          Plugins.create_for_page('thermometer', page, nil)
+          thermometer = Plugins::Thermometer.last
+          expect(thermometer.offset).to eq 0
+          expect(thermometer.goal).to eq 100
+        end
+      end
+
+      describe 'into English' do
+        before :each do
+          page.update_attributes(language: english)
+        end
+
+        it 'works for petitions' do
+          Plugins.create_for_page('petition', page, nil)
+          expect(Plugins::Petition.last.cta).to eq 'Sign the petition'
+        end
+
+        it 'works for fundraisers' do
+          Plugins.create_for_page('fundraiser', page, nil)
+          expect(Plugins::Fundraiser.last.title).to eq 'Donate now'
+        end
+
+        it 'works for thermometers' do
+          Plugins.create_for_page('thermometer', page, nil)
+          thermometer = Plugins::Thermometer.last
+          expect(thermometer.offset).to eq 0
+          expect(thermometer.goal).to eq 100
+        end
+      end
+
+      describe 'without language falls back to english' do
+        before :each do
+          page.update_attributes(language: nil)
+        end
+
+        it 'works for petitions' do
+          expect(page.language).to be_nil
+          Plugins.create_for_page('petition', page, nil)
+          expect(Plugins::Petition.last.cta).to eq 'Sign the petition'
+        end
+
+        it 'works for fundraisers' do
+          expect(page.language).to be_nil
+          Plugins.create_for_page('fundraiser', page, nil)
+          expect(Plugins::Fundraiser.last.title).to eq 'Donate now'
+        end
+
+        it 'works for thermometers' do
+          expect(page.language).to be_nil
+          Plugins.create_for_page('thermometer', page, nil)
+          thermometer = Plugins::Thermometer.last
+          expect(thermometer.offset).to eq 0
+          expect(thermometer.goal).to eq 100
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR does two things -
- rather than having default values specified as english strings, we specify them as localization keys and run them through the translation engine with the page's language, falling back to English. This way a German page will default to have German titles and CTAs
- show the petition's `cta` value not just on the button, but also on the petition title. See below

<img width="365" alt="screenshot 2016-02-24 17 31 54" src="https://cloud.githubusercontent.com/assets/102218/13304838/d5c04590-db1c-11e5-922d-413d9b55dd2a.png">
