### PR TITLE
Add lang property to <html> tag on member facing pages

### DIFF
--- a/app/views/layouts/sumofus.slim
+++ b/app/views/layouts/sumofus.slim
@@ -1,5 +1,5 @@
 doctype html
-html
+html lang="#{@page.language.try(:code).try(:downcase)}"
   head
     title  = @page.title
     meta name="viewport" content="width=device-width, initial-scale=1.0"

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -11,7 +11,6 @@
 
 /Facebook Meta Tags for proper behavior there, too
 - meta og: { site_name: 'SumOfUs',
-        image:  @page.primary_image.try(:content).try(:url),
         title: @page.title, url: page_url(@page),
         description: truncate(strip_tags(CGI.unescapeHTML(@page.content)), length: 260),
         type: 'website',


### PR DESCRIPTION
Paul wants us to explicitly list the language code on member facing pages to allow Optimizely to hook into them. Per [the W3 spec](https://www.w3.org/TR/html5/semantics.html#the-html-element), the right place to do that is on the `lang` attribute of the page's HTML tag. This is also used by screenreaders to flag what accent to use. 

I also removed a duplicate key cause it was giving me warnings when running rspec.