### PR TITLE
make code lines wrap on WYSIWYG

### DIFF
--- a/app/assets/javascripts/configure_wysiwyg.js
+++ b/app/assets/javascripts/configure_wysiwyg.js
@@ -16,6 +16,13 @@
       ],
       height: 280,
       fontSizes: ['8', '10', '11', '12', '14', '16', '20', '24', '36', '72'],
+      codemirror: {
+        theme: 'default',
+        mode: "text/html",
+        lineNumbers: true,
+        tabMode: 'indent',
+        lineWrapping: true
+      }
     });
     $contentField = $('#page_content');
 


### PR DESCRIPTION
Pretty self explanatory. I declined to make it do the HTML pretty-formatting cause it only did that in the code view, so you got the unsaved changes flag every time you flicked back and forth between code and WYSIWYG.