### PR TITLE
Show an explanatory message to users with javascript turned off

### DIFF
--- a/app/assets/stylesheets/sumofus/pages/page.scss
+++ b/app/assets/stylesheets/sumofus/pages/page.scss
@@ -24,3 +24,6 @@
   padding: 30px 5% 10px;
   margin-left: -5%;
 }
+.noscript-notice {
+  line-height: 1.3em;
+}

--- a/app/liquid/views/partials/_no_script.liquid
+++ b/app/liquid/views/partials/_no_script.liquid
@@ -1,0 +1,11 @@
+<noscript class="noscript-notice">
+  {{ 'page.no_script' | t }}
+  <style type="text/css">
+    .script-dependent {
+      display: none;
+    }
+    .script-dependent__for-height {
+      height: auto !important;
+    }
+  </style>
+</noscript>

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -2,12 +2,12 @@
   <div class="fundraiser-bar {{ extra_class }}">
     <div class="fundraiser-bar__mobile-view fundraiser-bar__mobile-view--closed">
       <div class="fundraiser-bar__content">
-        <div class="fundraiser-bar__top">
+        <div class="fundraiser-bar__top script-dependent__for-height">
           <div class="fundraiser-bar__mobile-ui">
             <a class="fundraiser-bar__close-button">&#x2715;</a>
           </div>
           <h2>{{ plugins.fundraiser[ref].title }}</h2>
-          <div class="fundraiser-bar__steps">
+          <div class="fundraiser-bar__steps script-dependent">
             <hr class="fundraiser-bar__step-connector" />
             <div class="fundraiser-bar__step-label" data-step="1">
               <div class="fundraiser-bar__step-number fundraiser-bar__step-number--past">1</div>
@@ -30,13 +30,14 @@
           </div>
         </div>
         <div class="fundraiser-bar__main form--big">
+          {% include 'No Script' %}
           <div class="fundraiser-bar__errors hidden-closed">
             <span class="fa fa-exclamation-triangle"></span>
             <div class="fundraiser-bar__error-intro">
               {{ 'fundraiser.error_intro' | t }}
             </div>
           </div>
-          <div class="fundraiser-bar__step-panel" data-step="1">
+          <div class="fundraiser-bar__step-panel script-dependent" data-step="1">
             <div class="fundraiser-bar__amount-buttons">
             </div>
             <input class="fundraiser-bar__custom-field" placeholder="{{ 'fundraiser.other_amount' | t }}" />
@@ -52,7 +53,7 @@
               {{ 'fundraiser.fine_print' | t }}
             </div>
           </div>
-          <div class="fundraiser-bar__step-panel" data-step="2">
+          <div class="fundraiser-bar__step-panel script-dependent" data-step="2">
             {% capture cta %}{{ 'fundraiser.proceed_to_payment' | t }}{% endcapture %}
             {% include 'Form',
               cta: cta,
@@ -61,7 +62,7 @@
               outstanding_fields: plugins.fundraiser[ref].outstanding_fields,
               fields: plugins.fundraiser[ref].fields %}
           </div>
-          <div class="fundraiser-bar__step-panel form--big" data-step="3">
+          <div class="fundraiser-bar__step-panel form--big script-dependent" data-step="3">
             <div class="fundraiser-bar__welcome-text hidden-irrelevant">
               {{ 'form.welcome_back' | t }},
               <span class="fundraiser-bar__welcome-name"></span>! <br />

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -19,15 +19,17 @@
           </p>
         </div>
         <div class="petition-bar__main">
-
           <div class="mobile-hide">
             {% include 'Thermometer' %}
           </div>
-          {% include 'Form',
-            cta: plugins.petition[ref].cta,
-            form_id: plugins.petition[ref].form_id,
-            outstanding_fields: plugins.fundraiser[ref].outstanding_fields,
-            fields: plugins.petition[ref].fields %}
+          {% include 'No Script' %}
+          <div class="script-dependent">
+            {% include 'Form',
+              cta: plugins.petition[ref].cta,
+              form_id: plugins.petition[ref].form_id,
+              outstanding_fields: plugins.fundraiser[ref].outstanding_fields,
+              fields: plugins.petition[ref].fields %}
+          </div>
         </div>
       </div>
     </div>

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -1,7 +1,7 @@
 de:
   page:
     more_info: Mehr Informationen
-    no_script: "Thanks for coming to learn about this issue! Unfortunately, you can't take action while Javascript is disabled in your browser. Please enable Javascript or return in a browser with Javascript enabled to take action."
+    no_script: "Vielen Dank für Ihr Interesse an diesem Thema. Leider können Sie nur unterzeichnen, wenn Javascript in Ihrem Browser aktiviert ist. Bitte aktivieren Sie Javascript oder versuchen Sie es noch einmal mit einem anderen Browser, der Javascript erlaubt."
   basics:
     or: oder
   branding:

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -1,6 +1,7 @@
 de:
   page:
     more_info: Mehr Informationen
+    no_script: "Thanks for coming to learn about this issue! Unfortunately, you can't take action while Javascript is disabled in your browser. Please enable Javascript or return in a browser with Javascript enabled to take action."
   basics:
     or: oder
   branding:

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -39,8 +39,8 @@ de:
   petition:
     sign_it: Petition Unterschreiben
     target_prefix: AN
-    confirmation: Ihr Name wurde übermittelt
-    excited_confirmation: Ihr Name wurde übermittelt!
+    confirmation: Ihre Unterschrift wurde der Petition hinzugefügt
+    excited_confirmation: Ihre Unterschrift wurde der Petition hinzugefügt!
     thank_you: 'Vielen Dank, dass Sie "%{petition_title}" mit Ihrer Unterschrift unterstützen.'
   form:
     welcome_back: Willkommen zurück

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -1,6 +1,7 @@
 en:
   page:
     more_info: More information
+    no_script: "Thanks for coming to learn about this issue! Unfortunately, you can't take action while Javascript is disabled in your browser. Please enable Javascript or return in a browser with Javascript enabled to take action."
   basics:
     or: or
   branding:

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -1,7 +1,7 @@
 fr:
   page:
     more_info: Plus d’informations
-    no_script: "Thanks for coming to learn about this issue! Unfortunately, you can't take action while Javascript is disabled in your browser. Please enable Javascript or return in a browser with Javascript enabled to take action."
+    no_script: "Merci de votre intérêt pour ce problème ! Malheureusement, vous ne pouvez pas réaliser cette action tant que Javascript n'est pas activé sur votre navigateur. Merci d'activer Javascript ou d'utiliser un  navigateur avec Javascript actif pour pouvoir réaliser cette action."
   basics:
     or: ou
   branding:

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -1,7 +1,7 @@
 fr:
   page:
     more_info: Plus d’informations
-    no_script: "Merci de votre intérêt pour ce problème ! Malheureusement, vous ne pouvez pas réaliser cette action tant que Javascript n'est pas activé sur votre navigateur. Merci d'activer Javascript ou d'utiliser un  navigateur avec Javascript actif pour pouvoir réaliser cette action."
+    no_script: "Merci de votre intérêt pour ce problème ! Malheureusement, vous ne pouvez pas réaliser cette action tant que Javascript n'est pas activé sur votre navigateur. Merci d'activer Javascript ou d'utiliser un navigateur avec Javascript actif pour pouvoir réaliser cette action."
   basics:
     or: ou
   branding:

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -1,6 +1,7 @@
 fr:
   page:
     more_info: Plus d’informations
+    no_script: "Thanks for coming to learn about this issue! Unfortunately, you can't take action while Javascript is disabled in your browser. Please enable Javascript or return in a browser with Javascript enabled to take action."
   basics:
     or: ou
   branding:


### PR DESCRIPTION
If you submit our petition or donation forms with javascript turned off, rails authenticity token is not submitted and you get redirected to a 422 page. We might be able to debug around this, but it's a tiny use case, and donations with BT's hosted fields will never work without javascript. Instead, I'm just showing a message to the user about their javascript. I'm waiting on the languages team for translations.

<img width="350" alt="screenshot 2016-03-02 14 44 01" src="https://cloud.githubusercontent.com/assets/102218/13475341/e121ad00-e087-11e5-83ac-d384bd70350a.png">

<img width="346" alt="screenshot 2016-03-02 14 40 04" src="https://cloud.githubusercontent.com/assets/102218/13475343/e3abe5f4-e087-11e5-80b5-1a856114ce2e.png">
