### PR TITLE
Set up Newrelic deploy event and brush up the deploy script.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'action2.sumofus.org'
   staging:
-    branch: newrelic-deploy
+    branch: development
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'action2.sumofus.org'
   staging:
-    branch: development
+    branch: newrelic-deploy
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,16 +20,14 @@ mv temp .ebextensions/04_newrelic.config
 envsubst '$ENV_URL' <.ebextensions/05_nginx_proxy.config >temp
 mv temp .ebextensions/05_nginx_proxy.config
 
-echo 'Shipping source bundle to S3...'
-zip -r9 $SHA1-config.zip Dockerrun.aws.json ./.ebextensions/
-SOURCE_BUNDLE=$SHA1-config.zip
-
 echo 'Shipping static assets to S3...'
 id=$(docker create soutech/champaign_web:$SHA1)
 docker cp $id:/myapp/public/assets statics
-
 aws s3 sync statics/ s3://$STATIC_BUCKET/assets/
 
+echo 'Shipping source bundle to S3...'
+zip -r9 $SHA1-config.zip Dockerrun.aws.json ./.ebextensions/
+SOURCE_BUNDLE=$SHA1-config.zip
 aws configure set default.region $AWS_REGION
 aws s3 cp $SOURCE_BUNDLE s3://$EB_BUCKET/$SOURCE_BUNDLE
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,7 +57,7 @@ aws elasticbeanstalk create-application-version --application-name "$AWS_APPLICA
 STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
 
 if [ "$STATUS" != "Ready" ]; then
-    echo -e "\Waiting for application state to clear up for deployment. "
+    echo -e "Waiting for application state to clear up for deployment. "
     echo -n "."
     wait_until_ready
 fi
@@ -67,17 +67,17 @@ aws elasticbeanstalk update-environment --environment-name $AWS_ENVIRONMENT_NAME
     --version-label $SHA1
 
 STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
-echo -e "\Waiting for deploy to finish. "
+echo -e "Waiting for deploy to finish. "
 wait_until_ready
 
-VERSION_LABEL="$(check_application_version $SHA1)"
+VERSION_LABEL="$(check_application_version $AWS_ENVIRONMENT_NAME)"
 if [ "$VERSION_LABEL" == "$SHA1" ]; then
-    echo -e "\Application deployed succesfully. Triggering NewRelic deploy event."
+    echo -e "Application deployed succesfully. Triggering NewRelic deploy event."
     curl -X POST -H "x-api-key: $NEWRELIC_LICENSE_KEY" \
     -d "deployment[app_name]=$AWS_APPLICATION_NAME" \
     -d "Deploying version $SHA1 to $AWS_ENVIRONMENT_NAME" https://api.newrelic.com/deployments.xml
     echo "All done!"
 else
-    echo -e "\Deploy failed - application version reverted. Check out deployment logs for details."
+    echo -e "Deploy failed - application version reverted. Check out deployment logs for details."
     exit 1
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,7 +57,7 @@ aws elasticbeanstalk create-application-version --application-name "$AWS_APPLICA
 STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
 
 if [ "$STATUS" != "Ready" ]; then
-    echo -e "Waiting for application state to clear up for deployment. "
+    echo "Waiting for application state to clear up for deployment. "
     echo -n "."
     wait_until_ready
 fi
@@ -67,17 +67,17 @@ aws elasticbeanstalk update-environment --environment-name $AWS_ENVIRONMENT_NAME
     --version-label $SHA1
 
 STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
-echo -e "Waiting for deploy to finish. "
+echo "Waiting for deploy to finish. "
 wait_until_ready
 
 VERSION_LABEL="$(check_application_version $AWS_ENVIRONMENT_NAME)"
 if [ "$VERSION_LABEL" == "$SHA1" ]; then
-    echo -e "Application deployed succesfully. Triggering NewRelic deploy event."
+    echo "Application deployed succesfully. Triggering NewRelic deploy event."
     curl -X POST -H "x-api-key: $NEWRELIC_LICENSE_KEY" \
     -d "deployment[app_name]=$AWS_APPLICATION_NAME" \
     -d "Deploying version $SHA1 to $AWS_ENVIRONMENT_NAME" https://api.newrelic.com/deployments.xml
     echo "All done!"
 else
-    echo -e "Deploy failed - application version reverted. Check out deployment logs for details."
+    echo "Deploy failed - application version reverted. Check out deployment logs for details."
     exit 1
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,77 +7,95 @@ export AWS_ENVIRONMENT_NAME=$3
 STATIC_BUCKET=$4
 export ENV_URL=$5
 
-echo 'Setting up configuration for Papertrail logging'
-export PAPERTRAIL_HOST=$(cut -d ":" -f 1 <<< $5)
-export PAPERTRAIL_PORT=$(cut -d ":" -f 2 <<< $5)
-export PAPERTRAIL_SYSTEM=$3
-cat .ebextensions/03_papertrail.config | envsubst '$PAPERTRAIL_HOST:$PAPERTRAIL_PORT:$PAPERTRAIL_SYSTEM' >temp
-mv temp .ebextensions/03_papertrail.config
+function ebextensions_setup() {
+    echo 'Setting up configuration for Papertrail logging'
+    export PAPERTRAIL_HOST=$(cut -d ":" -f 1 <<< $ENV_URL)
+    export PAPERTRAIL_PORT=$(cut -d ":" -f 2 <<< $ENV_URL)
+    export PAPERTRAIL_SYSTEM=$AWS_ENVIRONMENT_NAME
+    cat .ebextensions/03_papertrail.config | envsubst '$PAPERTRAIL_HOST:$PAPERTRAIL_PORT:$PAPERTRAIL_SYSTEM' >temp
+    mv temp .ebextensions/03_papertrail.config
 
-echo 'Applying environment-specific configuration in .ebextensions'
-envsubst '$AWS_ENVIRONMENT_NAME' <.ebextensions/04_newrelic.config >temp
-mv temp .ebextensions/04_newrelic.config
-envsubst '$ENV_URL' <.ebextensions/05_nginx_proxy.config >temp
-mv temp .ebextensions/05_nginx_proxy.config
+    echo 'Applying environment-specific configuration in .ebextensions'
+    envsubst '$AWS_ENVIRONMENT_NAME' <.ebextensions/04_newrelic.config >temp
+    mv temp .ebextensions/04_newrelic.config
+    envsubst '$ENV_URL' <.ebextensions/05_nginx_proxy.config >temp
+    mv temp .ebextensions/05_nginx_proxy.config
+}
 
-echo 'Shipping static assets to S3...'
-id=$(docker create soutech/champaign_web:$SHA1)
-docker cp $id:/myapp/public/assets statics
-aws s3 sync statics/ s3://$STATIC_BUCKET/assets/
+function sync_s3() {
+    echo 'Shipping static assets to S3...'
+    id=$(docker create soutech/champaign_web:$SHA1)
+    docker cp $id:/myapp/public/assets statics
+    aws s3 sync statics/ s3://$STATIC_BUCKET/assets/
 
-echo 'Shipping source bundle to S3...'
-zip -r9 $SHA1-config.zip Dockerrun.aws.json ./.ebextensions/
-SOURCE_BUNDLE=$SHA1-config.zip
-aws configure set default.region $AWS_REGION
-aws s3 cp $SOURCE_BUNDLE s3://$EB_BUCKET/$SOURCE_BUNDLE
+    echo 'Shipping source bundle to S3...'
+    zip -r9 $SHA1-config.zip Dockerrun.aws.json ./.ebextensions/
+    SOURCE_BUNDLE=$SHA1-config.zip
+    aws configure set default.region $AWS_REGION
+    aws s3 cp $SOURCE_BUNDLE s3://$EB_BUCKET/$SOURCE_BUNDLE
+}
 
-function check_application_status() {
+function application_status() {
     echo $(aws elasticbeanstalk describe-environments --environment-names $1  2>/dev/null \
     | jq -r '.Environments[].Status')
 }
 
 function wait_until_ready() {
+    STATUS="$(application_status $AWS_ENVIRONMENT_NAME)"
+    echo $1
     while [[ "$STATUS" != "Ready" ]]
     do
         sleep 15s
-        STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
+        STATUS="$(application_status $AWS_ENVIRONMENT_NAME)"
         echo -n "."
     done
 }
 
-function check_application_version() {
+function get_version() {
     echo $(aws elasticbeanstalk describe-environments --environment-names $1  2>/dev/null \
     | jq -r '.Environments[].VersionLabel')
 }
 
-echo 'Creating new application version...'
-aws elasticbeanstalk create-application-version --application-name "$AWS_APPLICATION_NAME" \
-  --version-label $SHA1 --source-bundle S3Bucket=$EB_BUCKET,S3Key=$SOURCE_BUNDLE
+function version_exists() {
+    # Finds the specified version among versions for the AWS application, and checks that it is not empty
+    ! [[ -z $(echo $(aws elasticbeanstalk describe-application-versions --application-name \
+    "$AWS_APPLICATION_NAME" --version-label "$SHA1" 2>/dev/null)) ]]
+}
 
-STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
+function create_version() {
+    if ! version_exists; then
+        echo 'Creating new application version...'
+        aws elasticbeanstalk create-application-version --application-name "$AWS_APPLICATION_NAME" \
+          --version-label $SHA1 --source-bundle S3Bucket=$EB_BUCKET,S3Key=$SOURCE_BUNDLE
+    fi
+}
 
-if [ "$STATUS" != "Ready" ]; then
-    echo "Waiting for application state to clear up for deployment. "
-    echo -n "."
-    wait_until_ready
-fi
+function deploy() {
+    echo 'Updating environment...'
+    aws elasticbeanstalk update-environment --environment-name $AWS_ENVIRONMENT_NAME \
+        --version-label $SHA1
+    wait_until_ready "Waiting for deploy to finish. "
+    VERSION_LABEL="$(get_version $AWS_ENVIRONMENT_NAME)"
+    if [ "$VERSION_LABEL" == "$SHA1" ]; then
+        echo ""
+        echo "Application deployed succesfully. Triggering NewRelic deploy event."
+        new_relic_deploy
+        echo "All done!"
+    else
+        echo "Deploy failed - application version reverted. Check out deployment logs for details."
+        exit 1
+    fi
+}
 
-echo 'Updating environment...'
-aws elasticbeanstalk update-environment --environment-name $AWS_ENVIRONMENT_NAME \
-    --version-label $SHA1
-
-STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
-echo "Waiting for deploy to finish. "
-wait_until_ready
-
-VERSION_LABEL="$(check_application_version $AWS_ENVIRONMENT_NAME)"
-if [ "$VERSION_LABEL" == "$SHA1" ]; then
-    echo "Application deployed succesfully. Triggering NewRelic deploy event."
+function new_relic_deploy() {
     curl -X POST -H "x-api-key: $NEWRELIC_LICENSE_KEY" \
     -d "deployment[app_name]=$AWS_APPLICATION_NAME" \
     -d "Deploying version $SHA1 to $AWS_ENVIRONMENT_NAME" https://api.newrelic.com/deployments.xml
-    echo "All done!"
-else
-    echo "Deploy failed - application version reverted. Check out deployment logs for details."
-    exit 1
-fi
+}
+
+
+ebextensions_setup
+sync_s3
+create_version
+wait_until_ready "Waiting for application state to clear up for deployment. "
+deploy

--- a/deploy.sh
+++ b/deploy.sh
@@ -45,13 +45,13 @@ function check_application_status() {
     | jq -r '.Environments[].Status')
 }
 
-STATUS="$(stack_status $STACK_NAME)"
+STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
 
 echo -n "."
 while [[ "$STATUS" != "Ready" ]]
 do
   sleep 15s
-  STATUS="$(stack_status $STACK_NAME)"
+  STATUS="$(check_application_status $AWS_ENVIRONMENT_NAME)"
   if [ "$STATUS" = "Degraded" ]; then
       echo ""
       echo "Your application appears to have deployed, but its status is currently degraded. Have a look at what's up."


### PR DESCRIPTION
This sets up deploy events for New Relic, guarantees that the deploy events get triggered only after the application status is ready and when it's running the application version specified on deploy. It also changes the deploy script in that it now forces the build to wait for the application to be ready before it tries to deploy - this way, builds won't fail because of two deploys happening in a short succession.