### PR TITLE
Legacy pages

### DIFF
--- a/app/assets/stylesheets/sumofus/components/petition.scss
+++ b/app/assets/stylesheets/sumofus/components/petition.scss
@@ -30,7 +30,7 @@
     @media(min-width: $mobile-width) {
       form, .petition-bar__petition-text, .thermometer,
       .fundraiser-bar__steps, .fundraiser-bar__step-panel,
-      .petition-bar__fine-print {
+      .petition-bar__fine-print, .petition-bar__target {
         max-width: 290px;
       }
       .fundraiser-bar__steps {
@@ -107,6 +107,7 @@
   &__target {
     margin: 0 0 8px;
     font-weight: bold;
+    line-height: 1.2em;
     @include rem(font-size, 1rem, true);
   }
 

--- a/app/assets/stylesheets/sumofus/pages/page.scss
+++ b/app/assets/stylesheets/sumofus/pages/page.scss
@@ -1,5 +1,6 @@
 .main-feature {
   padding: 55px 0;
+  min-height: 380px;
 }
 
 .page-link {

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -6,10 +6,10 @@ class Form < ActiveRecord::Base
   DEFAULT_NAME = 'Basic'
 
   DEFAULT_FIELDS = [
-    { label: 'Email Address',  name: 'email',   required: true,  data_type: 'email'   },
-    { label: 'Full Name',      name: 'name',    required: true,  data_type: 'text'    },
-    { label: 'Country',        name: 'country', required: true,  data_type: 'country' },
-    { label: 'Postal Code',    name: 'postal',  required: false, data_type: 'postal'    }
+    { label: 'form.default.email',   name: 'email',   required: true,  data_type: 'email'   },
+    { label: 'form.default.name',    name: 'name',    required: true,  data_type: 'text'    },
+    { label: 'form.default.country', name: 'country', required: true,  data_type: 'country' },
+    { label: 'form.default.postal',  name: 'postal',  required: false, data_type: 'postal'  }
   ]
 
   has_paper_trail on: [:update, :destroy]

--- a/app/models/plugins/has_form.rb
+++ b/app/models/plugins/has_form.rb
@@ -32,8 +32,9 @@ module Plugins::HasForm
 
   def create_form
     return if form.present? && !form.form_elements.empty?
+    locale = try(:page).try(:language).try(:code) || I18n.default_locale
     self.form = FormDuplicator.duplicate(
-      DefaultFormBuilder.create
+      DefaultFormBuilder.create(locale: locale)
     )
   end
 

--- a/app/services/default_form_builder.rb
+++ b/app/services/default_form_builder.rb
@@ -1,7 +1,8 @@
 class DefaultFormBuilder
   class << self
-    def create
-      form = Form.masters.find_or_initialize_by(name: Form::DEFAULT_NAME)
+    def create(locale: 'en')
+      @locale = locale
+      form = Form.masters.find_or_initialize_by(name: default_name)
 
       return form unless form.new_record?
 
@@ -9,6 +10,10 @@ class DefaultFormBuilder
     end
 
     private
+
+    def default_name
+      "#{Form::DEFAULT_NAME} (#{@locale.upcase})"
+    end
 
     def build_fields(form)
       fields(form).each do |field|
@@ -19,7 +24,10 @@ class DefaultFormBuilder
     end
 
     def fields(form)
-      Form::DEFAULT_FIELDS.map{|field| field.merge(form: form)}
+      Form::DEFAULT_FIELDS.map do |field|
+        translated = I18n.t(field[:label], locale: @locale)
+        field.merge(form: form, label: translated)
+      end
     end
   end
 end

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-staging' 'champaign-assets-staging' 'logs3.papertrailapp.com:34848' 'action-staging.sumofus.org'
   testing:
     # Change the branch value to your branch name to push up your branch to the testing server automatically.
-    branch: google_site_speed
+    branch: legacy-pages
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -38,6 +38,11 @@ de:
       cvv: Die Kartenprüfnummer
       number: Die Kreditkartennummer
       expiration: Das Ablaufdatum
+    generic:
+      title: "Vielen Dank für Ihre Unterschrift! Können Sie unsere Arbeit bitte mit einer Spende unterstützen?"
+      target: Sie
+      ask: "Helfen Sie SumOfUs im weltweiten Kampf gegen die Macht von Großkonzernen mit einer Spende!"
+      body: "Vielen Dank, dass Sie die Petition unterschrieben haben. Das war großartig! Jede Stimme zählt, wenn wir uns weltweit mit Großkonzernen anlegen. Doch es gibt noch viel zu tun! Dafür benötigen wir Geld. SumOfUs finanziert sich fast ausschließlich aus den Spenden unserer Mitglieder – und jeder kleine Beitrag hilft. Dank Ihrer Spende können wir es mit den größten und skrupellosesten Konzernen aufnehmen und sie zur Verantwortung ziehen. Unterstützen Sie uns bitte heute mit einer Spende!"
   petition:
     sign_it: Petition Unterschreiben
     target_prefix: AN

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -51,6 +51,11 @@ de:
     switch_user: Nicht Sie?
     processing: In Bearbeitung...
     submit: Abschicken
+    default:
+      name: VOLLSTÄNDIGER NAME
+      email: E-MAIL
+      country: LAND
+      postal: PLZ
   thermometer:
     signatures_until_goal: "Noch %{remaining} Unterschriften bis zur Zielmarke %{goal}"
     signatures: Unterschriften

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -51,6 +51,11 @@ en:
     switch_user: Not you?
     processing: Processing...
     submit: Submit
+    default:
+      name: Full name
+      email: Email Address
+      country: Country
+      postal: Postal Code
   thermometer:
     signatures_until_goal: "%{remaining} signatures until %{goal}"
     signatures: signatures # as in '225 signatures'

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -38,6 +38,11 @@ en:
       cvv: CVV
       number: Card number
       expiration: Expiration date
+    generic:
+      title: "Thanks for taking action! Can you chip in to continue the fight?"
+      target: You
+      ask: "Can you donate to help SumOfUs continue to fight corporate power around the world?"
+      body: "Thanks for taking action with SumOfUs. You’re awesome! Your action helps fight corporate power all over the world. But there's still lots of work to be done. SumOfUs is funded almost entirely by small donations from people in our community just like you, so every little donation counts. Your donation means that we can take on the biggest, baddest corporations and hold them accountable. Will you provide a donation to help us keep fighting today?"
   petition:
     sign_it: Sign the petition
     target_prefix: TO

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -38,6 +38,11 @@ fr:
       cvv: Le CVV
       number: Le numéro de votre carte
       expiration: La date d’expiration
+    generic:
+      title: "Merci d’avoir agi ! Pouvez-vous faire un don afin de faire progresser le combat? "
+      target: Vous
+      ask: "Pouvez-vous faire un don afin d’aider SumOfUs à continuer de combattre le pouvoir grandissant des grandes entreprises dans le monde ?"
+      body: "Merci d’avoir agi avec SumOfUs ! Votre action aide à combattre le pouvoir des grandes entreprises dans le monde. Il reste cependant beaucoup à faire. SumOfUs dépend presque entièrement de petits dons faits par des personnes comme vous. Chaque petit don compte.Votre don signifie que nous pouvons défier les multinationales les plus puissantes et les plus malveillantes ainsi que leur faire rendre des comptes. Pourriez-vous faire un don afin de nous aider à continuer le combat aujourd’hui?"
   petition:
     sign_it: Signez la pétition
     target_prefix: Pétition adressée à

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -51,6 +51,11 @@ fr:
     switch_user: Ce n’est pas vous?
     processing: En cours de traitement...
     submit: Envoyer
+    default:
+      name: NOM COMPLET
+      email: ADRESSE EMAIL
+      country: PAYS
+      postal: CODE POSTAL
   thermometer:
     signatures_until_goal: "%{remaining} signatures jusqu'à %{goal}"
     signatures: signatures #, par exemple '225 signatures'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,9 @@ end
 
 
 # Forms
-DefaultFormBuilder.create
+['en', 'fr', 'de'].each do |locale|
+  DefaultFormBuilder.create(locale: locale)
+end
 
 # Create tags and their associations to ActionKit
 all_tags = [

--- a/lib/tasks/sumofus.rake
+++ b/lib/tasks/sumofus.rake
@@ -91,6 +91,9 @@ namespace :sumofus do
       titles
     end
 
+    pages_before = Page.count
+    start_timestamp = Time.now
+
     count, existing_image = 0, nil
     petition_layout_id = LiquidLayout.where(title: 'Petition With Small Image').first.id
     fundraiser_layout_id = LiquidLayout.where(title: 'Fundraiser With Large Image').first.id
@@ -127,7 +130,7 @@ namespace :sumofus do
         if existing_image.blank?
           existing_image = page.images.create(content: page_image_handle)
         else
-          Image.new(page: page, content: existing_image.content)
+          Image.create(page: page, content: existing_image.content)
         end
       end
       count +=1
@@ -136,6 +139,9 @@ namespace :sumofus do
     follow_image_handle.close if follow_image_handle != page_image_handle
     page_image_handle.close
 
-    puts "#{count} pages added to the database"
+    updated_count = Page.where('updated_at > ?', start_timestamp).where('created_at <= ?', start_timestamp).size
+    created_count = Page.count - pages_before
+
+    puts "#{created_count} pages added, #{updated_count} pages updated, #{page_data.size - updated_count - created_count} skipped"
   end
 end

--- a/lib/tasks/sumofus.rake
+++ b/lib/tasks/sumofus.rake
@@ -2,50 +2,102 @@ require 'open-uri'
 
 namespace :sumofus do
   desc 'Import legacy actions into your database from a specified file'
-  task seed_legacy_actions: :environment do
-    if ARGV[1].nil?
+  task :seed_legacy_actions, [:action_file, :page_img_file, :follow_img_file] => :environment do |task, args|
+
+    if args[:action_file].blank?
       abort('Requires a valid url to a file containing the legacy actions to seed.')
+    else
+      page_image_handle = open(args[:page_img_file])
     end
 
-    if ARGV[2].nil?
+    if args[:page_img_file].blank?
       abort('Requires a valid url to a file containing a default header image to attach to the page.')
+    else
+      puts "Loading page data"
+      page_data_handle = open(args[:action_file])
+      page_data = JSON.load(page_data_handle.read)
+      page_data_handle.close
+      puts "Page data loaded"
     end
 
-    file_handle = open(ARGV[1])
-    data = file_handle.read
-    file_handle.close
+    if args[:follow_img_file].blank?
+      follow_image_handle = open(args[:page_img_file])
+    else
+      follow_image_handle = open(args[:follow_img_file])
+    end
 
-    image_handle = open(ARGV[2])
+    def create_post_action_pages(layout_id, image_handle)
+      pages = {}
+      ['en', 'fr', 'de'].map do |locale|
+        page = Page.find_or_initialize_by(title: I18n.t('fundraiser.generic.title', locale: locale))
+        page.liquid_layout_id = layout_id
+        page.language_id = language_ids[locale]
+        page.content = I18n.t('fundraiser.generic.body', locale: locale)
+        page.save!
+        page.images.create!(content: image_handle) if page.images.empty?
+        pages[locale] = page
+      end
+      pages
+    end
 
-    parsed_data = JSON.load data
-    count = 0
-    layout_id = LiquidLayout.where(title: 'Petition With Small Image').first.id
-    parsed_data.each_pair do |k, entry|
-      count +=1
+    def manage_newlines(content)
+      content.
+        gsub(/(?:\n\r?|\r\n?)/, '<br>').
+        gsub(/<br *\/*>/, '<br>').
+        gsub(/<div><br>\t&nbsp;<\/div>/, '<br>').
+        gsub(/(<br>)*\s*<\/p>\s*(<br>)*\s*<p>\s*(<br>)*/, '</p><br><p>').
+        gsub(/(<br>)*\s*<\/div>\s*(<br>)*\s*<div>\s*(<br>)*/, '</p><br><p>').
+        gsub(/(\s*<br>\s*){3,}/, '<br><br>')
+    end
+
+    def language_ids
+      return @language_ids unless @language_ids.blank?
+      @language_ids = {}
+      Language.all.each do |l|
+        @language_ids[l.code] = l.id
+      end
+      @language_ids
+    end
+
+    count, existing_image = 0, nil
+    petition_layout_id = LiquidLayout.where(title: 'Petition With Small Image').first.id
+    fundraiser_layout_id = LiquidLayout.where(title: 'Fundraiser With Large Image').first.id
+
+    post_action_pages = create_post_action_pages(fundraiser_layout_id, follow_image_handle)
+
+    page_data.each_pair do |k, entry|
       title = entry['title'].blank? ? entry['petition_ask'] : entry['title']
-      page = Page.find_or_create_by!(title: title, liquid_layout_id: layout_id)
-      page.content = entry['page_content'].gsub(/(?:\n\r?|\r\n?)/, '<br>')
+      page = Page.find_or_create_by!(title: title, liquid_layout_id: petition_layout_id)
+      page.content = manage_newlines(entry['page_content'])
       Page.reset_counters(page.id, :actions)
       Page.update_counters(page.id, action_count: entry['signature_count'])
       page.language_id = Language.where(code: entry['language']).first.id
       page.active = true
       page.slug = entry['slug']
-      page.save
+      page.follow_up_plan = :with_page
+      page.follow_up_page = post_action_pages[entry['language']]
+      page.save!
       thermometer = Plugins::Thermometer.where(page_id: page.id).first
       thermometer.goal = entry['thermometer_target']
-      thermometer.save
-      petition_form = Plugins::Petition.where(page_id: page.id).first
-      petition_form.description = entry['petition_ask'].gsub('"', '').gsub('Petition Text:', '')
-      petition_form.target = entry['petition_target'].gsub(/Sign our petition to /i, '').gsub(/Sign the petition to /, '').gsub(/:/, '')
-      petition_form.save
+      thermometer.save!
+      petition = Plugins::Petition.where(page_id: page.id).first
+      petition.description = entry['petition_ask'].gsub('"', '').gsub('Petition Text:', '')
+      petition.target = entry['petition_target'].gsub(/Sign our petition to /i, '').gsub(/Sign the petition to /, '').gsub(/:/, '')
+      petition.save!
       if page.images.count == 0
-        page.images.create(content: image_handle)
+        if existing_image.blank?
+          existing_image = page.images.create(content: page_image_handle)
+        else
+          Image.new(page: page, content: existing_image.content)
+        end
       end
-
+      puts "Added page \"#{page.title}\" at <#{page.slug}>"
+      count +=1
     end
 
-    image_handle.close
+    follow_image_handle.close if follow_image_handle != page_image_handle
+    page_image_handle.close
 
-    p "#{count} pages added to the database"
+    puts "#{count} pages added to the database"
   end
 end

--- a/spec/lib/user_language_iso_spec.rb
+++ b/spec/lib/user_language_iso_spec.rb
@@ -21,8 +21,8 @@ describe UserLanguageISO do
     expect(subject.for( build(:language, :spanish ))).to eq({user_es: 1})
   end
 
-  it 'returns nothing for sweedish' do
-    expect(subject.for( build(:language, code: 'swe' ))).to eq({})
+  it 'returns nothing for swedish' do
+    expect(subject.for( build(:language, code: 'sv' ))).to eq({})
   end
 end
 

--- a/spec/models/plugins/shared_examples.rb
+++ b/spec/models/plugins/shared_examples.rb
@@ -3,8 +3,15 @@ shared_examples "plugin with form" do |plugin_type|
   let(:form) { create :form_with_email }
 
   it 'has a default form' do
-    expect(subject.form.name).to eq('Basic')
+    expect(subject.form.name).to eq('Basic (EN)')
     expect(subject.form.master?).to be false
+  end
+
+  it 'translates default form if page has a language' do
+    german = create :language, code: 'de'
+    page = create :page, language: german
+    plugin = create plugin_type, page: page
+    expect(plugin.form.name).to eq 'Basic (DE)'
   end
 
   it "can accept random supplemental data to liquid_data method" do

--- a/spec/services/default_form_builder_spec.rb
+++ b/spec/services/default_form_builder_spec.rb
@@ -11,6 +11,32 @@ describe DefaultFormBuilder do
     expect( DefaultFormBuilder.create.form_elements.size ).to eq(4)
   end
 
+  describe "i18n" do
+    it 'translates the fields to German' do
+      expect( DefaultFormBuilder.create(locale: 'de').form_elements.first.label ).to eq 'E-MAIL'
+    end
+
+    it 'translates the fields to French' do
+      expect( DefaultFormBuilder.create(locale: :fr).form_elements.first.label ).to eq 'ADRESSE EMAIL'
+    end
+
+    it 'translates the fields to English' do
+      expect( DefaultFormBuilder.create.form_elements.first.label ).to eq 'Email Address'
+    end
+
+    it 'marks the German form as DE' do
+      expect( DefaultFormBuilder.create(locale: 'de').name ).to eq "Basic (DE)"
+    end
+
+    it 'marks the French form as FR' do
+      expect( DefaultFormBuilder.create(locale: 'fr').name ).to eq "Basic (FR)"
+    end
+
+    it 'marks the English form as EN' do
+      expect( DefaultFormBuilder.create(locale: :en).name ).to eq "Basic (EN)"
+    end
+  end
+
   context 'when form already exists' do
     before {  DefaultFormBuilder.create  }
 
@@ -21,7 +47,7 @@ describe DefaultFormBuilder do
     end
 
     it 'returns existing form' do
-      expect( DefaultFormBuilder.create.name).to eq('Basic')
+      expect( DefaultFormBuilder.create.name).to eq('Basic (EN)')
     end
   end
 end

--- a/spec/services/search/page_searcher/page_searcher_spec_data.rb
+++ b/spec/services/search/page_searcher/page_searcher_spec_data.rb
@@ -30,7 +30,7 @@ RSpec.shared_context 'page_searcher_spec_data' do
   let!(:content_tag_plugin_layout_match) {
     create(:page,
            title: 'a non-matching title',
-           language: build(:language, code: 'SWE', name: 'Swedish'),
+           language: build(:language, code: 'de', name: 'German'),
            tags: [tag],
            content: test_text,
            liquid_layout: layout,


### PR DESCRIPTION
This PR wraps up the work to import legacy pages from ActionSweet. It handles a couple of parts that we didn't get to in the first round
- after taking an action on any of these pages, you now get redirected to a generic post-action donate page in the appropriate language
- the generic post-action donate page needed a default form in the right language, so I went ahead and I15d the default forms
- there was a bug where we were keying off of title, not slug, so various pages were all written to the same record, resulting in 404ing a dozen or so slugs.
- I did a bit of work to try to straighten out newline formatting and spacing on the page