### PR TITLE
Recurring features

### DIFF
--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -19,6 +19,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     'ajax:success form.action': 'advanceToPayment',
     'submit form#hosted-fields': 'disableButton',
     'change select.fundraiser-bar__currency-selector': 'switchCurrency',
+    'change input.fundraiser-bar__recurring': 'updateButton',
     'click .fundraiser-bar__engage-currency-switcher': 'showCurrencySwitcher',
     'click .fundraiser-bar__close-button': 'hide',
   },
@@ -50,10 +51,10 @@ const FundraiserBar = Backbone.View.extend(_.extend(
       this.selectizeCountry();
       $(window).on('resize', () => this.policeHeights());
     }
-    this.buttonText = I18n.t('form.submit');
     this.insertActionKitId(options.akid);
     this.insertSource(options.source);
     this.initializeRecurring(options.recurringDefault);
+    this.updateButton();
     $('.fundraiser-bar__open-button').on('click', () => this.reveal());
   },
 
@@ -158,14 +159,23 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     let parsed = parseFloat(amount);
     if (parsed > 0){
       this.donationAmount = parsed;
+      this.updateButton();
+    } else {
+      this.changeStep(1);
+    }
+  },
+
+  updateButton () {
+    if (this.donationAmount > 0) {
       let currencySymbol = this.CURRENCY_SYMBOLS[this.currency];
       let digits = (this.donationAmount === Math.floor(this.donationAmount)) ? 0 : 2;
       let donationAmount = `${currencySymbol}${this.donationAmount.toFixed(digits)}`;
-      this.buttonText = `<span class="fa fa-lock"></span><span>${I18n.t('fundraiser.donate', {amount: donationAmount})}</span>`;
+      let monthly = this.readRecurring() ? `<span> / ${I18n.t('fundraiser.month')}</span>` : '';
+      this.buttonText = `<span class="fa fa-lock"></span>
+                         <span>${I18n.t('fundraiser.donate', {amount: donationAmount})}</span>
+                         ${monthly}`;
       this.$('.fundraiser-bar__display-amount').text(donationAmount);
       this.$('.fundraiser-bar__submit-button').html(this.buttonText);
-    } else {
-      this.changeStep(1);
     }
   },
 

--- a/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
+++ b/app/assets/javascripts/sumofus/backbone/fundraiser_bar.js
@@ -33,6 +33,7 @@ const FundraiserBar = Backbone.View.extend(_.extend(
   //    location: a hash of location values inferred from the user's request
   //    member: an object with fields that will prefill the form
   //    akid: the actionkitid (akid) to save with the user request
+  //    recurringDefault: either 'donation', 'recurring', or 'only_recurring'
   //    pageId: the ID of the plugin's page database record.
   //      and array of numbers, integers or floats, to display as donation amounts
   initialize (options = {}) {
@@ -52,7 +53,22 @@ const FundraiserBar = Backbone.View.extend(_.extend(
     this.buttonText = I18n.t('form.submit');
     this.insertActionKitId(options.akid);
     this.insertSource(options.source);
+    this.initializeRecurring(options.recurringDefault);
     $('.fundraiser-bar__open-button').on('click', () => this.reveal());
+  },
+
+  initializeRecurring (recurringDefault) {
+    const $checkbox = this.$('input.fundraiser-bar__recurring');
+    switch(recurringDefault) {
+      case 'only_recurring':
+        $checkbox.parents('.form__group').addClass('hidden-irrelevant');
+        // deliberate fall-through to next case (no break)
+      case 'recurring':
+        $checkbox.prop('checked', true);
+        break;
+      default:
+        $checkbox.prop('checked', false);
+    }
   },
 
   initializeSkipping (options){

--- a/app/assets/javascripts/sumofus/backbone/hosted_fields.js
+++ b/app/assets/javascripts/sumofus/backbone/hosted_fields.js
@@ -65,6 +65,7 @@ const HostedFieldsMethods = {
     return (clientToken) => {
       this.$('.fundraiser-bar__fields-loading').addClass('hidden-closed');
       this.$('#hosted-fields').removeClass('hidden-closed');
+      this.policeHeights();
     }
   },
 

--- a/app/models/plugins/fundraiser.rb
+++ b/app/models/plugins/fundraiser.rb
@@ -1,6 +1,8 @@
 class Plugins::Fundraiser < ActiveRecord::Base
   include Plugins::HasForm
 
+  enum recurring_default: [:donation, :recurring, :only_recurring]
+
   belongs_to :page, touch: true
   belongs_to :donation_band
 

--- a/app/models/plugins/fundraiser.rb
+++ b/app/models/plugins/fundraiser.rb
@@ -13,7 +13,10 @@ class Plugins::Fundraiser < ActiveRecord::Base
     backup_id = donation_band.try(:id)
     bands = Donations::BandFinder.find_band(donation_band_name, backup_id)
     bands = bands.present? ? bands.internationalize : {}
-    attributes.merge(form_liquid_data(supplemental_data)).merge(donation_bands: bands)
+    attributes.merge(form_liquid_data(supplemental_data)).merge(
+      donation_bands: bands,
+      recurring_default: recurring_default
+    )
   end
 end
 

--- a/app/models/plugins/fundraiser.rb
+++ b/app/models/plugins/fundraiser.rb
@@ -1,7 +1,7 @@
 class Plugins::Fundraiser < ActiveRecord::Base
   include Plugins::HasForm
 
-  enum recurring_default: [:donation, :recurring, :only_recurring]
+  enum recurring_default: [:one_off, :recurring, :only_recurring]
 
   belongs_to :page, touch: true
   belongs_to :donation_band

--- a/app/views/plugins/fundraisers/_form.slim
+++ b/app/views/plugins/fundraisers/_form.slim
@@ -12,6 +12,9 @@
       .form-group
         = label_with_tooltip(f, :donation_band, t('plugins.fundraiser.donation_band'), t('tooltips.fundraiser.donation_band'))
         = f.select :donation_band_id, DonationBand.all.collect { |d| [d.name, d.id] }, {}, {class: 'form-control form-select'}
+      .form-group
+        = f.label :recurring_default
+        = f.select :recurring_default, Plugins::Fundraiser.recurring_defaults.keys.to_a.map { |key| [t("plugins.fundraiser.recurring_default.#{key}"), key] }, {}, {class: 'form-control form-select'}
 
     .well
       = render partial: 'plugins/shared/apply_form_template', locals: { plugin: plugin }

--- a/app/views/plugins/fundraisers/_form.slim
+++ b/app/views/plugins/fundraisers/_form.slim
@@ -13,8 +13,8 @@
         = label_with_tooltip(f, :donation_band, t('plugins.fundraiser.donation_band'), t('tooltips.fundraiser.donation_band'))
         = f.select :donation_band_id, DonationBand.all.collect { |d| [d.name, d.id] }, {}, {class: 'form-control form-select'}
       .form-group
-        = f.label :recurring_default
-        = f.select :recurring_default, Plugins::Fundraiser.recurring_defaults.keys.to_a.map { |key| [t("plugins.fundraiser.recurring_default.#{key}"), key] }, {}, {class: 'form-control form-select'}
+        = label_with_tooltip(f, :recurring_default, t('plugins.fundraiser.recurring_default'), t('tooltips.fundraiser.recurring_default'))
+        = f.select :recurring_default, Plugins::Fundraiser.recurring_defaults.keys.to_a.map { |key| [t("plugins.fundraiser.recurring_defaults.#{key}"), key] }, {}, {class: 'form-control form-select'}
 
     .well
       = render partial: 'plugins/shared/apply_form_template', locals: { plugin: plugin }

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -120,6 +120,7 @@
           source:           window.sumofus.personalization.urlParams.source,
           member:           window.sumofus.personalization.member,
           location:         window.sumofus.personalization.location,
+          recurringDefault: window.sumofus.personalization.urlParams.recurring_default || "{{ plugins.fundraiser[ref].recurring_default }}",
           outstandingFields:window.sumofus.personalization.outstandingFields
         });
       });

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -243,6 +243,10 @@ en:
     fundraiser:
       donation_band: "Default donation band for unknown user"
       title: "Title (eg 'Donate now')"
+      recurring_default:
+        donation: 'Default to one-time donation'
+        recurring: 'Default to recurring donation'
+        only_recurring: 'Only allow recurring donations'
 
   ak_logs:
     index:

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -73,6 +73,7 @@ en:
     thermometer_offset: "Number of fake signatures to add to true count"
     fundraiser:
       donation_band: "This determines the amounts displayed on the page to an unknown user without any information in their URL. Generally, you will want to stick with an option designed for non-donors."
+      recurring_default: 'This sets whether the recurring donation checkbox is checked and/or hidden by default. If the url param recurring_default=recurring, recurring_default=only_recurring or recurring_default=one_off is passed, that will override the behavior specified here.'
     petition:
       text: "Appears above the form - this is what the member is signing on to"
       target: "Appears just above the page title and with the petition text"
@@ -243,8 +244,9 @@ en:
     fundraiser:
       donation_band: "Default donation band for unknown user"
       title: "Title (eg 'Donate now')"
-      recurring_default:
-        donation: 'Default to one-time donation'
+      recurring_default: 'Default to recurring donation?'
+      recurring_defaults:
+        one_off: 'Default to one-time donation'
         recurring: 'Default to recurring donation'
         only_recurring: 'Only allow recurring donations'
 

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -13,6 +13,7 @@ de:
     details: Kontaktdaten
     payment: Zahlung
     donate: "%{amount} Spenden"
+    month: Monat
     error_intro: Leider konnten wir Ihre Zahlung nicht bearbeiten!
     currency_in: "Beträge werden in %{currency} angezeigt"
     switch_currency: Währung ändern

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -13,6 +13,7 @@ en:
     details: Details
     payment: Payment
     donate: "Donate %{amount}" # used on the submit button, eg 'Donate $15'
+    month: month
     error_intro: We were unable to process your donation!
     currency_in: "Values shown in %{currency}"
     switch_currency: Switch currency

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -13,6 +13,7 @@ fr:
     details: Détails
     payment: Paiement
     donate: "Donner %{amount}" # utilisé dans le bouton de validation, eg 'Donner 15€'
+    month: mois
     error_intro: Votre don n’a pas pu être effectué!
     currency_in: "Monnaie en %{currency}"
     switch_currency: Changer de monnaie

--- a/db/migrate/20160308201945_add_recurring_to_fundraiser.rb
+++ b/db/migrate/20160308201945_add_recurring_to_fundraiser.rb
@@ -1,0 +1,5 @@
+class AddRecurringToFundraiser < ActiveRecord::Migration
+  def change
+    add_column :plugins_fundraisers, :recurring_default, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229225740) do
+ActiveRecord::Schema.define(version: 20160308201945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -263,11 +263,12 @@ ActiveRecord::Schema.define(version: 20160229225740) do
     t.string   "title"
     t.string   "ref"
     t.integer  "page_id"
-    t.boolean  "active",           default: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.boolean  "active",            default: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
     t.integer  "form_id"
     t.integer  "donation_band_id"
+    t.integer  "recurring_default", default: 0,     null: false
   end
 
   add_index "plugins_fundraisers", ["donation_band_id"], name: "index_plugins_fundraisers_on_donation_band_id", using: :btree

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>Page not found (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
     .background-image-404 {

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -357,6 +357,80 @@ describe("Fundraiser", function() {
       });
     });
 
+    describe('recurring default', function(){
+      describe('is "recurring"', function(){
+        beforeEach(function(){
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: '3', recurringDefault: 'recurring'});
+        });
+
+        it('checks the recurring box', function(){
+          expect($('input.fundraiser-bar__recurring').prop('checked')).to.eq(true);
+        });
+
+        it('does not hide the recurring box', function(){
+          expect($('input.fundraiser-bar__recurring').parents('.form__group')).not.to.have.class('hidden-irrelevant');
+        });
+
+        it('adds "/ month" the button text', function(){
+          expect($('.fundraiser-bar__submit-button').text().trim().replace(/\s+/g, ' ')).to.eq('Donate $3 / month');
+        });
+      });
+
+      describe('is "only_recurring"', function(){
+        beforeEach(function(){
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: '3', recurringDefault: 'only_recurring'});
+        });
+
+        it('checks the recurring box', function(){
+          expect($('input.fundraiser-bar__recurring').prop('checked')).to.eq(true);
+        });
+
+        it('hides the recurring box', function(){
+          expect($('input.fundraiser-bar__recurring').parents('.form__group')).to.have.class('hidden-irrelevant');
+        });
+
+        it('adds "/ month" the button text', function(){
+          expect($('.fundraiser-bar__submit-button').text().trim().replace(/\s+/g, ' ')).to.eq('Donate $3 / month');
+        });
+      });
+
+      describe('is "one_off"', function(){
+        beforeEach(function(){
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: '3', recurringDefault: 'one_off'});
+        });
+
+        it('leaves the recurring box unchecked', function(){
+          expect($('input.fundraiser-bar__recurring').prop('checked')).to.eq(false);
+        });
+
+        it('does not hide the recurring box', function(){
+          expect($('input.fundraiser-bar__recurring').parents('.form__group')).not.to.have.class('hidden-irrelevant');
+        });
+
+        it('does not add "/ month" the button text', function(){
+          expect($('.fundraiser-bar__submit-button').text().trim().replace(/\s+/g, ' ')).to.eq('Donate $3');
+        });
+      });
+
+      describe('is an empty string', function(){
+        beforeEach(function(){
+          suite.fundraiserBar = new window.sumofus.FundraiserBar({ amount: '3', recurringDefault: ''});
+        });
+
+        it('leaves the recurring box unchecked', function(){
+          expect($('input.fundraiser-bar__recurring').prop('checked')).to.eq(false);
+        });
+
+        it('does not hide the recurring box', function(){
+          expect($('input.fundraiser-bar__recurring').parents('.form__group')).not.to.have.class('hidden-irrelevant');
+        });
+
+        it('does not add "/ month" the button text', function(){
+          expect($('.fundraiser-bar__submit-button').text().trim().replace(/\s+/g, ' ')).to.eq('Donate $3');
+        });
+      });
+    });
+
     describe('degenerate arguments', function(){
 
       describe('it starts on first step when amount', function(){

--- a/spec/models/plugins/fundraiser_spec.rb
+++ b/spec/models/plugins/fundraiser_spec.rb
@@ -42,4 +42,9 @@ describe Plugins::Fundraiser do
     expect(serialized[:donation_bands]).to eq(expected_converted_values)
   end
 
+  it 'serializes the recurring_default as its name string' do
+    fundraiser.only_recurring!
+    expect( fundraiser.liquid_data[:recurring_default] ).to eq 'only_recurring'
+  end
+
 end


### PR DESCRIPTION
This PR allows a campaigner to select a fundraiser as "Default to one-time donation", "Default to recurring donation", or "Only allow recurring donations" in the back end. That sets the default behavior for whether the fundraiser should have the "make recurring" box checked or not and whether the box should be visible or not. If the url param `recurring_default=recurring`, `recurring_default=only_recurring` or `recurring_default=donation` is passed, that will override the behavior specified in the back-end.

It also shows on the button if this is a recurring donation. I'm still waiting on sign-off from the languages team about the German and French versions, but the English version is below. 

![toggle-monthly](https://cloud.githubusercontent.com/assets/102218/13619814/cc47476e-e550-11e5-9b45-8f59b2c3c99b.gif)

<img width="584" alt="screenshot 2016-03-08 17 04 14" src="https://cloud.githubusercontent.com/assets/102218/13619818/d24aaa98-e550-11e5-8e55-77ccd895cd7e.png">

