### PR TITLE
Share page design tweaks

### DIFF
--- a/app/assets/stylesheets/sumofus/components/photos.scss
+++ b/app/assets/stylesheets/sumofus/components/photos.scss
@@ -5,20 +5,6 @@
   @include background-size(cover);
   overflow: hidden;
   position: relative;
-
-  &--translucent {
-    &::after {
-      opacity: 0.15;
-      content: "";
-      top: 0;
-      left: 0;
-      bottom: 0;
-      right: 0;
-      position: absolute;
-      z-index: -1;
-      @include background-size(cover);
-    }
-  }
 }
 
 .cover-photo {

--- a/app/assets/stylesheets/sumofus/pages/share.scss
+++ b/app/assets/stylesheets/sumofus/pages/share.scss
@@ -1,21 +1,15 @@
 .thank-you {
-  &__action-confirmation {
-    text-transform: uppercase;
-    color: $teal;
-    text-align: center;
-    font-weight: bold;
-    font-size: 14px;
-    margin-bottom: 10px;
-  }
   &__cta {
-    font-size: 18px;
+    font-size: 42px;
     font-weight: normal;
     margin: 20px 0 10px;
   }
   &__thanks {
     @media(max-width: 450px) {
-      font-size: 30px;
-      line-height: 35px;
+      font-size: 24px;
+      line-height: 32px;
+      font-weight: normal;
+      color: $slate-gray;
     }
   }
 }

--- a/app/liquid/views/partials/_share_page.liquid
+++ b/app/liquid/views/partials/_share_page.liquid
@@ -12,7 +12,7 @@
 
 
 <div class="header-logo header-logo--light">
-  <a href="http://sumofus.org/">
+  <a href="https://sumofus.org/">
     <div class="header-logo__logo sumofus-logo--positive"></div>
   </a>
 </div>
@@ -22,7 +22,6 @@
 
     <div class="center-content__central-square">
 
-      <div class='thank-you__action-confirmation'>{{ confirmation }}</div>
       <h1 class="thank-you__thanks">{{ message }}</h1>
       <div class="thank-you__cta">{{ 'share.cta' | t }}</div>
 
@@ -31,7 +30,7 @@
           background-image: url({{ images[0].urls.large }})
         }
       </style>
-      <div class="medium-photo medium-photo--translucent center-content__centered-element">
+      <div class="medium-photo center-content__centered-element">
         {% include 'Share' %}
       </div>
     </div>

--- a/app/liquid/views/partials/_share_page.liquid
+++ b/app/liquid/views/partials/_share_page.liquid
@@ -25,11 +25,6 @@
       <h1 class="thank-you__thanks">{{ message }}</h1>
       <div class="thank-you__cta">{{ 'share.cta' | t }}</div>
 
-      <style type="text/css">
-        .medium-photo--translucent::after {
-          background-image: url({{ images[0].urls.large }})
-        }
-      </style>
       <div class="medium-photo center-content__centered-element">
         {% include 'Share' %}
       </div>


### PR DESCRIPTION
Cleaner share page design - no background image, focus on call-to-action (rather than thanks message), and no confirmation line above.

Tested with Optimizely and works well (11% better than our current design from Agency), resulting in more clicks on share buttons. 

Result should be:

![screen shot 2016-04-18 at 16 21 30](https://cloud.githubusercontent.com/assets/81187/14607483/ee1cc2fa-0581-11e6-813e-bb202099097a.png)
