### PR TITLE
[critical bug fix] fix liquid template smoke tests and empty german translation

### DIFF
--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -86,7 +86,7 @@ de:
     about: Über Uns
     privacy_policy: Datenschutz
     contact: Kontakt (Impressum)
-    controlshift: #intentionally left blank
+    controlshift: '' #intentionally left blank
   time:
     formats:
       default: "%-d. %B %Y"

--- a/spec/requests/liquid_rendering_spec.rb
+++ b/spec/requests/liquid_rendering_spec.rb
@@ -5,12 +5,13 @@ describe "Liquid page rendering" do
   LiquidMarkupSeeder.titles.each do |title|
 
     describe "page with layout #{title}" do
-      [:en, :fr, :de].each do |language|
+      [:en, :fr, :de].each do |language_code|
 
-        it "can render in #{language} without errors" do
+        it "can render in #{language_code} without errors" do
+          language = create :language, code: language_code
           LiquidMarkupSeeder.seed(quiet: true) # transactional fixtures nuke em every test :/
           layout = LiquidLayout.find_by(title: title)
-          page = create :page, liquid_layout: layout
+          page = create :page, liquid_layout: layout, language: language
 
           get "/pages/#{page.id}"
           expect(response).to be_successful


### PR DESCRIPTION
If we had merged to production at the beginning of this week, we would have brought down every German page on production. The problem was this line in `sumofus.de.yml`:
```
controlshift: #intentionally left blank
```
That needed to be 
```
controlshift: "" #intentionally left blank
```
The former is not valid YML syntax. I noticed it looked funny when I looked over @edubsky's PR, but I assumed it was unconventional but acceptable because 
    1) I have smoke tests that would have flagged it if it was a problem and
    2) I assumed that Eoin clicked around to test that it worked in all relevant languages.

Today I loaded a German page in my dev environment and caught the error. I then looked at my smoke test to figure out how they didn't flag this on CCI, and realized that they only tested the page in English despite claiming to try all three supported languages. Huge derp.

Lessons -
- make sure you see your tests fail when you write them so you know they'll fail when they should
- when you make changes to a UI, or to translation files, always click around in the relevant languages and UIs to make sure you didn't break anything
- when in doubt while reviewing code, just ask a question on that line
- always get someone to review your PRs before they're merged.