### PR TITLE
Tables and models for GoCardless

### DIFF
--- a/app/models/payment/go_cardless.rb
+++ b/app/models/payment/go_cardless.rb
@@ -1,0 +1,5 @@
+module Payment::GoCardless
+  def self.table_name_prefix
+    'payment_go_cardless_'
+  end
+end

--- a/app/models/payment/go_cardless/customer.rb
+++ b/app/models/payment/go_cardless/customer.rb
@@ -1,0 +1,9 @@
+class Payment::GoCardless::Customer < ActiveRecord::Base
+  belongs_to :member
+
+  has_many :payment_methods, class_name: 'Payment::GoCardless::PaymentMethods'
+  has_many :transactions, class_name: 'Payment::GoCardless::Transactions'
+  has_many :subscriptions, class_name: 'Payment::GoCardless::Subscriptions'
+
+  validates :go_cardless_id, presence: true, allow_blank: false
+end

--- a/app/models/payment/go_cardless/payment_method.rb
+++ b/app/models/payment/go_cardless/payment_method.rb
@@ -1,0 +1,13 @@
+class Payment::GoCardless::PaymentMethod < ActiveRecord::Base
+  belongs_to :customer, class_name: 'Payment::Braintree::Customer'
+
+  enum status: [:pending_submission,
+                :submitted,
+                :active,
+                :failed,
+                :cancelled,
+                :expired]
+
+  validates :status, presence: true, allow_blank: false
+  validates :go_cardless_id, presence: true, allow_blank: false
+end

--- a/app/models/payment/go_cardless/subscription.rb
+++ b/app/models/payment/go_cardless/subscription.rb
@@ -1,0 +1,15 @@
+class Payment::GoCardless::Subscription < ActiveRecord::Base
+  belongs_to :page
+  belongs_to :action
+  belongs_to :customer, class_name: 'Payment::Braintree::Customer'
+  belongs_to :payment_method, class_name: 'Payment::Braintree::PaymentMethod'
+
+  enum status: [:pending_customer_approval,
+                :customer_approval_denied,
+                :active,
+                :finished,
+                :cancelled]
+
+  validates :status, presence: true, allow_blank: false
+  validates :go_cardless_id, presence: true, allow_blank: false
+end

--- a/app/models/payment/go_cardless/transaction.rb
+++ b/app/models/payment/go_cardless/transaction.rb
@@ -1,0 +1,19 @@
+class Payment::GoCardless::Transaction < ActiveRecord::Base
+  belongs_to :page
+  belongs_to :action
+  belongs_to :customer, class_name: 'Payment::Braintree::Customer'
+  belongs_to :payment_method, class_name: 'Payment::Braintree::PaymentMethod'
+
+  enum status: [:pending_customer_approval,
+                :pending_submission,
+                :submitted,
+                :confirmed,
+                :paid_out,
+                :cancelled,
+                :customer_approval_denied,
+                :failed,
+                :charged_back]
+
+  validates :status, presence: true, allow_blank: false
+  validates :go_cardless_id, presence: true, allow_blank: false
+end

--- a/db/migrate/20160404203052_create_go_cardless_tables.rb
+++ b/db/migrate/20160404203052_create_go_cardless_tables.rb
@@ -1,0 +1,70 @@
+class CreateGoCardlessTables < ActiveRecord::Migration
+  def change
+    create_table :payment_go_cardless_customers do |t|
+      t.string :go_cardless_id
+      t.string :email
+      t.string :given_name
+      t.string :family_name
+      t.string :postal_code
+      t.string :country_code
+      t.string :language
+
+      t.references :member, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+
+    create_table :payment_go_cardless_payment_methods do |t|
+      t.string :go_cardless_id
+      t.string :reference
+      t.integer :status
+      t.string :scheme
+      t.date   :next_possible_charge_date
+
+      t.references :customer, references: :payment_go_cardless_customer, index: true
+
+      t.timestamps null: false
+    end
+    add_foreign_key :payment_go_cardless_payment_methods, :payment_go_cardless_customers, column: :customer_id
+
+
+    create_table :payment_go_cardless_subscriptions do |t|
+      t.string :go_cardless_id
+      t.decimal :amount
+      t.string :currency
+      t.integer :status
+      t.string :name
+      t.string :payment_reference
+
+      t.references :page, index: true, foreign_key: true
+      t.references :action, index: true, foreign_key: true
+      t.references :payment_method, references: :payment_go_cardless_payment_method, index: true
+      t.references :customer, references: :payment_go_cardless_customer, index: true
+
+      t.timestamps null: false
+    end
+    add_foreign_key :payment_go_cardless_subscriptions, :payment_go_cardless_customers, column: :customer_id
+    add_foreign_key :payment_go_cardless_subscriptions, :payment_go_cardless_payment_methods, column: :payment_method_id
+
+    create_table :payment_go_cardless_transactions do |t|
+      t.string :go_cardless_id
+      t.date :charge_date
+      t.decimal :amount
+      t.string :description
+      t.string :currency
+      t.integer :status
+      t.string :reference
+      t.decimal :amount_refunded
+
+      t.references :page, index: true, foreign_key: true
+      t.references :action, index: true, foreign_key: true
+      t.references :payment_method, references: :payment_go_cardless_payment_method, index: true
+      t.references :customer, references: :payment_go_cardless_customer, index: true
+
+      t.timestamps null: false
+    end
+    add_foreign_key :payment_go_cardless_transactions, :payment_go_cardless_customers, column: :customer_id
+    add_foreign_key :payment_go_cardless_transactions, :payment_go_cardless_payment_methods, column: :payment_method_id
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160311123938) do
+ActiveRecord::Schema.define(version: 20160404203052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -262,6 +262,76 @@ ActiveRecord::Schema.define(version: 20160311123938) do
 
   add_index "payment_braintree_transactions", ["page_id"], name: "index_payment_braintree_transactions_on_page_id", using: :btree
 
+  create_table "payment_go_cardless_customers", force: :cascade do |t|
+    t.string   "go_cardless_id"
+    t.string   "email"
+    t.string   "given_name"
+    t.string   "family_name"
+    t.string   "postal_code"
+    t.string   "country_code"
+    t.string   "language"
+    t.integer  "member_id"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+  add_index "payment_go_cardless_customers", ["member_id"], name: "index_payment_go_cardless_customers_on_member_id", using: :btree
+
+  create_table "payment_go_cardless_payment_methods", force: :cascade do |t|
+    t.string   "go_cardless_id"
+    t.string   "reference"
+    t.integer  "status"
+    t.string   "scheme"
+    t.date     "next_possible_charge_date"
+    t.integer  "customer_id"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "payment_go_cardless_payment_methods", ["customer_id"], name: "index_payment_go_cardless_payment_methods_on_customer_id", using: :btree
+
+  create_table "payment_go_cardless_subscriptions", force: :cascade do |t|
+    t.string   "go_cardless_id"
+    t.decimal  "amount"
+    t.string   "currency"
+    t.integer  "status"
+    t.string   "name"
+    t.string   "payment_reference"
+    t.integer  "page_id"
+    t.integer  "action_id"
+    t.integer  "payment_method_id"
+    t.integer  "customer_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+  end
+
+  add_index "payment_go_cardless_subscriptions", ["action_id"], name: "index_payment_go_cardless_subscriptions_on_action_id", using: :btree
+  add_index "payment_go_cardless_subscriptions", ["customer_id"], name: "index_payment_go_cardless_subscriptions_on_customer_id", using: :btree
+  add_index "payment_go_cardless_subscriptions", ["page_id"], name: "index_payment_go_cardless_subscriptions_on_page_id", using: :btree
+  add_index "payment_go_cardless_subscriptions", ["payment_method_id"], name: "index_payment_go_cardless_subscriptions_on_payment_method_id", using: :btree
+
+  create_table "payment_go_cardless_transactions", force: :cascade do |t|
+    t.string   "go_cardless_id"
+    t.date     "charge_date"
+    t.decimal  "amount"
+    t.string   "description"
+    t.string   "currency"
+    t.integer  "status"
+    t.string   "reference"
+    t.decimal  "amount_refunded"
+    t.integer  "page_id"
+    t.integer  "action_id"
+    t.integer  "payment_method_id"
+    t.integer  "customer_id"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+  end
+
+  add_index "payment_go_cardless_transactions", ["action_id"], name: "index_payment_go_cardless_transactions_on_action_id", using: :btree
+  add_index "payment_go_cardless_transactions", ["customer_id"], name: "index_payment_go_cardless_transactions_on_customer_id", using: :btree
+  add_index "payment_go_cardless_transactions", ["page_id"], name: "index_payment_go_cardless_transactions_on_page_id", using: :btree
+  add_index "payment_go_cardless_transactions", ["payment_method_id"], name: "index_payment_go_cardless_transactions_on_payment_method_id", using: :btree
+
   create_table "plugins_fundraisers", force: :cascade do |t|
     t.string   "title"
     t.string   "ref"
@@ -415,6 +485,16 @@ ActiveRecord::Schema.define(version: 20160311123938) do
   add_foreign_key "payment_braintree_customers", "members"
   add_foreign_key "payment_braintree_subscriptions", "pages"
   add_foreign_key "payment_braintree_transactions", "pages"
+  add_foreign_key "payment_go_cardless_customers", "members"
+  add_foreign_key "payment_go_cardless_payment_methods", "payment_go_cardless_customers", column: "customer_id"
+  add_foreign_key "payment_go_cardless_subscriptions", "actions"
+  add_foreign_key "payment_go_cardless_subscriptions", "pages"
+  add_foreign_key "payment_go_cardless_subscriptions", "payment_go_cardless_customers", column: "customer_id"
+  add_foreign_key "payment_go_cardless_subscriptions", "payment_go_cardless_payment_methods", column: "payment_method_id"
+  add_foreign_key "payment_go_cardless_transactions", "actions"
+  add_foreign_key "payment_go_cardless_transactions", "pages"
+  add_foreign_key "payment_go_cardless_transactions", "payment_go_cardless_customers", column: "customer_id"
+  add_foreign_key "payment_go_cardless_transactions", "payment_go_cardless_payment_methods", column: "payment_method_id"
   add_foreign_key "plugins_fundraisers", "donation_bands"
   add_foreign_key "plugins_fundraisers", "forms"
   add_foreign_key "plugins_fundraisers", "pages"

--- a/spec/factories/payment_go_cardless_customers.rb
+++ b/spec/factories/payment_go_cardless_customers.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :payment_go_cardless_customer, class: 'Payment::GoCardless::Customer' do
+    go_cardless_id { "CU#{Faker::Number.number(6)}" }
+    email { Faker::Internet.email }
+    country_code 'GB'
+    language 'en'
+  end
+end

--- a/spec/factories/payment_go_cardless_payment_methods.rb
+++ b/spec/factories/payment_go_cardless_payment_methods.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :payment_go_cardless_payment_method, class: 'Payment::GoCardless::PaymentMethod' do
+    go_cardless_id { "MD#{Faker::Number.number(6)}" }
+    status :active
+    scheme { ['bacs', 'sepa_core'].sample }
+  end
+end

--- a/spec/factories/payment_go_cardless_subscriptions.rb
+++ b/spec/factories/payment_go_cardless_subscriptions.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :payment_go_cardless_subscription, class: 'Payment::GoCardless::Subscription' do
+    go_cardless_id { "SU#{Faker::Number.number(6)}" }
+    amount 33.12
+    currency "GBP"
+    status :active
+  end
+end

--- a/spec/factories/payment_go_cardless_transactions.rb
+++ b/spec/factories/payment_go_cardless_transactions.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :payment_go_cardless_transaction, class: 'Payment::GoCardless::Transaction' do
+    go_cardless_id { "PM#{Faker::Number.number(6)}" }
+    amount 23.19
+    currency "EUR"
+    status :submitted
+  end
+end

--- a/spec/models/payment/go_cardless/customer_spec.rb
+++ b/spec/models/payment/go_cardless/customer_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe Payment::GoCardless::Customer do
+
+  let(:customer) { build :payment_go_cardless_customer }
+  subject { customer }
+
+  it { is_expected.to respond_to :go_cardless_id }
+  it { is_expected.to respond_to :email }
+  it { is_expected.to respond_to :given_name }
+  it { is_expected.to respond_to :family_name }
+  it { is_expected.to respond_to :postal_code }
+  it { is_expected.to respond_to :country_code }
+  it { is_expected.to respond_to :language }
+  it { is_expected.to respond_to :created_at }
+  it { is_expected.to respond_to :updated_at }
+
+  # Associations
+  it { is_expected.to respond_to :member }
+  it { is_expected.to respond_to :member_id }
+  it { is_expected.to respond_to :payment_methods }
+  it { is_expected.to respond_to :transactions }
+  it { is_expected.to respond_to :subscriptions }
+
+  # Fields passed back from GoCardless that we don't record
+  it { is_expected.to_not respond_to :address_line1 }
+  it { is_expected.to_not respond_to :address_line2 }
+  it { is_expected.to_not respond_to :address_line3 }
+  it { is_expected.to_not respond_to :city }
+  it { is_expected.to_not respond_to :region }
+  it { is_expected.to_not respond_to :swedish_identity_number }
+
+  describe 'validation' do
+    before :each do
+      expect(customer).to be_valid
+    end
+
+    it 'rejects blank go_cardless_id' do
+      customer.go_cardless_id = ''
+      expect(customer).to be_invalid
+    end
+  end
+
+end

--- a/spec/models/payment/go_cardless/payment_method_spec.rb
+++ b/spec/models/payment/go_cardless/payment_method_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe Payment::GoCardless::PaymentMethod do
+
+  let(:payment_method) { build :payment_go_cardless_payment_method }
+  subject { payment_method }
+
+  it { is_expected.to respond_to :go_cardless_id }
+  it { is_expected.to respond_to :status }
+  it { is_expected.to respond_to :reference }
+  it { is_expected.to respond_to :scheme }
+  it { is_expected.to respond_to :next_possible_charge_date }
+  it { is_expected.to respond_to :created_at }
+  it { is_expected.to respond_to :updated_at }
+
+  # Associations
+  it { is_expected.to respond_to :customer }
+  it { is_expected.to respond_to :customer_id }
+
+  describe 'validation' do
+    before :each do
+      expect(payment_method).to be_valid
+    end
+
+    it 'rejects nil status' do
+      payment_method.status = nil
+      expect(payment_method).to be_invalid
+    end
+
+    it 'rejects blank go_cardless_id' do
+      payment_method.go_cardless_id = ''
+      expect(payment_method).to be_invalid
+    end
+  end
+
+  describe 'status' do
+
+    it 'can be set to "pending_submission"' do
+      payment_method.status = "pending_submission"
+      expect(payment_method.pending_submission?).to eq true
+    end
+
+    it 'can be set to "submitted"' do
+      payment_method.status = "submitted"
+      expect(payment_method.submitted?).to eq true
+    end
+
+    it 'can be set to "active"' do
+      payment_method.status = "active"
+      expect(payment_method.active?).to eq true
+    end
+
+    it 'can be set to "failed"' do
+      payment_method.status = "failed"
+      expect(payment_method.failed?).to eq true
+    end
+
+    it 'can be set to "cancelled"' do
+      payment_method.status = "cancelled"
+      expect(payment_method.cancelled?).to eq true
+    end
+
+    it 'can be set to "expired"' do
+      payment_method.status = "expired"
+      expect(payment_method.expired?).to eq true
+    end
+  end
+end

--- a/spec/models/payment/go_cardless/subscription_spec.rb
+++ b/spec/models/payment/go_cardless/subscription_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe Payment::GoCardless::Subscription do
+
+  let(:subscription) { build :payment_go_cardless_subscription }
+  subject { subscription }
+
+  it { is_expected.to respond_to :go_cardless_id }
+  it { is_expected.to respond_to :amount }
+  it { is_expected.to respond_to :currency }
+  it { is_expected.to respond_to :status }
+  it { is_expected.to respond_to :name }
+  it { is_expected.to respond_to :created_at }
+  it { is_expected.to respond_to :updated_at }
+
+  # Associations
+  it { is_expected.to respond_to :page_id }
+  it { is_expected.to respond_to :page }
+  it { is_expected.to respond_to :action }
+  it { is_expected.to respond_to :action_id }
+  it { is_expected.to respond_to :payment_method }
+  it { is_expected.to respond_to :payment_method_id }
+  it { is_expected.to respond_to :customer }
+  it { is_expected.to respond_to :customer_id }
+
+  # Fields passed back from GoCardless that we don't record
+  it { is_expected.not_to respond_to :start_date }
+  it { is_expected.not_to respond_to :end_date }
+  it { is_expected.not_to respond_to :interval }
+  it { is_expected.not_to respond_to :interval_unit }
+  it { is_expected.not_to respond_to :day_of_month }
+  it { is_expected.not_to respond_to :month }
+
+  it 'handles amount as BigDecimal' do
+    create :payment_go_cardless_subscription, amount: 12.41
+    create :payment_go_cardless_subscription, amount: 10701.11
+    expect(Payment::GoCardless::Subscription.all.map(&:amount).sum).to eq 10713.52
+    expect(Payment::GoCardless::Subscription.last.amount.class).to eq BigDecimal
+  end
+
+  describe 'validation' do
+    before :each do
+      expect(subscription).to be_valid
+    end
+
+    it 'rejects nil status' do
+      subscription.status = nil
+      expect(subscription).to be_invalid
+    end
+
+    it 'rejects blank go_cardless_id' do
+      subscription.go_cardless_id = ''
+      expect(subscription).to be_invalid
+    end
+  end
+
+  describe 'status' do
+
+    it 'can be set to "pending_customer_approval"' do
+      subscription.status = "pending_customer_approval"
+      expect(subscription.pending_customer_approval?).to eq true
+    end
+
+    it 'can be set to "customer_approval_denied"' do
+      subscription.status = "customer_approval_denied"
+      expect(subscription.customer_approval_denied?).to eq true
+    end
+
+    it 'can be set to "active"' do
+      subscription.status = "active"
+      expect(subscription.active?).to eq true
+    end
+
+    it 'can be set to "finished"' do
+      subscription.status = "finished"
+      expect(subscription.finished?).to eq true
+    end
+
+    it 'can be set to "cancelled"' do
+      subscription.status = "cancelled"
+      expect(subscription.cancelled?).to eq true
+    end
+  end
+end

--- a/spec/models/payment/go_cardless/transaction_spec.rb
+++ b/spec/models/payment/go_cardless/transaction_spec.rb
@@ -1,0 +1,105 @@
+require 'rails_helper'
+
+describe Payment::GoCardless::Transaction do
+
+  let(:transaction) { build :payment_go_cardless_transaction }
+  subject { transaction }
+
+  it { is_expected.to respond_to :go_cardless_id }
+  it { is_expected.to respond_to :amount }
+  it { is_expected.to respond_to :currency }
+  it { is_expected.to respond_to :status }
+  it { is_expected.to respond_to :charge_date }
+  it { is_expected.to respond_to :amount_refunded }
+  it { is_expected.to respond_to :reference }
+  it { is_expected.to respond_to :created_at }
+  it { is_expected.to respond_to :updated_at }
+
+  # Associations
+  it { is_expected.to respond_to :page }
+  it { is_expected.to respond_to :page_id }
+  it { is_expected.to respond_to :action }
+  it { is_expected.to respond_to :action_id }
+  it { is_expected.to respond_to :payment_method }
+  it { is_expected.to respond_to :payment_method_id }
+  it { is_expected.to respond_to :customer }
+  it { is_expected.to respond_to :customer_id }
+
+  it 'handles amount as BigDecimal' do
+    create :payment_go_cardless_transaction, amount: 12.41
+    create :payment_go_cardless_transaction, amount: 10701.11
+    expect(Payment::GoCardless::Transaction.all.map(&:amount).sum).to eq 10713.52
+    expect(Payment::GoCardless::Transaction.last.amount.class).to eq BigDecimal
+  end
+
+  it 'handles amount_refunded as BigDecimal' do
+    create :payment_go_cardless_transaction, amount_refunded: 12.51
+    create :payment_go_cardless_transaction, amount_refunded: 10701.11
+    expect(Payment::GoCardless::Transaction.all.map(&:amount_refunded).sum).to eq 10713.62
+    expect(Payment::GoCardless::Transaction.last.amount.class).to eq BigDecimal
+  end
+
+  describe 'validation' do
+    before :each do
+      expect(transaction).to be_valid
+    end
+
+    it 'rejects nil status' do
+      transaction.status = nil
+      expect(transaction).to be_invalid
+    end
+
+    it 'rejects blank go_cardless_id' do
+      transaction.go_cardless_id = ''
+      expect(transaction).to be_invalid
+    end
+  end
+
+  describe 'status' do
+
+    it 'can be set to "pending_customer_approval"' do
+      transaction.status = "pending_customer_approval"
+      expect(transaction.pending_customer_approval?).to eq true
+    end
+
+    it 'can be set to pending_submission"' do
+      transaction.status = "pending_submission"
+      expect(transaction.pending_submission?).to eq true
+    end
+
+    it 'can be set to "submitted"' do
+      transaction.status = "submitted"
+      expect(transaction.submitted?).to eq true
+    end
+
+    it 'can be set to "confirmed"' do
+      transaction.status = "confirmed"
+      expect(transaction.confirmed?).to eq true
+    end
+
+    it 'can be set to "paid_out"' do
+      transaction.status = "paid_out"
+      expect(transaction.paid_out?).to eq true
+    end
+
+    it 'can be set to cancelled"' do
+      transaction.status = "cancelled"
+      expect(transaction.cancelled?).to eq true
+    end
+
+    it 'can be set to "customer_approval_denied"' do
+      transaction.status = "customer_approval_denied"
+      expect(transaction.customer_approval_denied?).to eq true
+    end
+
+    it 'can be set to "failed"' do
+      transaction.status = "failed"
+      expect(transaction.failed?).to eq true
+    end
+
+    it 'can be set to "charged_back"' do
+      transaction.status = "charged_back"
+      expect(transaction.charged_back?).to eq true
+    end
+  end
+end


### PR DESCRIPTION
Today I added the tables, models, and model specs for the GoCardless integration.The target branch for this PR is just the `going-cardless` branch, which is very much WIP itself, so this PR is just a chance to comment and make sure we're aligned about this.

One of my goals was to try to prevent doing excessive bookkeeping by writing anything in two places or tracking fields we will probably never use and that we could just query GC for if we want them.

A couple decisions I made -
- all the tables are related, using the ids of the rows in our own tables as foreign keys (not GC ids).
- all relations between new tables are indexed
- every table stores its GC id in a field called `go_cardless_id`
- we don't store every single field that GC does - just ones we might ever want to change or show the user. 
- status on each table is an `enum` that accepts all the possible status values given in the GC docs.
- `go_cardless_id` and `status` are the only fields that are validated (to be not blank)
- I namespaced everything to be `Payment::GoCardless::Transaction`, in contrast to `Payment::BraintreePayment` I think it's a pretty clear application of namespacing, and `app/models/payment/go_cardless.rb` is the perfect place for the GC version of the logic that's in `app/models/payment.rb`. I'm looking forward to namespacing the Braintree stuff too a little while later.