### PR TITLE
Unsaved notice

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,6 +31,8 @@
 //= require datatables
 //= require datatables/dataTables.bootstrap
 
+//= require i18n
+//= require i18n/translations
 //= require show_errors
 //= require dropzone_image_upload
 //= require selectize_config

--- a/app/assets/javascripts/page_edit_bar.js
+++ b/app/assets/javascripts/page_edit_bar.js
@@ -202,8 +202,12 @@ let PageEditBar = Backbone.View.extend({
     let $lastSaved = $('.page-edit-bar__last-saved');
     const noNotice = $lastSaved.find('.page-edit-bar__unsaved-notice').length < 1;
     const unsavedDataExists = !_.isEqual(this.model.lastSaved, this.readData());
-    if (noNotice && unsavedDataExists){
-      $lastSaved.append(`<div class="page-edit-bar__unsaved-notice">${I18n.t('pages.edit.unsaved_changes')}</div>`);
+    if (unsavedDataExists){
+      if (noNotice) {
+        $lastSaved.append(`<div class="page-edit-bar__unsaved-notice">${I18n.t('pages.edit.unsaved_changes')}</div>`);
+      }
+    } else {
+      $lastSaved.find('.page-edit-bar__unsaved-notice').remove();
     }
   },
 

--- a/app/assets/javascripts/page_edit_bar.js
+++ b/app/assets/javascripts/page_edit_bar.js
@@ -121,11 +121,17 @@ let PageEditBar = Backbone.View.extend({
       if (data.refresh){ location.reload(); }
       this.enableSubmit();
       $.publish('page:saved', data);
-      let now = new Date();
       $('.page-edit-bar__save-box').removeClass('page-edit-bar__save-box--has-error');
       $('.page-edit-bar__error-message').text('');
-      $('.page-edit-bar__last-saved').text(`Last saved at ${now.getHours()}:${now.getMinutes()}:${now.getSeconds()}`);
+      $('.page-edit-bar__last-saved').text(`Last saved at ${this.currentTime()}`);
     }
+  },
+
+  currentTime: function() {
+    const now = new Date();
+    const minutes = (`0${now.getMinutes()}`).slice(-2); // for leading zero
+    const seconds = (`0${now.getSeconds()}`).slice(-2); // for leading zero
+    return `${now.getHours()}:${minutes}:${seconds}`
   },
 
   saveFailed: function() {

--- a/app/assets/javascripts/page_edit_bar.js
+++ b/app/assets/javascripts/page_edit_bar.js
@@ -123,7 +123,7 @@ let PageEditBar = Backbone.View.extend({
       $.publish('page:saved', data);
       $('.page-edit-bar__save-box').removeClass('page-edit-bar__save-box--has-error');
       $('.page-edit-bar__error-message').text('');
-      $('.page-edit-bar__last-saved').text(`Last saved at ${this.currentTime()}`);
+      $('.page-edit-bar__last-saved').text(I18n.t('pages.edit.last_saved_at', {time: this.currentTime()}));
     }
   },
 
@@ -141,10 +141,10 @@ let PageEditBar = Backbone.View.extend({
       $('.page-edit-bar__save-box').addClass('page-edit-bar__save-box--has-error')
       if(data.status == 422) {
         ErrorDisplay.show(e, data);
-        $('.page-edit-bar__error-message').text("The server didn't like something you entered. Click here to see the error.");
+        $('.page-edit-bar__error-message').text(I18n.t('pages.edit.user_error'));
         $.publish('page:errors');
       } else {
-        $('.page-edit-bar__error-message').text("The server unexpectedly messed up saving your work.");
+        $('.page-edit-bar__error-message').text(I18n.t('pages.edit.unknown_error'));
       }
     }
   },
@@ -171,13 +171,13 @@ let PageEditBar = Backbone.View.extend({
 
   disableSubmit: function(){
     this.outstandingSaveRequest = true;
-    this.$saveBtn.text('Saving...');
+    this.$saveBtn.text(I18n.t('pages.edit.saving'));
     this.$saveBtn.addClass('disabled');
   },
 
   enableSubmit: function(){
     this.outstandingSaveRequest = false;
-    this.$saveBtn.text('Save my work');
+    this.$saveBtn.text(I18n.t('pages.edit.save_work'));
     this.$saveBtn.removeClass('disabled');
   },
 
@@ -203,7 +203,7 @@ let PageEditBar = Backbone.View.extend({
     const noNotice = $lastSaved.find('.page-edit-bar__unsaved-notice').length < 1;
     const unsavedDataExists = !_.isEqual(this.model.lastSaved, this.readData());
     if (noNotice && unsavedDataExists){
-      $lastSaved.append('<div class="page-edit-bar__unsaved-notice">You have unsaved changes.</div>');
+      $lastSaved.append(`<div class="page-edit-bar__unsaved-notice">${I18n.t('pages.edit.unsaved_changes')}</div>`);
     }
   },
 

--- a/app/assets/javascripts/page_edit_bar.js
+++ b/app/assets/javascripts/page_edit_bar.js
@@ -17,7 +17,11 @@ let PageModel = Backbone.Model.extend({
       this.lastSaved = data;
       Backbone.Model.prototype.save.call(this, data, _.extend({patch: true}, callbacks));
     }
-  }
+  },
+
+  setLastSaved: function(data) {
+    this.lastSaved = data;
+  },
 
 });
 
@@ -175,14 +179,26 @@ let PageEditBar = Backbone.View.extend({
     const SAVE_PERIOD = 5000; // milliseconds
     const shouldAutosave = (this.$('.page-edit-bar__toggle-autosave').data('autosave') == true);
     this.autosave = true;
+    this.model.setLastSaved(this.readData());
     if (shouldAutosave != this.autosave) {
       this.toggleAutosave();
     }
     window.setInterval(() => {
       if(this.autosave) {
         this.save();
+      } else {
+        this.showUnsavedAlert();
       }
     }, SAVE_PERIOD)
+  },
+
+  showUnsavedAlert: function() {
+    let $lastSaved = $('.page-edit-bar__last-saved');
+    const noNotice = $lastSaved.find('.page-edit-bar__unsaved-notice').length < 1;
+    const unsavedDataExists = !_.isEqual(this.model.lastSaved, this.readData());
+    if (noNotice && unsavedDataExists){
+      $lastSaved.append('<div class="page-edit-bar__unsaved-notice">You have unsaved changes.</div>');
+    }
   },
 
 });

--- a/app/assets/stylesheets/page-edit.scss
+++ b/app/assets/stylesheets/page-edit.scss
@@ -154,6 +154,13 @@ body.page-edit-body {
     color: $page-edit-text-color;
     font-size: 12px;
   }
+  &__unsaved-notice {
+    display: inline-block;
+    background: $brand-danger;
+    padding: 2px 10px;
+    border-radius: 4px;
+    color: white;
+  }
   @media(min-width: 950px) {
     // put toggles and label inline
 

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -124,13 +124,19 @@ en:
       no_images_notice: "You haven't any photos. Drag your pics into the box below."
       layout_select: 'Page layout'
       follow_up_layout_select: 'Follow-up action'
-      no_layout: None selected
+      no_layout: 'None selected'
       change_layout: 'Change layout'
       change_follow_up: 'Change follow up'
       add_link: 'Add source'
       language_label: "Language"
       primary_image: 'Which is the main image for the page?'
       new_variant: 'Create new share variant'
+      unsaved_changes: 'You have unsaved changes.'
+      user_error: "The server didn't like something you entered. Click here to see the error."
+      unknown_error: "The server unexpectedly messed up saving your work."
+      last_saved_at: "Last saved at %{time}"
+      save_work: "Save my work"
+      saving: "Saving..."
     analytics:
       hours_chart_title: "Total actions last 12 hours"
       refresh: 'refresh'


### PR DESCRIPTION
This PR displays a notice in the save box when autosave is turned off and a campaigner has made changes that have not been pushed to the server. It does not display when autosave is turned on because it polls at the same rate as the autosave - if the "Unsaved changes" message would display on autosave, the save has already been dispatched.

![unsave-changes](https://cloud.githubusercontent.com/assets/102218/13542791/ffc88a5e-e22a-11e5-8984-01c42eaac771.gif)
