### PR TITLE
Make image uploader show model validation errors

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -5,7 +5,11 @@ class ImagesController < ApplicationController
     @image = @page.images.create( image_params )
 
     respond_to do |format|
-      format.js { render partial: 'images/thumbnail', locals: { image: @image } }
+      if @image.errors.empty?
+        format.js { render partial: 'images/thumbnail', locals: { image: @image } }
+      else
+        format.js { render json: @image.errors.full_messages.first, status: 422 }
+      end
     end
   end
 

--- a/spec/controllers/images_controller_spec.rb
+++ b/spec/controllers/images_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe ImagesController do
   let(:page)  { instance_double('Page', valid?: true) }
-  let(:image) { double('image', content: 'foo') }
+  let(:image) { double('image', content: 'foo', errors: []) }
 
   before do
     allow(Page).to receive(:find){ page }
@@ -10,7 +10,7 @@ describe ImagesController do
 
   describe 'POST #create' do
     before do
-      allow(page).to receive_message_chain(:images, :create)
+      allow(page).to receive_message_chain(:images, :create).and_return(image)
     end
 
     subject { post :create, page_id: '1', image: { content: 'foo' }, format: :js }
@@ -23,6 +23,14 @@ describe ImagesController do
     it 'creates image' do
       expect(page).to receive_message_chain(:images, :create).with(content: 'foo')
       subject
+    end
+
+    it 'responds with errors if unsuccessful' do
+      image = instance_double('Image', id: nil, errors: instance_double('ActiveRecord::Errors', empty?: false, full_messages: ['Content type is invalid', 'File is too large']))
+      allow(page).to receive_message_chain(:images, :create).and_return(image)
+      post :create, page_id: '1', image: { content: 'foo' }, format: :js
+      expect(response.status).to eq 422
+      expect(response.body).to eq 'Content type is invalid'
     end
   end
 


### PR DESCRIPTION
The image controller couldn't handle Image model validation errors and it just returned the error page html and stuffed it in a stupidly long tooltip. This is now handled properly, and I added a spec.