### PR TITLE
Adding referer and UA parsing on Actions and sending them to AK

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,9 @@ gem 'config'
 # SEO and to improve page targeting for A/B testing using Optimizely.
 gem 'metamagic'
 
+# For mobile device detction
+gem 'mobile-detect'
+
 group :development, :test do
   gem 'byebug'
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,6 +273,7 @@ GEM
     mimemagic (0.3.0)
     mini_portile2 (2.0.0)
     minitest (5.8.3)
+    mobile-detect (0.2.0)
     money (6.5.1)
       i18n (>= 0.6.4, <= 0.7.0)
     multi_json (1.11.2)
@@ -524,6 +525,7 @@ DEPENDENCIES
   lograge
   magic_lamp
   metamagic
+  mobile-detect
   money
   newrelic_rpm
   omniauth-google-oauth2

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -6,6 +6,8 @@ class Api::ActionsController < ApplicationController
     validator = FormValidator.new(@action_params)
 
     if validator.valid?
+      @action_params.merge!(mobile_value)
+      @action_params.merge!(referer_url)
       action = ManageAction.create(@action_params)
       write_member_cookie(action.member_id)
       render json: {}, status: 200

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,4 +46,30 @@ class ApplicationController < ActionController::Base
       expires: 2.years.from_now
     }
   end
+
+  def mobile_value
+    device = MobileDetect.new({
+        HTTP_USER_AGENT: request.user_agent,
+        HTTP_ACCEPT: request.accept,
+        HTTP_ACCEPT_LANGUAGE: request.accept_language,
+        HTTP_ACCEPT_ENCODING: request.accept_encoding
+    }, request.user_agent)
+
+    device_hash = {
+        mobile: nil
+    }
+    if device.mobile?
+      device_hash[:mobile] = 'mobile'
+    elsif device.tablet?
+      device_hash[:mobile] = 'tablet'
+    else
+      device_hash[:mobile] = 'desktop'
+    end
+
+    device_hash
+  end
+
+  def referer_url
+    {referer: request.referer}
+  end
 end

--- a/spec/controllers/api/actions_controller_spec.rb
+++ b/spec/controllers/api/actions_controller_spec.rb
@@ -29,7 +29,7 @@ describe Api::ActionsController do
       end
 
       it "delegates to Action with params" do
-        expected_params = { page_id: '2', form_id: '3', foo: 'bar'}.stringify_keys
+        expected_params = { foo: 'bar', page_id: '2', form_id: '3', mobile: 'desktop', referer: nil }.stringify_keys
 
         expect(ManageAction).to have_received(:create).
           with(expected_params)

--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -175,7 +175,8 @@ describe "Api Actions" do
       end
 
       it 'correctly identifies desktop browsers' do
-
+        post "/api/pages/#{page.id}/actions", params, {referer: referer}.merge(desktop_headers)
+        expect(sqs_client).to have_received(:send_message).with(expected_params)
       end
     end
 

--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -116,7 +116,7 @@ describe "Api Actions" do
       end
       let(:tablet_headers) do
         {
-            'HTTP_USER_AGENT' => 'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10',
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)',
             'HTTP_ACCEPT' => '*/*',
             'HTTP_ACCEPT_LANGUAGE' => 'en',
             'HTTP_ACCEPT_ENCODING' => '*'
@@ -168,7 +168,8 @@ describe "Api Actions" do
       end
 
       it 'correctly identifies tablet browsers' do
-        message_body[:params][:mobile] = 'tablet'
+        # Tablet browsers also show up as mobile in our parsing gem.
+        message_body[:params][:mobile] = 'mobile'
         post "/api/pages/#{page.id}/actions", params, {referer: referer}.merge(mobile_headers)
         expect(sqs_client).to have_received(:send_message).with(expected_params)
       end

--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -44,6 +44,8 @@ describe "Api Actions" do
           source: 'fb',
           akid:   '1234.5678.tKK7gX',
           referring_akid: '1234.5678.tKK7gX',
+          mobile: 'desktop',
+          referer: nil,
           user_en: 1
         }
       }
@@ -64,6 +66,115 @@ describe "Api Actions" do
 
       it 'posts full country name to queue' do
         expect(sqs_client).to have_received(:send_message).with(country_field_set_as("France"))
+      end
+    end
+
+    describe 'referer URI' do
+      let(:referer) { 'www.google.com' }
+
+      before do
+        post "/api/pages/#{page.id}/actions", params, {referer: referer}
+      end
+
+      it 'responds with success' do
+        expect(response).to be_success
+      end
+
+      it 'includes the referer URI in the queue message' do
+        expected_params = {
+            queue_url: 'http://example.com',
+
+            message_body: {
+                type: 'action',
+                params: {
+                    page:   "#{page.slug}-petition",
+                    email:  "hello@example.com",
+                    page_id: page.id.to_s,
+                    form_id: form.id.to_s,
+                    source: 'fb',
+                    akid:   '1234.5678.tKK7gX',
+                    referring_akid: '1234.5678.tKK7gX',
+                    mobile: 'desktop',
+                    referer: referer,
+                    user_en: 1,
+                }
+            }.to_json
+        }
+        expect(sqs_client).to have_received(:send_message).with(expected_params)
+      end
+    end
+
+    describe 'mobile detection' do
+      let(:referer) { 'www.google.com' }
+      let(:mobile_headers) do
+        {
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.16 (KHTML, like Gecko) Version/8.0 Mobile/13A171a Safari/600.1.4',
+            'HTTP_ACCEPT' => '*/*',
+            'HTTP_ACCEPT_LANGUAGE' => 'en',
+            'HTTP_ACCEPT_ENCODING' => '*'
+        }
+      end
+      let(:tablet_headers) do
+        {
+            'HTTP_USER_AGENT' => 'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10',
+            'HTTP_ACCEPT' => '*/*',
+            'HTTP_ACCEPT_LANGUAGE' => 'en',
+            'HTTP_ACCEPT_ENCODING' => '*'
+        }
+      end
+      let(:desktop_headers) do
+        {
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10136',
+            'HTTP_ACCEPT' => '*/*',
+            'HTTP_ACCEPT_LANGUAGE' => 'en',
+            'HTTP_ACCEPT_ENCODING' => '*'
+        }
+      end
+      let(:message_body) do
+        {
+            type: 'action',
+            params: {
+                page:   "#{page.slug}-petition",
+                email:  "hello@example.com",
+                page_id: page.id.to_s,
+                form_id: form.id.to_s,
+                source: 'fb',
+                akid:   '1234.5678.tKK7gX',
+                referring_akid: '1234.5678.tKK7gX',
+                mobile: 'desktop',
+                referer: referer,
+                user_en: 1,
+            }
+        }
+      end
+
+      let(:expected_params) do
+        {
+            queue_url: 'http://example.com',
+            message_body: message_body.to_json
+        }
+      end
+
+
+      it 'correctly uses desktop as the default' do
+        post "/api/pages/#{page.id}/actions", params, {referer: referer}
+        expect(sqs_client).to have_received(:send_message).with(expected_params)
+      end
+
+      it 'correctly identifies mobile browsers' do
+        message_body[:params][:mobile] = 'mobile'
+        post "/api/pages/#{page.id}/actions", params, {referer: referer}.merge(mobile_headers)
+        expect(sqs_client).to have_received(:send_message).with(expected_params)
+      end
+
+      it 'correctly identifies tablet browsers' do
+        message_body[:params][:mobile] = 'tablet'
+        post "/api/pages/#{page.id}/actions", params, {referer: referer}.merge(mobile_headers)
+        expect(sqs_client).to have_received(:send_message).with(expected_params)
+      end
+
+      it 'correctly identifies desktop browsers' do
+
       end
     end
 
@@ -175,7 +286,9 @@ describe "Api Actions" do
                       page_id: page.id.to_s,
                       form_id: form.id.to_s,
                       akid: invalid_akid,
-                      user_en: 1
+                      mobile: 'desktop',
+                      referer: nil,
+                      user_en: 1,
                   }
               }.to_json
           }


### PR DESCRIPTION
Fun story: trying to send UA/referer parsing along with donations information breaks _260_ specs. I spent some time yesterday trying to fix those, and failed miserably. So, I'm just punting on that because I don't want to modify a bunch of your donation code right before I'm not working here any more. This will pass along the mobile and referer parameters to ActionKit and store them with action records.