### PR TITLE
I18n link dates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'slim-rails'
 gem 'liquid'
 gem 'remotipart', '~> 1.2'
 gem "i18n-js", ">= 3.0.0.rc12"
+gem 'rails-i18n', '~> 4.0.0'
 
 # Use Devise for Authentication
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails-i18n (4.0.8)
+      i18n (~> 0.7)
+      railties (~> 4.0)
     rails-observers (0.1.2)
       activemodel (~> 4.0)
     railties (4.2.5)
@@ -541,6 +544,7 @@ DEPENDENCIES
   rails-assets-odometer!
   rails-assets-speakingurl!
   rails-assets-underscore!
+  rails-i18n (~> 4.0.0)
   rails-observers
   readthis
   redis (>= 3.2.0)

--- a/app/liquid/liquid_i18n.rb
+++ b/app/liquid/liquid_i18n.rb
@@ -45,6 +45,10 @@ module LiquidI18n
     end
   end
 
+  def i18n_date(date, format = :default)
+    I18n.l( Time.parse(date), format: format.to_sym )
+  end
+
   def val(base, key, value)
     "#{base}, #{key}: #{value}"
   end

--- a/app/liquid/views/partials/_links.liquid
+++ b/app/liquid/views/partials/_links.liquid
@@ -8,7 +8,24 @@
       {{ link.source }}.
     {% endunless %}
     {% unless link.date == blank %}
-      {{ link.date | date: "%-d %B, %Y" }}.
+      {{ link.date | date: "%-d" }}
+      {% comment %} i18n of the month {% endcomment %}
+      {% assign m = link.date | date: "%-m" %}
+        {% case m %}
+          {% when '1' %}{{ 'links.january' | t }}
+          {% when '2' %}{{ 'links.february' | t }}
+          {% when '3' %}{{ 'links.march' | t }}
+          {% when '4' %}{{ 'links.april' | t }}
+          {% when '5' %}{{ 'links.may' | t }}
+          {% when '6' %}{{ 'links.june' | t }}
+          {% when '7' %}{{ 'links.july' | t }}
+          {% when '8' %}{{ 'links.august' | t }}
+          {% when '9' %}{{ 'links.september' | t }}
+          {% when '10' %}{{ 'links.october' | t }}
+          {% when '11' %}{{ 'links.november' | t }}
+          {% when '12' %}{{ 'links.december' | t }}
+        {% endcase %}
+      {{ link.date | date: "%Y" }}.
     {% endunless %}
   </div>
 {% endfor %}  

--- a/app/liquid/views/partials/_links.liquid
+++ b/app/liquid/views/partials/_links.liquid
@@ -8,24 +8,8 @@
       {{ link.source }}.
     {% endunless %}
     {% unless link.date == blank %}
-      {{ link.date | date: "%-d" }}
-      {% comment %} i18n of the month {% endcomment %}
-      {% assign m = link.date | date: "%-m" %}
-        {% case m %}
-          {% when '1' %}{{ 'links.january' | t }}
-          {% when '2' %}{{ 'links.february' | t }}
-          {% when '3' %}{{ 'links.march' | t }}
-          {% when '4' %}{{ 'links.april' | t }}
-          {% when '5' %}{{ 'links.may' | t }}
-          {% when '6' %}{{ 'links.june' | t }}
-          {% when '7' %}{{ 'links.july' | t }}
-          {% when '8' %}{{ 'links.august' | t }}
-          {% when '9' %}{{ 'links.september' | t }}
-          {% when '10' %}{{ 'links.october' | t }}
-          {% when '11' %}{{ 'links.november' | t }}
-          {% when '12' %}{{ 'links.december' | t }}
-        {% endcase %}
-      {{ link.date | date: "%Y" }}.
+      {{ link.date | i18n_date }}.
     {% endunless %}
   </div>
-{% endfor %}  
+{% endfor %}
+

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -88,5 +88,5 @@ de:
     contact: Kontakt (Impressum)
   time:
     formats:
-      default: "%-d %B, %Y"
+      default: "%-d. %B %Y"
 

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -86,16 +86,7 @@ de:
     about: Über Uns
     privacy_policy: Datenschutz
     contact: Kontakt (Impressum)
-  links:
-    january: Januar
-    february: Februar
-    march: März
-    april: April
-    may: Mai
-    june: Juni
-    july: Juli
-    august: August
-    september: September
-    october: Oktober
-    november: November
-    december: Dezember
+  time:
+    formats:
+      default: "%-d %B, %Y"
+

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -86,3 +86,16 @@ de:
     about: Über Uns
     privacy_policy: Datenschutz
     contact: Kontakt (Impressum)
+  links:
+    january: Januar
+    february: Februar
+    march: März
+    april: April
+    may: Mai
+    june: Juni
+    july: Juli
+    august: August
+    september: September
+    october: Oktober
+    november: November
+    december: Dezember

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -88,5 +88,5 @@ en:
     contact: Contact
   time:
     formats:
-      default: "%-d %B, %Y"
+      default: "%-d %B %Y"
 

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -86,4 +86,16 @@ en:
     about: About
     privacy_policy: Privacy Policy
     contact: Contact
-
+  links:
+    january: January
+    february: February
+    march: March
+    april: April
+    may: May
+    june: June
+    july: July
+    august: August
+    september: September
+    october: October
+    november: November
+    december: December

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -86,16 +86,7 @@ en:
     about: About
     privacy_policy: Privacy Policy
     contact: Contact
-  links:
-    january: January
-    february: February
-    march: March
-    april: April
-    may: May
-    june: June
-    july: July
-    august: August
-    september: September
-    october: October
-    november: November
-    december: December
+  time:
+    formats:
+      default: "%-d %B, %Y"
+

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -86,16 +86,8 @@ fr:
     about: Nous Connaitre
     privacy_policy: Mentions Légales
     contact: Contact
-  links:
-    january: janvier
-    february: février
-    march: mars
-    april: avril
-    may: mai
-    june: juin
-    july: juillet
-    august: août
-    september: septembre
-    october: octobre
-    november: novembre
-    december: décembre
+  time:
+    formats:
+      default: "%-d %B, %Y"
+
+

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -86,3 +86,16 @@ fr:
     about: Nous Connaitre
     privacy_policy: Mentions Légales
     contact: Contact
+  links:
+    january: janvier
+    february: février
+    march: mars
+    april: avril
+    may: mai
+    june: juin
+    july: juillet
+    august: août
+    september: septembre
+    october: octobre
+    november: novembre
+    december: décembre

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -88,6 +88,6 @@ fr:
     contact: Contact
   time:
     formats:
-      default: "%-d %B, %Y"
+      default: "%-d %B %Y"
 
 

--- a/spec/liquid/liquid_i18n_spec.rb
+++ b/spec/liquid/liquid_i18n_spec.rb
@@ -105,5 +105,26 @@ describe LiquidI18n do
       expect(subject.val(subject.val('rebel-bass', 'king', 'pin'), 'time', 'flies')).to eq "rebel-bass, king: pin, time: flies"
     end
   end
+
+
+  describe '#date_for_link' do
+    after(:all) do
+      I18n.locale = I18n.default_locale
+    end
+
+    {
+      en: "1 December, 2016",
+      fr: "1 décembre, 2016",
+      de: "1 Dezember, 2016"
+    }.each do |locale, translation|
+      it "localises date for #{locale}" do
+        I18n.locale = locale
+
+        expect(
+          subject.i18n_date('2016-12-01')
+        ).to eq(translation)
+      end
+    end
+  end
 end
 

--- a/spec/liquid/liquid_i18n_spec.rb
+++ b/spec/liquid/liquid_i18n_spec.rb
@@ -113,9 +113,9 @@ describe LiquidI18n do
     end
 
     {
-      en: "1 December, 2016",
-      fr: "1 décembre, 2016",
-      de: "1 Dezember, 2016"
+      en: "1 December 2016",
+      fr: "1 décembre 2016",
+      de: "1. Dezember 2016"
     }.each do |locale, translation|
       it "localises date for #{locale}" do
         I18n.locale = locale


### PR DESCRIPTION
OK -- Saturday morning fun. Attempting i18n of the date (in particular, month) based on some reading on liquid, for a ticket @edubsky created.

Questions: 

1) @edubsky: I think the traditional format in DE is 28. Mai 2015. This writes format as 28 Mai 2015 (i.e. without the period after the day) to keep it simple and standard across EN/DE/FR. Is that format OK or does it look odd/wrong in DE?

2) Do I also need to manually update the liquid templates on staging and production via the campaigner UI, or does this propagate from the codebase? 

3) Tell me what I've got wrong or missed! Haven't been able to test locally or anything as don't have Champaign running locally, and of course I'm totally winging it here.