### PR TITLE
Footer date corrected and cs link added

### DIFF
--- a/app/liquid/views/partials/_simple_footer.liquid
+++ b/app/liquid/views/partials/_simple_footer.liquid
@@ -6,13 +6,14 @@
         {{ 'branding.tagline' | t }}
       </div>
       <div class="simple-footer__license">
-        &copy; 2015 SumOfUs, {{ 'branding.license' | t }}
+        &copy; 2016 SumOfUs, {{ 'branding.license' | t }}
       </div>
       <div class="simple-footer__links">
         <a href="http://sumofus.org/" class="simple-footer__link">{{ 'footer.home' | t }}</a>
         <a href="http://sumofus.org/about" class="simple-footer__link">{{ 'footer.about' | t}}</a>
         <a href="http://sumofus.org/privacy" class="simple-footer__link">{{ 'footer.privacy_policy' | t }}</a>
         <a href="http://sumofus.org/contact" class="simple-footer__link">{{ 'footer.contact' | t }}</a>
+        <a href="https://community.sumofus.org/petition/new?source=footer" class="simple-footer__link">{{ 'footer.controlshift' | t }}</a>
       </div>
     </div>
   </div>

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -86,6 +86,7 @@ de:
     about: Über Uns
     privacy_policy: Datenschutz
     contact: Kontakt (Impressum)
+    controlshift: #intentionally left blank
   time:
     formats:
       default: "%-d. %B %Y"

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -86,6 +86,7 @@ en:
     about: About
     privacy_policy: Privacy Policy
     contact: Contact
+    controlshift: Start your own campaign
   time:
     formats:
       default: "%-d %B %Y"

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -86,6 +86,7 @@ fr:
     about: Nous Connaitre
     privacy_policy: Mentions Légales
     contact: Contact
+    controlshift: Lancez votre propre pétition
   time:
     formats:
       default: "%-d %B %Y"


### PR DESCRIPTION
I changed 2015 to 2016 in our webpage footer copyright notice.
I also added a link to start a petition on community.sumofus.org (controlshift). We have it working in English and French, so I've got anchor texts for those languages in their yml files, but I'm leaving the anchor text intentionally blank in the German yml file because we don't have controlshift setup in German yet. So if all goes well browsers will just render an anchor with nothing in it.