### PR TITLE
Legacy tag

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,8 @@ require 'browser'
 
 class PagesController < ApplicationController
   before_action :authenticate_user!, except: [:show, :create, :follow_up]
-  before_action :get_page, only: [:show, :edit, :update, :destroy, :follow_up, :analytics]
+  before_action :get_page, only: [:edit, :update, :destroy, :follow_up, :analytics]
+  before_action :get_page_or_homepage, only: [:show]
 
   def index
     # Filter the desired pages by search parameters, and sort them descending by their date of update.
@@ -57,7 +58,7 @@ class PagesController < ApplicationController
   private
 
   def render_liquid(layout)
-    raise ActiveRecord::RecordNotFound unless @page.active? || user_signed_in?
+    return redirect_to(Settings.homepage_url) unless @page.active? || user_signed_in?
     localize_by_page_language(@page)
 
     @rendered = renderer(layout).render
@@ -80,6 +81,12 @@ class PagesController < ApplicationController
 
   def get_page
     @page = Page.find(params[:id])
+  end
+
+  def get_page_or_homepage
+    @page = Page.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to Settings.homepage_url
   end
 
   def page_params

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,1 @@
+homepage_url: '//sumofus.org'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -5,6 +5,7 @@ secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
 omniauth_client_secret: <%= ENV['OMNIAUTH_CLIENT_SECRET'] %>
 omniauth_client_id: <%= ENV['OMNIAUTH_CLIENT_ID'] %>
 liquid_templating_source: <%= ENV['LIQUID_TEMPLATING_SOURCE'] || 'store' %>
+homepage_url: '//sumofus.org'
 oauth_domain_whitelist:
   - 'sumofus.org'
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -16,6 +16,7 @@
      secret_key_base: 'a fake secret key'
      omniauth_client_secret: 'a fake client secret'
      omniauth_client_id: 'a fake client_id'
+     homepage_url: '//sumofus.org'
      oauth_domain_whitelist:
        - 'example.com'
 

--- a/lib/tasks/sumofus.rake
+++ b/lib/tasks/sumofus.rake
@@ -7,7 +7,7 @@ namespace :sumofus do
     # the actionkit_uri still needs to be confirmed
     return @tag unless @tag.blank?
     @tag = Tag.find_or_create_by(name: 'Actionsweet_Legacy')
-    @tag.update_attributes(actionkit_uri: '/rest/v1/tag/1170/')
+    @tag.update_attributes(actionkit_uri: '/rest/v1/tag/1693/')
     @tag
   end
 

--- a/lib/tasks/sumofus.rake
+++ b/lib/tasks/sumofus.rake
@@ -3,6 +3,14 @@ require 'open-uri'
 namespace :sumofus do
   desc 'Import legacy actions into your database from a specified file'
 
+  def legacy_tag
+    # the actionkit_uri still needs to be confirmed
+    return @tag unless @tag.blank?
+    @tag = Tag.find_or_create_by(name: 'Actionsweet_Legacy')
+    @tag.update_attributes(actionkit_uri: '/rest/v1/tag/1170/')
+    @tag
+  end
+
   task :check_legacy_actions, [:action_file] => :environment do |task, args|
     if args[:action_file].blank?
       abort('Requires a valid url to a file containing the legacy actions to seed.')
@@ -57,6 +65,12 @@ namespace :sumofus do
         expected_title = I18n.t('fundraiser.generic.title', locale: entry['language'])
         if follow_title != expected_title
           puts "Page at <#{entry['slug']}> has follow_up page with title #{follow_title}, should be #{expected_title}"
+        end
+
+        # check that it has the legacy tag
+        relevant_tags = page.tags.select{ |t| t.id == legacy_tag.id }
+        if relevant_tags != [legacy_tag]
+          puts "Page at <#{entry['slug']}> has tags #{page.tags.map(&:attributes)}, should include #{legacy_tag.attributes}"
         end
       rescue ActiveRecord::RecordNotFound
         puts "Page is missing: <#{entry['slug']}> with expected title \"#{entry['title']}\""
@@ -171,7 +185,8 @@ namespace :sumofus do
       page.title = titles[clean_title(entry)][entry['slug']]
       page.follow_up_plan = :with_page
       page.follow_up_page = post_action_pages[entry['language']]
-      puts "Adding page \"#{page.title}\" at <#{page.slug}>"
+      page.tags += [legacy_tag] unless page.tags.include? legacy_tag
+      puts "Processing page \"#{page.title}\" at <#{page.slug}>"
       page.save!
 
       # update plugins

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -146,28 +146,33 @@ describe PagesController do
       expect(assigns(:rendered)).to eq(renderer.render)
     end
 
-    it 'raises 404 if user not logged in and page unpublished' do
+    it 'redirects to sumofus.org if user not logged in and page unpublished' do
       allow(controller).to receive(:user_signed_in?) { false }
       allow(page).to receive(:active?){ false }
-      expect{ get :show, id: '1' }.to raise_error ActiveRecord::RecordNotFound
+      expect( get :show, id: '1' ).to redirect_to('//sumofus.org')
     end
 
-    it 'does not raise 404 if user not logged in and page published' do
+    it 'does not redirect to sumofus.org if user not logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { false }
       allow(page).to receive(:active?){ true }
-      expect{ get :show, id: '1' }.not_to raise_error
+      expect( get :show, id: '1' ).not_to be_redirect
     end
 
-    it 'does not raise 404 if user logged in and page unpublished' do
+    it 'does not redirect to sumofus.org if user logged in and page unpublished' do
       allow(controller).to receive(:user_signed_in?) { true }
       allow(page).to receive(:active?){ false }
-      expect{ get :show, id: '1' }.not_to raise_error
+      expect( get :show, id: '1' ).not_to be_redirect
     end
 
-    it 'does not raise 404 if user logged in and page published' do
+    it 'does not redirect to sumofus.org if user logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { true }
       allow(page).to receive(:active?){ true }
-      expect{ get :show, id: '1' }.not_to raise_error
+      expect( get :show, id: '1' ).not_to be_redirect
+    end
+
+    it 'redirects to sumofus.org if page is not found' do
+      allow(Page).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+      expect( get :show, id: '1000000' ).to redirect_to('//sumofus.org')
     end
 
     context 'on pages with localization' do
@@ -232,28 +237,33 @@ describe PagesController do
       expect(assigns(:rendered)).to eq(renderer.render)
     end
 
-    it 'raises 404 if user not logged in and page unpublished' do
+    it 'redirects to sumofus.org if user not logged in and page unpublished' do
       allow(controller).to receive(:user_signed_in?) { false }
       allow(page).to receive(:active?){ false }
-      expect{ get :show, id: '1' }.to raise_error ActiveRecord::RecordNotFound
+      expect( get :follow_up, id: '1' ).to redirect_to('//sumofus.org')
     end
 
-    it 'does not raise 404 if user not logged in and page published' do
+    it 'does not redirect to sumofus.org if user not logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { false }
-      allow(page).to       receive(:active?){ true }
-      expect{ get :show, id: '1' }.not_to raise_error
+      allow(page).to receive(:active?){ true }
+      expect( get :follow_up, id: '1' ).not_to be_redirect
     end
 
-    it 'does not raise 404 if user logged in and page unpublished' do
+    it 'does not redirect to sumofus.org if user logged in and page unpublished' do
       allow(controller).to receive(:user_signed_in?) { true }
       allow(page).to receive(:active?){ false }
-      expect{ get :show, id: '1' }.not_to raise_error
+      expect( get :follow_up, id: '1' ).not_to be_redirect
     end
 
-    it 'does not raise 404 if user logged in and page published' do
+    it 'does not redirect to sumofus.org if user logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { true }
       allow(page).to receive(:active?){ true }
-      expect{ get :show, id: '1' }.not_to raise_error
+      expect( get :follow_up, id: '1' ).not_to be_redirect
+    end
+
+    it 'raises 404 if page is not found' do
+      allow(Page).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+      expect{ get :follow_up, id: '1000000' }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -18,6 +18,7 @@ describe PagesController do
     allow(request.env['warden']).to receive(:authenticate!) { user }
     allow(controller).to receive(:current_user) { user }
     allow_any_instance_of(ActionController::TestRequest).to receive(:location).and_return({})
+    Settings.homepage_url = "http://nealdonnelly.com"
   end
 
   describe 'GET #index' do
@@ -146,33 +147,33 @@ describe PagesController do
       expect(assigns(:rendered)).to eq(renderer.render)
     end
 
-    it 'redirects to sumofus.org if user not logged in and page unpublished' do
+    it 'redirects to homepage if user not logged in and page unpublished' do
       allow(controller).to receive(:user_signed_in?) { false }
       allow(page).to receive(:active?){ false }
-      expect( get :show, id: '1' ).to redirect_to('//sumofus.org')
+      expect( get :show, id: '1' ).to redirect_to(Settings.homepage_url)
     end
 
-    it 'does not redirect to sumofus.org if user not logged in and page published' do
+    it 'does not redirect to homepage if user not logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { false }
       allow(page).to receive(:active?){ true }
       expect( get :show, id: '1' ).not_to be_redirect
     end
 
-    it 'does not redirect to sumofus.org if user logged in and page unpublished' do
+    it 'does not redirect to homepage if user logged in and page unpublished' do
       allow(controller).to receive(:user_signed_in?) { true }
       allow(page).to receive(:active?){ false }
       expect( get :show, id: '1' ).not_to be_redirect
     end
 
-    it 'does not redirect to sumofus.org if user logged in and page published' do
+    it 'does not redirect to homepage if user logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { true }
       allow(page).to receive(:active?){ true }
       expect( get :show, id: '1' ).not_to be_redirect
     end
 
-    it 'redirects to sumofus.org if page is not found' do
+    it 'redirects to homepage if page is not found' do
       allow(Page).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
-      expect( get :show, id: '1000000' ).to redirect_to('//sumofus.org')
+      expect( get :show, id: '1000000' ).to redirect_to(Settings.homepage_url)
     end
 
     context 'on pages with localization' do
@@ -237,25 +238,25 @@ describe PagesController do
       expect(assigns(:rendered)).to eq(renderer.render)
     end
 
-    it 'redirects to sumofus.org if user not logged in and page unpublished' do
+    it 'redirects to homepage if user not logged in and page unpublished' do
       allow(controller).to receive(:user_signed_in?) { false }
       allow(page).to receive(:active?){ false }
-      expect( get :follow_up, id: '1' ).to redirect_to('//sumofus.org')
+      expect( get :follow_up, id: '1' ).to redirect_to(Settings.homepage_url)
     end
 
-    it 'does not redirect to sumofus.org if user not logged in and page published' do
+    it 'does not redirect to homepage if user not logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { false }
       allow(page).to receive(:active?){ true }
       expect( get :follow_up, id: '1' ).not_to be_redirect
     end
 
-    it 'does not redirect to sumofus.org if user logged in and page unpublished' do
+    it 'does not redirect to homepage if user logged in and page unpublished' do
       allow(controller).to receive(:user_signed_in?) { true }
       allow(page).to receive(:active?){ false }
       expect( get :follow_up, id: '1' ).not_to be_redirect
     end
 
-    it 'does not redirect to sumofus.org if user logged in and page published' do
+    it 'does not redirect to homepage if user logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { true }
       allow(page).to receive(:active?){ true }
       expect( get :follow_up, id: '1' ).not_to be_redirect


### PR DESCRIPTION
This PR wraps up the last two things for the legacy pages:
- it adds the `Actionsweet_Legacy` tag to all the legacy pages
- it redirects 404s on `pages#show` to sumofus.org rather than showing the 404 page.