### PR TITLE
Form defaults

### DIFF
--- a/app/assets/javascripts/sumofus/backbone/form_methods.js
+++ b/app/assets/javascripts/sumofus/backbone/form_methods.js
@@ -63,7 +63,12 @@ const FormMethods = {
       let $field = $(field);
       let name = $field.prop('name');
       if (unvalidatedPrefillValues.hasOwnProperty(name)) {
-        $field.val(unvalidatedPrefillValues[name]);
+        // weird edge case handling - if the name field is country and the country code is
+        // the 'Reserved' country code, don't prefill since it's not a real code.
+        let isUnknownCountry = (name.match('country') && unvalidatedPrefillValues[name] == 'RD')
+        if (!isUnknownCountry) {
+          $field.val(unvalidatedPrefillValues[name]);
+        }
       }
       if (prefillValues.hasOwnProperty(name) && fieldsToSkipPrefill.indexOf(name) === -1) {
         $field.val(prefillValues[name]);

--- a/app/assets/stylesheets/page-edit.scss
+++ b/app/assets/stylesheets/page-edit.scss
@@ -182,8 +182,6 @@ body.page-edit-body {
   }
 }
 
-
-
 .page-edit-step__title, .edit-block__title, .centered-overlay__title {
   position: absolute;
   top: 0;
@@ -214,6 +212,10 @@ body.page-edit-body {
 
   &--just-title {
     padding: 35px;
+  }
+
+  a {
+    cursor: pointer;
   }
 
   .two-ninths.form-group {

--- a/app/controllers/form_elements_controller.rb
+++ b/app/controllers/form_elements_controller.rb
@@ -39,7 +39,7 @@ class FormElementsController < ApplicationController
   private
 
   def permitted_params
-    params.require(:form_element).permit(:label, :name, :data_type, :required)
+    params.require(:form_element).permit(:label, :name, :data_type, :required, :default_value)
   end
 
   def find_form

--- a/app/liquid/champaign_liquid_filters.rb
+++ b/app/liquid/champaign_liquid_filters.rb
@@ -1,0 +1,8 @@
+module ChampaignLiquidFilters
+
+  def select_option(tags_string, to_select)
+    # if one is already selected then leave it
+    return tags_string if tags_string =~ /selected/
+    tags_string.gsub(/(<option.*?value=["']#{to_select}["'])(.*?)>/, '\1 selected \2>')
+  end
+end

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -31,7 +31,11 @@
         {% when 'country' %}
           <select name="{{field.name}}" class="petition-bar__country-selector form__content" placeholder="{{field.label}}">
             <option></option>
-            {{ country_option_tags }}
+            {% if field.default_value == blank %}
+              {{ country_option_tags }}
+            {% else %}
+              {{ country_option_tags | select_option: field.default_value }}
+            {% endif %}
           </select>
         {% endcase %}
       </div>

--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -9,19 +9,24 @@
       <div class="form__group petition-bar__field-container">
         {% case field.data_type %}
         {% when 'text' or 'postal' %}
-          <input type="text" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" maxlength="249" />
+          <input type="text" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" maxlength="249" value="{{ field.default_value }}" />
         {% when 'hidden' %}
-          <input type="hidden" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}">
+          <input type="hidden" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" value="{{ field.default_value }}" />
         {% when 'paragraph' %}
-          <textarea name="{{ field.name }}" placeholder="{{ field.label }}" class="form-control form__content" id="" maxlength="9999"></textarea>
+          <textarea name="{{ field.name }}" placeholder="{{ field.label }}" class="form-control form__content" id="" maxlength="9999">{{ field.default_value }}</textarea>
         {% when 'email' %}
-          <input type="email" name="{{field.name}}" class="form-control mailcheck form__content" id="" placeholder="{{ field.label }}" />
+          <input type="email" name="{{field.name}}" class="form-control mailcheck form__content" id="" placeholder="{{ field.label }}" value="{{ field.default_value }}" />
         {% when 'phone' %}
-          <input type="tel" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}" />
+          <input type="tel" name="{{field.name}}" class="form-control form__content" id="" placeholder="{{ field.label }}"  value="{{ field.default_value }}" />
         {% when 'checkbox' %}
+          {% if field.default_value == blank %}
+            {% assign checked = '' %}
+          {% else %}
+            {% assign checked = 'checked' %}
+          {% endif %}
           <label class="checkbox-label">
             <input name="{{field.name}}" type="hidden" value="0" />
-            <input type="checkbox" name="{{field.name}}" class="form__content" value="1" /> {{ field.label }}
+            <input type="checkbox" name="{{field.name}}" class="form__content" value="1" {{ checked }}/> {{ field.label }}
           </label>
         {% when 'country' %}
           <select name="{{field.name}}" class="petition-bar__country-selector form__content" placeholder="{{field.label}}">

--- a/app/views/form_elements/_element.slim
+++ b/app/views/form_elements/_element.slim
@@ -4,6 +4,9 @@ li.list-group-item data-id=element.id
   = element.label
   span.secondary-label
     = "(#{element.name})"
+  - unless element.default_value.blank?
+    span.secondary-label
+      = "(default: #{truncate(element.default_value, length: 20)})"
 
   .control-bar
     - if element.required

--- a/app/views/forms/_add_element.slim
+++ b/app/views/forms/_add_element.slim
@@ -11,6 +11,10 @@
   .form-group.clearfix
     = label_with_tooltip(f, :data_type, t('form_elements.name'), t('tooltips.form_elements.name'))
     = f.text_field :name,  class: 'form-control typeahead', placeholder: t('form_elements.name_suggestion')
+  a.reveal-default-value= t('form_elements.add_default_value')
+  .form-group.hidden-closed.default-value-field
+    = label_with_tooltip(f, :default_value, t('form_elements.default_value'), t('tooltips.form_elements.default_value'))
+    = f.text_field :default_value,  class: 'form-control', placeholder: t('form_elements.default_value_suggestion')
 
   .form-group
     .checkbox
@@ -23,3 +27,9 @@
 
 javascript:
   $.publish('form:edit');
+  $(document).ready(function(){
+    $('.reveal-default-value').on('click', function(e){
+      $('.reveal-default-value').addClass('hidden-closed')
+      $('.default-value-field').removeClass('hidden-closed');
+    })
+  });

--- a/app/views/forms/_preview.html.slim
+++ b/app/views/forms/_preview.html.slim
@@ -6,7 +6,7 @@ form
       - when 'text', 'email', 'phone', 'postal'
         input.form-control placeholder=label value=element.default_value
       - when 'country'
-        = select_tag '', options_for_select(ISO3166::Country.all_names_with_codes), class: "form-control", selected: element.default_value
+        = select_tag '', options_for_select(ISO3166::Country.all_names_with_codes, element.default_value), class: "form-control"
       - when 'hidden'
         - tag_explanation = "Hidden tag: #{element.name}."
         - tag_explanation += " Default value: #{element.default_value}" unless element.default_value.blank?

--- a/app/views/forms/_preview.html.slim
+++ b/app/views/forms/_preview.html.slim
@@ -4,14 +4,17 @@ form
       - label = "#{element.label}#{element.required ? '*' : ''}"
       - case element.data_type
       - when 'text', 'email', 'phone', 'postal'
-        input.form-control placeholder=label
+        input.form-control placeholder=label value=element.default_value
       - when 'country'
-        = select_tag '', options_for_select(ISO3166::Country.all_names_with_codes), class: "form-control"
+        = select_tag '', options_for_select(ISO3166::Country.all_names_with_codes), class: "form-control", selected: element.default_value
       - when 'hidden'
-        i= "Hidden tag: #{element.name}"
+        - tag_explanation = "Hidden tag: #{element.name}."
+        - tag_explanation += " Default value: #{element.default_value}" unless element.default_value.blank?
+        i = tag_explanation
       - when 'paragraph'
         textarea.form-control placeholder=label
+          =element.default_value
       - when 'checkbox'
-        = check_box_tag element.name
+        = check_box_tag element.name, 1, element.default_value.present?
         '&nbsp;
         = label

--- a/config/initializers/liquid.rb
+++ b/config/initializers/liquid.rb
@@ -2,5 +2,6 @@ require './app/liquid/liquid_file_system'
 require './app/liquid/liquid_i18n'
 
 Liquid::Template.register_filter(LiquidI18n)
+Liquid::Template.register_filter(ChampaignLiquidFilters)
 Liquid::Template.file_system = LiquidFileSystem
 Liquid::Template.error_mode = Rails.env.production? ? :lax : :strict

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -89,6 +89,7 @@ en:
       data_type: 'This changes what user inputs the field will accept'
       label: 'This is the label of the field presented to the signer.'
       name: "The field name to be stored in ActionKit. Select a standard AK field from the suggestions, or enter your own. If entering your own, add _customer or _shareholder to company names, or _other for others. Examples: apple_customer, shell_shareholder, journalist_other"
+      default_value: "The field will be pre-populated with whatever you write here. Write '1' or 'checked' to pre-check checkboxes. Countries should be two character country code."
 
   oauth:
     not_authorised: "You're not authorised to authenticate with that account."
@@ -189,9 +190,12 @@ en:
     label: 'Label (user-facing)'
     data_type: 'Field type'
     name: 'Name (internal-facing)'
+    default_value: 'Default value'
+    add_default_value: 'Add default value'
     required: 'Required'
     label_suggestion: "eg. Street Address"
     name_suggestion: "eg. address1"
+    default_value_suggestion: 'eg. 10 Downing St.'
 
   links:
     forms:

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -19,7 +19,7 @@ de:
     switch_currency: Währung ändern
     proceed_to_details: Weiter zu Kontaktdaten
     proceed_to_payment: Weiter zur Zahlung
-    other_amount: Anderer Betrag
+    other_amount: Anderer
     make_recurring: Monatlich spenden
     thank_you: Vielen Dank für Ihre Spende!
     card_declined: Der Zahlungsdienst hat Ihre Kreditkarte nicht akzeptiert. Bitte wählen Sie eine andere Zahlungsmethode.

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -57,7 +57,7 @@ fr:
     processing: En cours de traitement...
     submit: Envoyer
     default:
-      name: NOM COMPLET
+      name: PRENOM ET NOM
       email: ADRESSE EMAIL
       country: PAYS
       postal: CODE POSTAL
@@ -68,8 +68,8 @@ fr:
   share:
     cta: Partagez la pétition avec vos ami(e)s afin de tripler votre impact!
     send_email: Envoyer un courriel
-    share: Partager
-    tweet: Tweet
+    share: Partagez
+    tweet: Tweetez
     twitter_handle: '@sumofus_fr'
   errors:
     probably_invalid: semble invalide

--- a/spec/liquid/champaign_liquid_filters_spec.rb
+++ b/spec/liquid/champaign_liquid_filters_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe ChampaignLiquidFilters do
+
+  # to define a liquid filter, you make a module with instance methods that
+  # gets included by liquid. You can't make them module_functions, so here
+  # we extend a generic class to call the filter
+  subject { Class.new.extend(ChampaignLiquidFilters) }
+
+  describe 'select_option' do
+
+    let(:base_options) do
+       '<option value="DM">Dominique</option>
+        <option value="SV">El Salvador</option>
+        <option value="ES">Espagne</option>
+        <option value="EE">Estonie</option>'
+    end
+
+    it 'does not add selected if one is already selected with attribute' do
+      options = base_options + '<option value="FJ" selected="selected">Fidji</option>'
+      expect(subject.select_option(options, 'ES')).to eq options
+    end
+
+    it 'does not add selected if one is already selected with property"' do
+      options = base_options + '<option selected value="FJ">Fidji</option>'
+      expect(subject.select_option(options, 'ES')).to eq options
+    end
+
+    it 'correctly selects with single quotes' do
+      options = base_options.gsub('"', "'")
+      processed = subject.select_option(options, 'ES')
+      expect(processed).to include("<option value='ES' selected >Espagne</option>")
+      expect(processed.scan('selected').size).to eq 1
+    end
+
+    it 'correctly selects with double quotes' do
+      options = base_options.gsub("'", '"')
+      processed = subject.select_option(options, 'ES')
+      expect(processed).to include('<option value="ES" selected >Espagne</option>')
+      expect(processed.scan('selected').size).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
This PR gives campaigners the ability to add a default value to a form field for a petition or donation. It also has some copy changes and adds a new liquid filter that was needed to set the default value of the country dropdown.

![default-form-value](https://cloud.githubusercontent.com/assets/102218/14389203/c8103166-fd6e-11e5-89da-a0de9a9a671b.gif)
