### PR TITLE
Add a privacy notice to the bottom of forms with email

### DIFF
--- a/app/assets/stylesheets/sumofus/components/fundraiser.scss
+++ b/app/assets/stylesheets/sumofus/components/fundraiser.scss
@@ -26,7 +26,7 @@
     &--static {
       position: static;
       float: none;
-      margin: 20px auto;
+      margin: 15px auto 9px;
     }
   }
   &__amount-button {
@@ -166,13 +166,6 @@
     left: 26px;
     color: #f8492e;
     font-size: 30px;
-  }
-  &__fine-print {
-    font-size: 12px;
-    color: $slate-gray;
-    line-height: 16px;
-    width: 100%;
-    float: left;
   }
   &__first-continue {
     margin-bottom: 20px;

--- a/app/assets/stylesheets/sumofus/components/petition.scss
+++ b/app/assets/stylesheets/sumofus/components/petition.scss
@@ -126,6 +126,15 @@
     display: block;
   }
 
+  &__fine-print {
+    font-size: 12px;
+    color: $slate-gray;
+    line-height: 16px;
+    width: 100%;
+    float: left;
+    margin-top: 10px;
+  }
+
   &__mobile-ui {
 
     @media(min-width: $mobile-width) {

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -48,9 +48,6 @@
             <button class="fundraiser-bar__first-continue button" style="display:none;">
               {{ 'fundraiser.proceed_to_details' | t }}
             </button>
-            <div class="fundraiser-bar__fine-print">
-              {{ 'fundraiser.fine_print' | t }}
-            </div>
           </div>
           <div class="fundraiser-bar__step-panel" data-step="2">
             {% capture cta %}{{ 'fundraiser.proceed_to_payment' | t }}{% endcapture %}
@@ -60,6 +57,10 @@
               form_url_postscript: '/validate',
               outstanding_fields: plugins.fundraiser[ref].outstanding_fields,
               fields: plugins.fundraiser[ref].fields %}
+            <div class="fundraiser-bar__fine-print">
+              {% capture privacy_link %}<a href="https://sumofus.org/privacy" target="_blank">{{ 'petition.privacy_link' | t }}</a>{% endcapture %}
+              {{ 'petition.fine_print' | val: 'privacy_link', privacy_link | t }}
+            </div>
           </div>
           <div class="fundraiser-bar__step-panel form--big" data-step="3">
             <div class="fundraiser-bar__welcome-text hidden-irrelevant">
@@ -94,6 +95,9 @@
               </div>
               <button type="submit" class="button fundraiser-bar__submit-button">{{ 'form.submit' | t }}</button>
             </form>
+            <div class="fundraiser-bar__fine-print">
+              {{ 'fundraiser.fine_print' | t }}
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -19,7 +19,6 @@
           </p>
         </div>
         <div class="petition-bar__main">
-
           <div class="mobile-hide">
             {% include 'Thermometer' %}
           </div>
@@ -28,6 +27,10 @@
             form_id: plugins.petition[ref].form_id,
             outstanding_fields: plugins.fundraiser[ref].outstanding_fields,
             fields: plugins.petition[ref].fields %}
+          <div class="petition-bar__fine-print">
+            {% capture privacy_link %}<a href="https://sumofus.org/privacy" target="_blank">{{ 'petition.privacy_link' | t }}</a>{% endcapture %}
+            {{ 'petition.fine_print' | val: 'privacy_link', privacy_link | t }}
+          </div>
         </div>
       </div>
     </div>

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -41,6 +41,8 @@ de:
     confirmation: Ihr Name wurde übermittelt
     excited_confirmation: Ihr Name wurde übermittelt!
     thank_you: 'Vielen Dank, dass Sie "%{petition_title}" mit Ihrer Unterschrift unterstützen.'
+    fine_print: "SumOfUs schützt %{privacy_link} und hält Sie auf dem Laufenden über diese und andere Kampagnen."
+    privacy_link: Ihre Daten
   form:
     welcome_back: Willkommen zurück
     switch_user: Nicht Sie?

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -41,6 +41,8 @@ en:
     confirmation: Name submitted
     excited_confirmation: Name submitted!
     thank_you: 'Thanks for adding your name to "%{petition_title}"!'
+    fine_print: "SumOfUs will protect %{privacy_link}, and keep you updated about this and similar campaigns."
+    privacy_link: your privacy
   form:
     welcome_back: Welcome back
     switch_user: Not you?

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -41,6 +41,8 @@ fr:
     confirmation: Nom envoyé
     excited_confirmation: Nom envoyé!
     thank_you: 'Merci d’avoir ajouté votre nom à la pétition "%{petition_title}"!'
+    fine_print: "SumOfUs protège %{privacy_link} et vous tiendra au courant de campagnes similaires."
+    privacy_link: vos informations personnelles
   form:
     welcome_back: Bienvenue
     switch_user: Ce n’est pas vous?


### PR DESCRIPTION
This PR adds a disclaimer with a link to our privacy policy to the bottom of petition forms and to the second step of the fundraiser form. It also moves the donation fine print to step 3 of the donation form so it is shown even if the amount is preselected.

Paul originally wanted the donation form's privacy notice to go on step 3, but that made step 3 vertically too long. I also realized that people never skip step 2 if they're registering for the list for the first time, so it makes sense to put it there. Here's how it looks now:

![fine-print](https://cloud.githubusercontent.com/assets/102218/13475255/6e94e8c4-e087-11e5-814b-d27f2dfd758b.gif)
