### PR TITLE
Little fixes

### DIFF
--- a/app/assets/javascripts/page_edit_bar.js
+++ b/app/assets/javascripts/page_edit_bar.js
@@ -199,6 +199,7 @@ let PageEditBar = Backbone.View.extend({
   },
 
   showUnsavedAlert: function() {
+    $.publish('wysiwyg:submit'); // update wysiwyg
     let $lastSaved = $('.page-edit-bar__last-saved');
     const noNotice = $lastSaved.find('.page-edit-bar__unsaved-notice').length < 1;
     const unsavedDataExists = !_.isEqual(this.model.lastSaved, this.readData());

--- a/app/assets/stylesheets/sumofus/components/petition.scss
+++ b/app/assets/stylesheets/sumofus/components/petition.scss
@@ -29,7 +29,8 @@
     }
     @media(min-width: $mobile-width) {
       form, .petition-bar__petition-text, .thermometer,
-      .fundraiser-bar__steps, .fundraiser-bar__step-panel {
+      .fundraiser-bar__steps, .fundraiser-bar__step-panel,
+      .petition-bar__fine-print {
         max-width: 290px;
       }
       .fundraiser-bar__steps {


### PR DESCRIPTION
This PR fixes two little oversights -
- changing the content of the WYSIWYG did not set off the "unsaved changes" flag. that is now remedied.
- the privacy notice on the small-image petition form displayed too wide. that is now fixed.