### PR TITLE
Make liquid seeder auto-interpret post-action and primary layouts

### DIFF
--- a/app/liquid/liquid_tag_finder.rb
+++ b/app/liquid/liquid_tag_finder.rb
@@ -61,12 +61,27 @@ class LiquidTagFinder
     string_search(/description: *(.+)/i, string_comments.flatten)
   end
 
+  # Looks for a liquid comment like {% comment %} Experimental: true {% endcomment %}
+  def experimental?
+    has_comment?('experimental')
+  end
+
+  # Looks for a liquid comment like {% comment %} Primary layout: true {% endcomment %}
+  def primary_layout?
+    has_comment?('primary layout')
+  end
+
+  # Looks for a liquid comment like {% comment %} Post-action layout: true {% endcomment %}
+  def post_action_layout?
+    has_comment?('post-action layout')
+  end
+
   # Looks for a liquid comment like
-  #   {% comment %} Experimental: true {% endcomment %}
+  #   {% comment %} Key: true {% endcomment %}
   # If the tag is found and the value is +true+, this returns +true+.
   # Otherwise it returns +false+.
-  def experimental?
-    status = string_search(/experimental: *(.+)/i, string_comments.flatten)
+  def has_comment?(key)
+    status = string_search(/#{Regexp.quote(key)}: *(.+)/i, string_comments.flatten)
     status.present? ? status.match(/true/i).present? : false
   end
 

--- a/app/liquid/views/layouts/fundraiser-with-large-image.liquid
+++ b/app/liquid/views/layouts/fundraiser-with-large-image.liquid
@@ -1,4 +1,5 @@
 {% comment %} Description: The page for taking donations with a wide cover photo.{% endcomment %}
+{% comment %} Primary layout: true {% endcomment %}
 
 {% include 'Full Width Header' %}
 

--- a/app/liquid/views/layouts/fundraiser-with-small-image.liquid
+++ b/app/liquid/views/layouts/fundraiser-with-small-image.liquid
@@ -1,4 +1,5 @@
 {% comment %} Description: The fundraiser page with a small cover photo. {% endcomment %}
+{% comment %} Primary layout: true {% endcomment %}
 
 {% include 'Small Header' %}
 

--- a/app/liquid/views/layouts/petition-with-large-image.liquid
+++ b/app/liquid/views/layouts/petition-with-large-image.liquid
@@ -1,4 +1,5 @@
 {% comment %} Description: The petition page with a wide cover photo.{% endcomment %}
+{% comment %} Primary layout: true {% endcomment %}
 
 {% include 'Full Width Header' %}
 

--- a/app/liquid/views/layouts/petition-with-small-image.liquid
+++ b/app/liquid/views/layouts/petition-with-small-image.liquid
@@ -1,4 +1,5 @@
 {% comment %} Description: The petition page with a small cover photo. {% endcomment %}
+{% comment %} Primary layout: true {% endcomment %}
 
 {% include 'Small Header' %}
 

--- a/app/liquid/views/layouts/post-donation-share.liquid
+++ b/app/liquid/views/layouts/post-donation-share.liquid
@@ -1,4 +1,5 @@
 {% comment %} Description: A follow-up page thanking for donating money and asking to share {% endcomment %}
+{% comment %} Post-action layout: true {% endcomment %}
 
 {% capture confirmation %}{{ 'fundraiser.confirmation' | t }}{% endcapture %}
 {% capture message %}{{ 'fundraiser.thank_you' | t }}{% endcapture %}

--- a/app/liquid/views/layouts/post-petition-share.liquid
+++ b/app/liquid/views/layouts/post-petition-share.liquid
@@ -1,4 +1,5 @@
 {% comment %} Description: A follow-up page thanking for signing a petition and asking to share {% endcomment %}
+{% comment %} Post-action layout: true {% endcomment %}
 
 {% capture confirmation %}{{ 'petition.confirmation' | t }}{% endcapture %}
 {% capture message %}{{ 'petition.thank_you' | val: 'petition_title', title | t }}{% endcapture %}

--- a/lib/liquid_markup_seeder.rb
+++ b/lib/liquid_markup_seeder.rb
@@ -63,6 +63,8 @@ module LiquidMarkupSeeder
     return unless view.is_a? LiquidLayout
     ltf = LiquidTagFinder.new(view.content)
     view.experimental = ltf.experimental?
+    view.primary_layout = ltf.primary_layout?
+    view.post_action_layout = ltf.post_action_layout?
     view.description = ltf.description
   end
 end

--- a/spec/lib/liquid_markup_seeder_spec.rb
+++ b/spec/lib/liquid_markup_seeder_spec.rb
@@ -32,12 +32,16 @@ describe LiquidMarkupSeeder do
     let(:view) { build :liquid_layout }
     let(:description) { "{% comment %} description: something sweet {%endcomment%}" }
     let(:experimental) { "{% comment %} experimental: true {% endcomment %}" }
+    let(:post_action) { "{% comment %} Post-action layout: true {% endcomment %}" }
+    let(:primary) { "{% comment %} Primary layout: true {% endcomment %}" }
 
-    it 'sets experimental and description if they are included' do
-      view.content = description + experimental
+    it 'sets experimental, post-action, primary, and description if they are included' do
+      view.content = description + experimental + post_action + primary
       subject.set_metadata_fields(view)
       expect(view.description).to eq "something sweet"
       expect(view.experimental).to eq true
+      expect(view.primary_layout).to eq true
+      expect(view.post_action_layout).to eq true
     end
 
     it 'sets to nil if not included' do

--- a/spec/liquid/liquid_tag_finder_spec.rb
+++ b/spec/liquid/liquid_tag_finder_spec.rb
@@ -257,27 +257,44 @@ describe LiquidTagFinder do
 
     it 'returns true if experimental is "true"' do
       tag = '{% comment %} experimental: true {% endcomment %}'
-      description = LiquidTagFinder.new(tag+base_content).experimental?
-      expect(description).to eq true
+      expect(LiquidTagFinder.new(tag+base_content).experimental?).to eq true
     end
 
     it 'returns true if experimental is "TRUE"' do
       tag = '{% comment %} experimental: TRUE {% endcomment %}'
-      description = LiquidTagFinder.new(tag+base_content).experimental?
-      expect(description).to eq true
+      expect(LiquidTagFinder.new(tag+base_content).experimental?).to eq true
     end
 
     it 'returns false if experimental is 1' do
       tag = '{% comment %} experimental: 1 {% endcomment %}'
-      description = LiquidTagFinder.new(tag+base_content).experimental?
-      expect(description).to eq false
+      expect(LiquidTagFinder.new(tag+base_content).experimental?).to eq false
     end
 
     it 'returns false if experimental tag is absent' do
-      description = LiquidTagFinder.new(base_content).experimental?
-      expect(description).to eq false
+      expect(LiquidTagFinder.new(base_content).experimental?).to eq false
+    end
+  end
+
+  describe 'primary_layout?' do
+    it 'returns true if primary layout is "true"' do
+      tag = '{% comment %} Primary layout: true {% endcomment %}'
+      expect(LiquidTagFinder.new(tag+base_content).primary_layout?).to eq true
     end
 
+    it 'returns false if primary_layout tag is absent' do
+      expect(LiquidTagFinder.new(base_content).primary_layout?).to eq false
+    end
+  end
+
+  describe 'post_action_layout?' do
+    it 'returns true if post-action layout is "true"' do
+      tag = '{% comment %} Post-action layout: true {% endcomment %}'
+      expect(LiquidTagFinder.new(tag+base_content).post_action_layout?).to eq true
+    end
+
+    it 'returns false if post_action_layout tag is absent' do
+      expect(LiquidTagFinder.new(base_content).post_action_layout?).to eq false
+    end
   end
 
 end


### PR DESCRIPTION
Right now, there's a one-off rake task that identifies which layouts are primary and which post-action. This leverages the code I wrote for the `experimental` tag to let us set these values in the liquid in our repo, so our templates in the db will stay in sync with our version control by default.