### PR TITLE
Add javascript panel to page editor to stop putting JS in WYSIWYG HTML

### DIFF
--- a/app/assets/javascripts/page_edit_bar.js
+++ b/app/assets/javascripts/page_edit_bar.js
@@ -101,7 +101,7 @@ let PageEditBar = Backbone.View.extend({
   },
 
   save: function() {
-    $.publish('wysiwyg:submit'); // for summernote to update content
+    $.publish('wysiwyg:submit'); // for summernote + codemirror to update content
     if (!this.outstandingSaveRequest) {
       this.disableSubmit();
       this.model.save(this.readData(), {

--- a/app/assets/javascripts/syntax-highlighting.js
+++ b/app/assets/javascripts/syntax-highlighting.js
@@ -6,9 +6,11 @@
 
 $(function(){
   $('.syntax-highlighting').each(function(idx, el){
-    CodeMirror.fromTextArea(el, {
-      mode: 'htmlmixed',
+    var mode = $(el).data('highlight-mode') || 'htmlmixed';
+    var cm = CodeMirror.fromTextArea(el, {
+      mode: mode,
       theme: '3024-night'
     });
+    $.subscribe('wysiwyg:submit', cm.save);
   });
 });

--- a/app/assets/stylesheets/page-edit.scss
+++ b/app/assets/stylesheets/page-edit.scss
@@ -182,6 +182,15 @@ body.page-edit-body {
   }
 }
 
+.javascript-editor {
+  &__toggle {
+    float: right;
+  }
+  .CodeMirror {
+    height: 136px;
+  }
+}
+
 .page-edit-step__title, .edit-block__title, .centered-overlay__title {
   position: absolute;
   top: 0;

--- a/app/views/pages/_form.slim
+++ b/app/views/pages/_form.slim
@@ -13,3 +13,13 @@
       .form-group
         = label_with_tooltip(f, :content, t('pages.edit.content'), t('tooltips.content'))
         = render 'shared/wysiwyg'
+
+      .form-group
+        - js_hidden = ''
+        - if page.javascript.blank?
+          a data-target=".javascript-editor" data-toggle="collapse" class="javascript-editor__toggle"
+            = t('pages.edit.add_javascript')
+          - js_hidden = 'collapse'
+        .javascript-editor class="#{js_hidden}"
+          = label_with_tooltip(f, :javascript, t('pages.edit.javascript'), t('tooltips.javascript'))
+          = f.text_area :javascript, class: 'form-control syntax-highlighting', 'data-highlight-mode' => 'javascript'

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -20,3 +20,8 @@
 = @rendered
 = render 'personalization', data: @data
 = render 'campaigner_overlay', page: @page
+
+javascript:
+  $(document).ready(function() {
+    #{@page.javascript.try(:html_safe)}
+  });

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -62,6 +62,7 @@ en:
   tooltips:
     title: "This is the the signer-facing external title that appears on the page and in Google results. It's also how the page is identified internally in Champaign."
     content: "This will maintain any formatting pasted from Google docs, so set font size to 16 and font to Helvetica Neue when pasting. You can also use this to embed images and videos inline."
+    javascript: 'Put any javascript you want the page to execute here. It will be run after the page is loaded, inside a document.ready handler.'
     tags: 'Standard SumOfUs tags as used in ActionKit'
     page_layout: "Change this to a petition page, a fundraising page, or change the appearance"
     follow_up: "Choose what the follow-up page should look like, or redirect to another page after the action"
@@ -115,6 +116,8 @@ en:
     edit:
       title: 'Title'
       content: 'Body text'
+      add_javascript: 'Add javascript'
+      javascript: 'Javascript'
       settings: 'Settings'
       pictures: 'Pictures'
       shares: 'Shares'

--- a/db/migrate/20160418211612_add_javascript_to_page.rb
+++ b/db/migrate/20160418211612_add_javascript_to_page.rb
@@ -1,0 +1,5 @@
+class AddJavascriptToPage < ActiveRecord::Migration
+  def change
+    add_column :pages, :javascript, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160314215202) do
+ActiveRecord::Schema.define(version: 20160418211612) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -197,6 +197,7 @@ ActiveRecord::Schema.define(version: 20160314215202) do
     t.string   "ak_donation_resource_uri"
     t.integer  "follow_up_plan",             default: 0,         null: false
     t.integer  "follow_up_page_id"
+    t.text     "javascript"
   end
 
   add_index "pages", ["follow_up_liquid_layout_id"], name: "index_pages_on_follow_up_liquid_layout_id", using: :btree

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -36,6 +36,7 @@ describe Page do
   it { is_expected.to respond_to :tag_names }
   it { is_expected.to respond_to :plugin_names }
   it { is_expected.to respond_to :meta_tags }
+  it { is_expected.to respond_to :javascript }
 
   it { is_expected.not_to respond_to :secondary_liquid_layout }
 


### PR DESCRIPTION
It's been rather common for campaigners to want to do weird one-off tweaks to the page layout, such as removing the total signature count, changing the word signature to pledge, or prefill a field. Prefilling is now supported natively, but what's become clear is that they need a way to mess around with stuff rather than waiting on us to implement it. 

So far, this has meant using Optimizely to deliver the changes, or inserting a `<script>` tag into the HTML  pane of the WYSIWYG editor. Neither is ideal, so what I've done is added a javascript field to the page. It's hidden by default with a link to "Add javascript" below the WYSIWYG if the javascript is empty, but it displays on page load if it already has a value. The javascript gets dumped into a `<script>` tag inside of a `$(document).ready()` handler, as that often trips up people inexperienced with DOM manipulation.