### PR TITLE
Campaigner tweaks

### DIFF
--- a/app/assets/javascripts/shares_editor.js
+++ b/app/assets/javascripts/shares_editor.js
@@ -106,7 +106,11 @@ let setupOnce = require('setup_once');
         $.get(`/api/pages/${data.id}/share-rows`, (rows) => {
           _.each(rows, (row) => {
             let $row = $(row.html);
-            $row = $(`#${$row.prop('id')}`).replaceWith($row);
+            $original = $(`#${$row.prop('id')}`);
+            if ($original.hasClass('hidden-closed')) {
+              $row.addClass('hidden-closed');
+            }
+            $row = $original.replaceWith($row);
             $row = $(`#${$row.prop('id')}`);
             if (!this.editRow($row).hasClass('hidden-closed')) {
               $row.find('.shares-editor__toggle-edit').text('Done');

--- a/app/views/pages/edit.slim
+++ b/app/views/pages/edit.slim
@@ -1,4 +1,5 @@
 = render 'edit_sidebar', page: @page
+- low_priority_plugins = [Plugins::Thermometer]
 
 section.page-edit-step#basics data-icon='pencil'
   h1.page-edit-step__title = t('.content')
@@ -8,6 +9,12 @@ section.page-edit-step#layout data-icon='cog'
   h1.page-edit-step__title = t('.settings')
   = render 'settings_form', page: @page
 
+- @page.plugins.each do |plugin|
+  - next if low_priority_plugins.include? plugin.class
+  section.page-edit-step id=plugin_title(plugin) data-icon=plugin_icon(plugin)
+    h1.page-edit-step__title= plugin_title(plugin)
+    = render "#{plugin.class.to_s.underscore.pluralize}/form", plugin: plugin, page: @page
+
 section.page-edit-step#pictures data-icon='camera-retro'
   h1.page-edit-step__title = t('.pictures')
   = render 'photo_form', page: @page
@@ -16,14 +23,15 @@ section.page-edit-step#shares data-icon='share-square-o'
   h1.page-edit-step__title = t('.shares')
   = render 'shares_editor', page: @page
 
-- @page.plugins.each do |plugin|
-  section.page-edit-step id=plugin_title(plugin) data-icon=plugin_icon(plugin)
-    h1.page-edit-step__title= plugin_title(plugin)
-    = render "#{plugin.class.to_s.underscore.pluralize}/form", plugin: plugin, page: @page
-
 section.page-edit-step#sources data-icon='link'
   h1.page-edit-step__title = t('.sources')
   = render 'link_form', page: @page
+
+- @page.plugins.each do |plugin|
+  - next unless low_priority_plugins.include? plugin.class
+  section.page-edit-step id=plugin_title(plugin) data-icon=plugin_icon(plugin)
+    h1.page-edit-step__title= plugin_title(plugin)
+    = render "#{plugin.class.to_s.underscore.pluralize}/form", plugin: plugin, page: @page
 
 section.page-edit-step.page-edit-step--just-title#review data-icon='eye' data-link-to=member_facing_page_url(@page)
   h1.page-edit-step__title


### PR DESCRIPTION
- fixes a bug where the shares editor would blow up when autosave was on
- changes the order of the plugins on the pages editor, so that petition and fundraiser are moved up and thermometer is moved down

<img width="254" alt="screenshot 2016-02-24 17 41 20" src="https://cloud.githubusercontent.com/assets/102218/13304992/d833eda8-db1d-11e5-9ea1-c447f66bdfcc.png">
