### PR TITLE
Forms

### DIFF
--- a/app/admin/form_element.rb
+++ b/app/admin/form_element.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register FormElement do
-  permit_params :label, :data_type, :field_type, :default_value, :required, :visible, :name, :position
+  permit_params :label, :data_type, :default_value, :required, :visible, :name, :position
 
   index do
     selectable_column

--- a/app/assets/javascripts/collection_editor.js
+++ b/app/assets/javascripts/collection_editor.js
@@ -9,6 +9,7 @@
 //   - Use for autocompleting for setting the field's name value
 
 const setupOnce = require('setup_once');
+const ErrorDisplay = require('show_errors');
 
 (function(){
   let CollectionEditor = Backbone.View.extend({
@@ -99,6 +100,8 @@ const setupOnce = require('setup_once');
 
     newElementAdded: function(e, resp, c) {
       this.$('.list-group').append(resp);
+      this.$('#form_element_label, #form_element_name').val('');
+      ErrorDisplay.clearErrors(this.$('form#new_collection_element'));
       this.makeSortable();
     },
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -119,6 +119,11 @@ section {
       }
     }
   }
+  .secondary-label {
+    opacity: 0.4;
+    font-size: 12px;
+    margin-left: 5px;
+  }
 }
 
 li.list-group-item {

--- a/app/assets/stylesheets/sumofus/components/form.scss
+++ b/app/assets/stylesheets/sumofus/components/form.scss
@@ -5,7 +5,7 @@
     margin-bottom: 5px;
     position: relative;
 
-    input {
+    input, textarea {
       &.has-error {
         border-color: $orange;
       }
@@ -19,6 +19,7 @@
       color: $orange;
       font-size: 14px;
       float: right;
+      text-align: right;
     }
     &--prefilled {
       display: none;
@@ -32,7 +33,7 @@
     }
   }
   &--big {
-    input, select, .selectize-control.single .selectize-input, .hosted-fields__host {
+    input, select, textarea, .selectize-control.single .selectize-input, .hosted-fields__host {
       @include rem(font-size, 1rem, true);
       @include box-sizing(border-box);
       border: 2px solid white;
@@ -61,6 +62,11 @@
     label.checkbox-label {
       margin: 10px 0 4px;
       font-size: 14px;
+    }
+
+    textarea {
+      line-height: 1.4em;
+      height: 120px;
     }
 
     .selectize-dropdown.single {

--- a/app/assets/stylesheets/sumofus/global/typography.scss
+++ b/app/assets/stylesheets/sumofus/global/typography.scss
@@ -76,7 +76,8 @@ a {
 }
 
 .body-text {
-  p, span {
+  line-height: 1.6em;
+  p, span, div {
     line-height: 1.6em;
   }
 }

--- a/app/controllers/form_elements_controller.rb
+++ b/app/controllers/form_elements_controller.rb
@@ -9,8 +9,7 @@ class FormElementsController < ApplicationController
         format.html { render partial: 'element', locals: { form: @form, element: @form_element }, status: :ok }
       else
         format.html { render :new }
-        format.js { render 'errors' }
-        format.json { render json: @liquid_layout.errors, status: :unprocessable_entity }
+        format.js { render json: { errors: @form_element.errors, name: :form_element }, status: :unprocessable_entity }
       end
     end
   end

--- a/app/controllers/plugins/forms_controller.rb
+++ b/app/controllers/plugins/forms_controller.rb
@@ -1,8 +1,8 @@
 class Plugins::FormsController < ApplicationController
 
   def create
-    master = Form.find params[:master_id]
-    plugin = Plugins.find_for params[:plugin_type], params[:plugin_id]
+    master = Form.find permitted_params[:master_id]
+    plugin = Plugins.find_for permitted_params[:plugin_type], permitted_params[:plugin_id]
     new_form = attach_duplicate_form(master, plugin)
 
     respond_to do |format|
@@ -14,7 +14,7 @@ class Plugins::FormsController < ApplicationController
   end
 
   def show
-    plugin = Plugins.find_for params[:plugin_type], params[:plugin_id]
+    plugin = Plugins.find_for permitted_params[:plugin_type], permitted_params[:plugin_id]
     render partial: 'plugins/shared/preview', locals: { plugin: plugin }
   end
 
@@ -24,6 +24,10 @@ class Plugins::FormsController < ApplicationController
     new_form = FormDuplicator.duplicate(form)
     plugin.update_form(new_form)
     new_form
+  end
+
+  def permitted_params
+    params.permit(:plugin_id, :plugin_type, :master_id)
   end
 end
 

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -10,6 +10,8 @@
         {% case field.data_type %}
         {% when 'text' or 'postal' %}
           <input type="text" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" />
+        {% when 'paragraph' %}
+          <textarea name="{{ field.name }}" placeholder="{{ field.label }}" class="form-control form__content" id=""></textarea>
         {% when 'email' %}
           <input type="email" name="{{field.name}}" class="form-control mailcheck form__content" id="" placeholder="{{ field.label }}" />
         {% when 'phone' %}

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -9,9 +9,9 @@
       <div class="form__group petition-bar__field-container">
         {% case field.data_type %}
         {% when 'text' or 'postal' %}
-          <input type="text" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" />
+          <input type="text" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" maxlength="249" />
         {% when 'paragraph' %}
-          <textarea name="{{ field.name }}" placeholder="{{ field.label }}" class="form-control form__content" id=""></textarea>
+          <textarea name="{{ field.name }}" placeholder="{{ field.label }}" class="form-control form__content" id="" maxlength="9999"></textarea>
         {% when 'email' %}
           <input type="email" name="{{field.name}}" class="form-control mailcheck form__content" id="" placeholder="{{ field.label }}" />
         {% when 'phone' %}

--- a/app/models/form_element.rb
+++ b/app/models/form_element.rb
@@ -18,6 +18,7 @@ class FormElement < ActiveRecord::Base
     country
     postal
   }
+  validates :data_type, inclusion: { in: VALID_TYPES }
 
   private
 
@@ -27,8 +28,10 @@ class FormElement < ActiveRecord::Base
   end
 
   def set_name
-    unless ActionKitFields::ACTIONKIT_FIELDS_WHITELIST.include?(name)
-      self.name = "action_#{name}" unless name =~  ActionKitFields::VALID_PREFIX_RE
+    unless name.blank? || ActionKitFields::ACTIONKIT_FIELDS_WHITELIST.include?(name)
+      if !(name =~ ActionKitFields::VALID_PREFIX_RE) && !(name =~ /^(action_)+$/)
+        self.name = "action_#{name}"
+      end
     end
   end
 end

--- a/app/models/form_element.rb
+++ b/app/models/form_element.rb
@@ -11,6 +11,7 @@ class FormElement < ActiveRecord::Base
   # Array of possible field types.
   VALID_TYPES = %w{
     text
+    paragraph
     checkbox
     email
     phone

--- a/app/models/plugins/has_form.rb
+++ b/app/models/plugins/has_form.rb
@@ -22,12 +22,10 @@ module Plugins::HasForm
   end
 
   def update_form(new_form)
-    if form
-      form.form_elements.destroy_all
-      form.destroy
-    end
-
+    return if new_form.blank?
+    old_form = form
     update(form: new_form)
+    old_form.destroy if old_form.present?
   end
 
   private

--- a/app/validators/action_kit_fields.rb
+++ b/app/validators/action_kit_fields.rb
@@ -69,17 +69,15 @@ class ActionKitFields < ActiveModel::Validator
 
   def validate(record)
     @name = record.name
-
-    unless valid_name
-      record.errors[:name] << "#{record.name} is not a permitted ActionKit name."
+    unless has_valid_form
+      record.errors[:name] << "'#{record.name}' is not a permitted ActionKit name."
+    end
+    unless has_valid_characters
+      record.errors[:name] << "'#{record.name}' may only contain numbers, underscores, and lowercase letters."
     end
   end
 
   private
-
-  def valid_name
-    has_valid_characters && has_valid_form
-  end
 
   # Does the name match an existing ActionKit field name, else
   # does it have a valid prefix ( +action_+, or +user_+ ).

--- a/app/views/form_elements/_element.slim
+++ b/app/views/form_elements/_element.slim
@@ -2,11 +2,13 @@ li.list-group-item data-id=element.id
   span.sort
     i.glyphicon.glyphicon-sort
   = element.label
+  span.secondary-label
+    = "(#{element.name})"
 
   .control-bar
     - if element.required
-      span.label.label-primary required
-    span.label.label-info = element.data_type
+      span.label.label-warning required
+    span.label.label-primary = element.data_type
 
     = link_to form_form_element_path(form, element),
       { method: :delete,

--- a/app/views/form_elements/create.js.coffee
+++ b/app/views/form_elements/create.js.coffee
@@ -1,8 +1,0 @@
-formEdit = '<%=j render partial: 'forms/edit', locals: {form: @form} %>'
-formNew =  '<%=j render partial: 'forms/add_element', locals: {form: @form, form_element: FormElement.new} %>'
-
-$('.forms-edit').html formEdit
-$('.forms-add-element').html formNew
-$('#form_element_label').focus()
-$.publish("forms:edit:loaded")
-

--- a/app/views/form_elements/errors.js.coffee
+++ b/app/views/form_elements/errors.js.coffee
@@ -1,3 +1,0 @@
-html = '<%=j render partial: 'forms/add_element', locals: {form: @form, form_element: @form_element} %>'
-$('.forms-add-element').html html
-$.publish("forms:edit:loaded")

--- a/app/views/forms/_add_element.slim
+++ b/app/views/forms/_add_element.slim
@@ -2,16 +2,16 @@
 
 = form_for [form, form_element], remote: true, html: {class: 'form-element', id: 'new_collection_element'}  do |f|
   .form-group
+    = label_with_tooltip(f, :data_type, t('form_elements.data_type'), t('tooltips.form_elements.data_type'))
+    - type_names = { 'text' => "text (single line)", "paragraph" => 'text (multi-line)' }
+    - options = FormElement::VALID_TYPES.map{ |type| [type_names.fetch(type, type), type] }
+    = f.select :data_type, options_for_select(options), {}, class: 'form-control'
+  .form-group
     = label_with_tooltip(f, :label, t('form_elements.label'), t('tooltips.form_elements.label'))
     = f.text_field :label,  class: 'form-control', placeholder: t('form_elements.label_suggestion')
   .form-group.clearfix
     = label_with_tooltip(f, :data_type, t('form_elements.name'), t('tooltips.form_elements.name'))
     = f.text_field :name,  class: 'form-control typeahead', placeholder: t('form_elements.name_suggestion')
-  .form-group
-    = label_with_tooltip(f, :data_type, t('form_elements.data_type'), t('tooltips.form_elements.data_type'))
-    - type_names = { 'text' => "text (single line)", "paragraph" => 'text (multi-line)' }
-    - options = FormElement::VALID_TYPES.map{ |type| [type_names.fetch(type, type), type] }
-    = f.select :data_type, options_for_select(options), {}, class: 'form-control'
 
   .form-group
     .checkbox

--- a/app/views/forms/_add_element.slim
+++ b/app/views/forms/_add_element.slim
@@ -9,7 +9,9 @@
     = f.text_field :name,  class: 'form-control typeahead', placeholder: t('form_elements.name_suggestion')
   .form-group
     = label_with_tooltip(f, :data_type, t('form_elements.data_type'), t('tooltips.form_elements.data_type'))
-    = f.select :data_type, options_for_select(FormElement::VALID_TYPES), {}, class: 'form-control'
+    - type_names = { 'text' => "text (single line)", "paragraph" => 'text (multi-line)' }
+    - options = FormElement::VALID_TYPES.map{ |type| [type_names.fetch(type, type), type] }
+    = f.select :data_type, options_for_select(options), {}, class: 'form-control'
 
   .form-group
     .checkbox

--- a/app/views/forms/_add_element.slim
+++ b/app/views/forms/_add_element.slim
@@ -1,5 +1,4 @@
 = render partial: 'shared/error_messages', locals: {target: form_element }
-
 = form_for [form, form_element], remote: true, html: {class: 'form-element', id: 'new_collection_element'}  do |f|
   .form-group
     = label_with_tooltip(f, :data_type, t('form_elements.data_type'), t('tooltips.form_elements.data_type'))

--- a/app/views/forms/_preview.html.slim
+++ b/app/views/forms/_preview.html.slim
@@ -7,6 +7,8 @@ form
         input.form-control placeholder=label
       - when 'country'
         = select_tag '', options_for_select(ISO3166::Country.all_names_with_codes), class: "form-control"
+      - when 'paragraph'
+        textarea.form-control placeholder=label
       - when 'checkbox'
         = check_box_tag element.name
         '&nbsp;

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -82,7 +82,7 @@ en:
     form_elements:
       data_type: 'This changes what user inputs the field will accept'
       label: 'This is the label of the field presented to the petition signer.'
-      name: "This is how the field is stored in ActionKit. Select a canonical AK field from the suggestions, or enter your own and it will be automatically prefixed with 'data_'"
+      name: "This is how the field is stored in ActionKit. Select a canonical AK field from the suggestions, or enter your own and it will be automatically prefixed with 'action_'"
 
   oauth:
     not_authorised: "You're not authorised to authenticate with that account."
@@ -224,7 +224,7 @@ en:
     petition:
       petition_description: "Petition Text"
       choose_form_template: "Use a form template"
-      customise_form: "Customise your petition form"
+      customise_form: "Customize your form"
       add_new_field: "Add a new field"
       add_field: "Add field"
       apply_template: "Apply template"

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -82,7 +82,7 @@ en:
     form_elements:
       data_type: 'This changes what user inputs the field will accept'
       label: 'This is the label of the field presented to the petition signer.'
-      name: "This is how the field is stored in ActionKit. Select a canonical AK field from the suggestions, or enter your own and it will be automatically prefixed with 'action_'"
+      name: "This is how the field is stored in ActionKit. Select a canonical AK field from the suggestions, or enter your own. AK's 'action_' prefix will be added automatically if you don't include it."
 
   oauth:
     not_authorised: "You're not authorised to authenticate with that account."

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -44,7 +44,7 @@ en:
     is_invalid_phone: 'can only have numbers, dash, plus, and parentheses'
     is_invalid_country: 'must be a two letter country code'
     is_invalid_postal: 'must be a valid postal code'
-    is_invalid_length: 'must be less than 250 characters long'
+    is_invalid_length: 'must be less than %{length} characters long'
 
   menu:
     pages: 'Pages'

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -63,4 +63,4 @@ de:
     is_invalid_email: ist keine gültige E-Mail-Adresse
     is_invalid_phone: "kann nur Nummern, Schrägstriche, Pluszeichen und Klammern enthalten"
     is_invalid_country: muss eine gültige Ländervorwahl sein
-    is_invalid_length: 'must be less than %{length} characters long' # FIXME: still in English
+    is_invalid_length: 'darf maximal %{length} Zeichen enthalten'

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -63,3 +63,4 @@ de:
     is_invalid_email: ist keine gültige E-Mail-Adresse
     is_invalid_phone: "kann nur Nummern, Schrägstriche, Pluszeichen und Klammern enthalten"
     is_invalid_country: muss eine gültige Ländervorwahl sein
+    is_invalid_length: 'must be less than %{length} characters long' # FIXME: still in English

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -63,3 +63,4 @@ en:
     is_invalid_email: is not a valid email address
     is_invalid_phone: 'can only have numbers, dash, plus, and parentheses'
     is_invalid_country: must be a valid country code
+    is_invalid_length: 'must be less than %{length} characters long'

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -63,4 +63,4 @@ fr:
     is_invalid_email: n’est pas une adresse email valide
     is_invalid_phone: 'peut uniquement comprendre des chiffres, tirets, plus, et des parenthèses'
     is_invalid_country: doit comprendre un code pays valide
-    is_invalid_length: 'must be less than %{length} characters long' # FIXME: still in English
+    is_invalid_length: 'doit contenir moins de %{length} caractères'

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -63,3 +63,4 @@ fr:
     is_invalid_email: n’est pas une adresse email valide
     is_invalid_phone: 'peut uniquement comprendre des chiffres, tirets, plus, et des parenthèses'
     is_invalid_country: doit comprendre un code pays valide
+    is_invalid_length: 'must be less than %{length} characters long' # FIXME: still in English

--- a/db/migrate/20160229225740_remove_field_type_from_form_element.rb
+++ b/db/migrate/20160229225740_remove_field_type_from_form_element.rb
@@ -1,0 +1,5 @@
+class RemoveFieldTypeFromFormElement < ActiveRecord::Migration
+  def change
+    remove_column :form_elements, :field_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160219174402) do
+ActiveRecord::Schema.define(version: 20160229225740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,7 +83,6 @@ ActiveRecord::Schema.define(version: 20160219174402) do
     t.integer  "form_id"
     t.string   "label"
     t.string   "data_type"
-    t.string   "field_type"
     t.string   "default_value"
     t.boolean  "required"
     t.boolean  "visible"
@@ -182,11 +181,11 @@ ActiveRecord::Schema.define(version: 20160219174402) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "compiled_html"
-    t.string   "status",                     default: "pending"
-    t.text     "messages"
     t.text     "content",                    default: ""
     t.boolean  "featured",                   default: false
     t.boolean  "active",                     default: false
+    t.string   "status",                     default: "pending"
+    t.text     "messages"
     t.integer  "liquid_layout_id"
     t.integer  "follow_up_liquid_layout_id"
     t.integer  "action_count",               default: 0
@@ -254,8 +253,8 @@ ActiveRecord::Schema.define(version: 20160219174402) do
     t.integer  "page_id"
     t.string   "payment_instrument_type"
     t.integer  "status"
-    t.string   "processor_response_code"
     t.decimal  "amount",                  precision: 10, scale: 2
+    t.string   "processor_response_code"
   end
 
   add_index "payment_braintree_transactions", ["page_id"], name: "index_payment_braintree_transactions_on_page_id", using: :btree

--- a/spec/controllers/plugins/forms_controller_spec.rb
+++ b/spec/controllers/plugins/forms_controller_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe Plugins::FormsController do
+  let(:user) { instance_double('User', id: 1) }
+  let(:petition) { build :plugins_petition } 
+
+  before do
+    allow(request.env['warden']).to receive(:authenticate!).and_return(user)
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(Plugins).to receive(:find_for).and_return(petition)
+  end
+
+  describe 'GET show' do
+
+    let(:params) { { plugin_type: 'petition', plugin_id: '3' } }
+
+    before :each do
+      get :show, params
+    end
+
+    it 'finds the plugin' do
+      expect(Plugins).to have_received(:find_for).with(params[:plugin_type], params[:plugin_id])
+    end
+
+    it 'renders the form preview' do
+      expect(response).to render_template(partial: 'plugins/shared/_preview')
+    end
+  end
+
+  describe 'POST create' do
+    let(:params) { { master_id: '2', plugin_type: 'petition', plugin_id: '3' } }
+    let(:first_form) { instance_double('Form', id: 1, master: true)}
+    let(:second_form) { instance_double('Form', id: 7, master: false) }
+
+    before do
+      allow(Form).to receive(:find).and_return(first_form)
+      allow(FormDuplicator).to receive(:duplicate).and_return(second_form)
+      allow(petition).to receive(:update_form)
+      request.accept = "application/json"
+      post :create, params
+    end
+
+    it 'finds form by form_id' do
+      expect(Form).to have_received(:find).with(params[:master_id])
+    end
+
+    it 'finds plugin by plugin type and id' do
+      expect(Plugins).to have_received(:find_for).with(params[:plugin_type], params[:plugin_id])
+    end
+
+    it 'duplicates the form' do
+      expect(FormDuplicator).to have_received(:duplicate).with(first_form)
+    end
+
+    it 'calls plugin.update_form with the duplicated form' do
+      expect(petition).to have_received(:update_form).with(second_form)
+    end
+
+    it 'returns the form rendered as html in a json blob' do
+      expect(response.status).to eq 200
+      expect(response).to render_template(partial: 'forms/_edit')
+      body = JSON.parse(response.body)
+      expect(body.keys).to match_array ['html', 'form_id']
+      expect(body['form_id']).to eq second_form.id
+    end
+  end
+
+  describe 'strong params' do
+    let(:params) { { master_id: '2', plugin_type: 'petition', plugin_id: '3', form_id: 'disallowed' } }
+
+    it 'are used for POST create' do
+      expect{ post :create, params }.to raise_error(ActionController::UnpermittedParameters)
+    end
+
+    it 'are used for GET show' do
+      expect{ get :show, params }.to raise_error(ActionController::UnpermittedParameters)
+    end
+  end
+end

--- a/spec/factories/form_elements.rb
+++ b/spec/factories/form_elements.rb
@@ -30,5 +30,11 @@ FactoryGirl.define do
       name      'postal'
       data_type 'postal'
     end
+
+    trait :paragraph do
+      label     'Your thoughts'
+      name      'comment'
+      data_type 'paragraph'
+    end
   end
 end

--- a/spec/models/form_element_spec.rb
+++ b/spec/models/form_element_spec.rb
@@ -21,20 +21,32 @@ describe FormElement do
     describe 'name fixing' do
       it 'keeps name if whitelisted' do
         expect(
-          create(:form_element, form: form, name: 'address1').name
+          FormElement.create(label: 'My label!', form: form, name: 'address1').name
         ).to eq('address1')
       end
 
       it 'prefixes custom names' do
         expect(
-          create(:form_element, form: form, name: 'foo_bar').name
+          FormElement.create(label: 'My label!', form: form, name: 'foo_bar').name
         ).to eq('action_foo_bar')
       end
 
       it 'does nothing when prefix is present' do
         expect(
-          create(:form_element, form: form, name: 'action_foo_bar').name
+          FormElement.create(label: 'My label!', form: form, name: 'action_foo_bar').name
         ).to eq('action_foo_bar')
+      end
+
+      it 'does nothing when name is blank' do
+        expect(
+          FormElement.create(label: 'My label!', form: form, name: '').name
+        ).to eq('')
+      end
+
+      it 'does nothing when name is "action_"' do
+        expect(
+          FormElement.create(label: 'My label!', form: form, name: 'action_').name
+        ).to eq('action_')
       end
     end
   end
@@ -57,6 +69,56 @@ describe FormElement do
       Timecop.freeze(future) do
         petition.form.form_elements.first.update(label: 'foo')
         expect(petition.page.reload.updated_at.to_s).to eq(future.to_s)
+      end
+    end
+  end
+
+  describe 'validations' do
+    subject { build(:form_element) }
+
+    it { is_expected.to be_valid }
+
+    describe 'fail when it' do
+      it 'has a blank label' do
+        subject.label = ''
+        expect(subject).not_to be_valid
+        expect(subject.errors.keys).to eq [:label]
+      end
+
+      it 'has an blank data_type' do
+        subject.data_type = ''
+        expect(subject).not_to be_valid
+        expect(subject.errors.keys).to eq [:data_type]
+      end
+
+      it 'has a unknown data_type' do
+        subject.data_type = 'state'
+        expect(subject).not_to be_valid
+        expect(subject.errors.keys).to eq [:data_type]
+      end
+
+      it 'has a blank name' do
+        subject.name = ''
+        expect(subject).not_to be_valid
+        expect(subject.errors.keys).to eq [:name]
+      end
+
+      it 'has action_ as the name' do
+        subject.name = 'action_'
+        expect(subject).not_to be_valid
+        expect(subject.errors.keys).to eq [:name]
+      end
+
+      it 'has bad AK characters in the name' do
+        subject.name = 'action_sass matazz'
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages).to eq({name: ["'action_sass matazz' may only contain numbers, underscores, and lowercase letters."]})
+      end
+
+      it "has a name that doesn't match the AK format" do
+        subject.name = 'action_'
+        expect(subject).not_to be_valid
+        expect(subject.errors.messages).to eq({name: ["'action_' is not a permitted ActionKit name."]})
       end
     end
   end

--- a/spec/models/plugins/shared_examples.rb
+++ b/spec/models/plugins/shared_examples.rb
@@ -70,12 +70,25 @@ shared_examples "plugin with form" do |plugin_type|
 
     it 'deletes original form' do
       old_form = subject.form
-
-      subject.update_form(new_form)
+      expect{
+        subject.update_form(new_form)
+      }.to change{ Form.count }.by -1
 
       expect{
         old_form.reload
       }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "deletes the original form's form_elements" do
+      el_count = subject.form.form_elements.size
+      expect(el_count).to be > 0
+      expect{ subject.update_form(new_form) }.to change{ FormElement.count }.by(-el_count)
+    end
+
+    it 'does nothing if new_form is nil' do
+      old_form = subject.form
+      expect{ subject.update_form(nil) }.not_to change{ Form.count }
+      expect(subject.form).to eq old_form
     end
   end
 end

--- a/spec/services/form_validator_spec.rb
+++ b/spec/services/form_validator_spec.rb
@@ -39,6 +39,12 @@ describe FormValidator do
         params.merge!(address1: "")
         expect(subject).to_not be_valid
       end
+
+      it "with paragraph data type and empty string" do
+        element.update_attributes(data_type: 'paragraph')
+        params.merge!(address1: "")
+        expect(subject).to_not be_valid
+      end
     end
   end
 
@@ -161,17 +167,43 @@ describe FormValidator do
     end
   end
 
-  describe 'text length validation' do
-    let!(:name) { create :form_element, form: form, required: false, label: 'Name', name: 'name' }
-    let!(:address) { create :form_element, form: form, required: false, label: 'Address ', name: 'address1' }
-    let(:params){  {form_id: form.id, name: 'a'*250, address1: 'b'*249 } }
+  describe 'with text as data type' do
+    let(:element) { create :form_element, form: form, required: false, label: 'Address', name: 'address1' }
+    let(:params){  {form_id: element.form_id, address1: 'b'*249 } }
 
-    it 'name is too long' do
-      expect(subject.errors[:name].first).to match(/less than 250/)
+    it 'is valid with a 249 character string' do
+      expect(subject.errors).to be_empty
     end
 
-    it 'address1 is not too long' do
-      expect(subject.errors[:address1]).to be_empty
+    it 'is invalid with a 250 character string' do
+      params.merge!(address1: 'b'*250)
+      expect(subject.errors).not_to be_empty
+      expect(subject.errors[:address1].first).to match(/less than 250/)
+    end
+  end
+
+  describe 'with comment as data type' do
+    let(:element) { create :form_element, :paragraph, form: form, required: false, label: 'Address', name: 'address1' }
+    let(:params){  {form_id: element.form_id, address1: 'b'*9_999 } }
+
+    it 'is valid with a 9,999 character string' do
+      expect(subject.errors).to be_empty
+    end
+
+    it 'is valid with a nil when element not required' do
+      params.merge!(address1: nil)
+      expect(subject.errors).to be_empty
+    end
+
+    it 'is valid with an empty string when element not required' do
+      params.merge!(address1: '')
+      expect(subject.errors).to be_empty
+    end
+
+    it 'is invalid with a 10,000 character string' do
+      params.merge!(address1: 'b'*10_000)
+      expect(subject.errors).not_to be_empty
+      expect(subject.errors[:address1].first).to match(/less than 10000/)
     end
   end
 end


### PR DESCRIPTION
Originally this was just to add the textarea comment type to the forms, which is done and can be reviewed. It still has some outstanding translations though, so I'm going to use this PR to also address all the various bugs and improvements to the form editor listed in [this ticket](https://www.pivotaltracker.com/story/show/113178647), which are reproduced below.

Right now when trying to add a custom element to a form:
- Field type selector displays below label/name selector. It should display above. 
- The error message if the name (internal) is not valid persists until page refresh. It should disappear (or update) when I re-attempt to add that form element. 
- If you insert an internal name that is not valid, it appends action_ to the front of the name in the field (rather than just adding this automatically, although I think it does that, too, resulting in a field called action_action_xxxx)
- Applying a template after one has been applied causes an error
- The tooltip says that it will append the name with data_. That's wrong, it will append with action_
- The error message and tooltip should be more descriptive (e.g. Check you didn't include any spaces in your name, which are not accepted). 
- Once you've added a form element, there's no way to view or edit the internal name, which would be good.
- Once you add a form field, the type/label/name fields should clear out ready to add the next one.
- Right now copy is "Customize your petition form". It should be "Customize your form".
- **Form controller HAS NO SPEC!!!**