### PR TITLE
Sharing 'n formatting

### DIFF
--- a/app/assets/stylesheets/page-edit.scss
+++ b/app/assets/stylesheets/page-edit.scss
@@ -9,6 +9,14 @@ body.page-edit-body {
   background-color: $page-edit-bar-color;
 }
 
+.note-editable {
+  // don't pad the paragraphs in the WYSIWYG or the output
+  ol, ul, p {
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+}
+
 .page-edit-bar, .sidebar {
   width: 20%;
   height: 100%;

--- a/app/assets/stylesheets/sumofus/components/petition.scss
+++ b/app/assets/stylesheets/sumofus/components/petition.scss
@@ -171,6 +171,7 @@
       padding: 20px 8%;
       height: 60px;
       width: 92%;
+      z-index: 1100;
 
       text-align: center;
       background-color: $overcast-gray;

--- a/app/assets/stylesheets/sumofus/components/photos.scss
+++ b/app/assets/stylesheets/sumofus/components/photos.scss
@@ -42,6 +42,11 @@
     bottom: 40px;
     width: 100%;
   }
+  &__title {
+    @media(max-width: $mobile-width) {
+      font-size: 32px;
+    }
+  }
   &__target {
     &:empty {
       display: none;

--- a/app/assets/stylesheets/sumofus/global/typography.scss
+++ b/app/assets/stylesheets/sumofus/global/typography.scss
@@ -83,11 +83,6 @@ a {
   p, ul, ol {
     margin-bottom: 18px;
   }
-  p+br {
-    // don't display <br> tags that follow
-    // immediately on <p> tags, cause they have margin
-    display: none
-  }
   ul, ol {
     padding-left: 40px;
   }

--- a/app/assets/stylesheets/sumofus/global/typography.scss
+++ b/app/assets/stylesheets/sumofus/global/typography.scss
@@ -80,8 +80,10 @@ a {
   p, span, div {
     line-height: 1.6em;
   }
+  // don't pad the paragraphs in the WYSIWYG or the output
   p, ul, ol {
-    margin-bottom: 18px;
+    margin-top: 0;
+    margin-bottom: 0;
   }
   ul, ol {
     padding-left: 40px;

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -94,7 +94,7 @@ module PagesHelper
   def twitter_meta(page, share_card={})
     {
       card: 'summary_large_image',
-      domain: 'http://sumofus.org',
+      domain: Settings.homepage_url,
       site: t('share.twitter_handle'),
       creator: t('share.twitter_handle'),
       title: page.title,
@@ -112,7 +112,7 @@ module PagesHelper
       description: truncate(strip_tags(CGI.unescapeHTML(page.content)), length: 260),
       url: page_url(page),
       type: 'website',
-      article: { publisher: 'https://www.facebook.com/SumOfUs-181924628560212/' },
+      article: { publisher: Settings.facebook_url },
       image: {
         width: '1200',
         height: '630',

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -90,4 +90,50 @@ module PagesHelper
       'glyphicon-menu-down'
     end
   end
+
+  def twitter_meta(page, share_card={})
+    {
+      card: 'summary_large_image',
+      domain: 'http://sumofus.org',
+      site: t('share.twitter_handle'),
+      creator: t('share.twitter_handle'),
+      title: page.title,
+      description: truncate(strip_tags(CGI.unescapeHTML(page.content)), length: 140),
+      image: page.primary_image.try(:content).try(:url)
+    }.merge(share_card) do |key, v1, v2|
+      v2.blank? ? v1 : v2
+    end
+  end
+
+  def facebook_meta(page, share_card={})
+    {
+      site_name: 'SumOfUs',
+      title: page.title,
+      description: truncate(strip_tags(CGI.unescapeHTML(page.content)), length: 260),
+      url: page_url(page),
+      type: 'website',
+      article: { publisher: 'https://www.facebook.com/SumOfUs-181924628560212/' },
+      image: {
+        width: '1200',
+        height: '630',
+        url: page.primary_image.try(:content).try(:url)
+      }
+    }.merge(share_card) do |key, v1, v2|
+      if key == :image
+        v2.blank? ? v1 : v1.merge(url: v2)
+      else
+        v2.blank? ? v1 : v2
+      end
+    end
+  end
+
+  def share_card(page)
+    share = Share::Facebook.where(page_id: page.id).last
+    return {} if share.blank?
+    {
+      title: share.title,
+      description: share.description,
+      image: Image.find_by(id: share.image_id).try(:content).try(:url)
+    }
+  end
 end

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -1,21 +1,7 @@
+- share_card = share_card(@page)
+- meta twitter: twitter_meta(@page, share_card)
+- meta og: facebook_meta(@page, share_card)
 - meta optimization_tags: @page.meta_tags
-
-/Twitter Meta Tags for proper behavior there
-- meta twitter: {card: 'summary_large_image',
-        domain: 'http://sumofus.org',
-        site: t('share.twitter_handle'),
-        creator: t('share.twitter_handle'),
-        title: @page.title,
-        description: truncate(strip_tags(CGI.unescapeHTML(@page.content)), length: 140),
-        image: @page.primary_image.try(:content).try(:url) }
-
-/Facebook Meta Tags for proper behavior there, too
-- meta og: { site_name: 'SumOfUs',
-        title: @page.title, url: page_url(@page),
-        description: truncate(strip_tags(CGI.unescapeHTML(@page.content)), length: 260),
-        type: 'website',
-        article: {publisher: 'https://www.facebook.com/SumOfUs-181924628560212/'},
-        image: {width: '1200', height: '630', url: @page.primary_image.try(:content).try(:url)}}
 
 = @rendered
 = render 'personalization', data: @data

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -1,13 +1,13 @@
 - meta optimization_tags: @page.meta_tags
 
 /Twitter Meta Tags for proper behavior there
-- meta twitter: { card: 'summary_large_image',
+- meta twitter: {card: 'summary_large_image',
         domain: 'http://sumofus.org',
         site: t('share.twitter_handle'),
         creator: t('share.twitter_handle'),
         title: @page.title,
         description: truncate(strip_tags(CGI.unescapeHTML(@page.content)), length: 140),
-        img: {src: @page.primary_image.try(:content).try(:url)}}
+        image: @page.primary_image.try(:content).try(:url) }
 
 /Facebook Meta Tags for proper behavior there, too
 - meta og: { site_name: 'SumOfUs',

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,3 @@
-homepage_url: '//sumofus.org'
+homepage_url: 'http://sumofus.org'
+facebook_url: 'https://www.facebook.com/SumOfUs-181924628560212/'
 host: "http://localhost"

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -5,7 +5,8 @@ secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
 omniauth_client_secret: <%= ENV['OMNIAUTH_CLIENT_SECRET'] %>
 omniauth_client_id: <%= ENV['OMNIAUTH_CLIENT_ID'] %>
 liquid_templating_source: <%= ENV['LIQUID_TEMPLATING_SOURCE'] || 'store' %>
-homepage_url: '//sumofus.org'
+homepage_url: 'http://sumofus.org'
+facebook_url: 'https://www.facebook.com/SumOfUs-181924628560212/'
 oauth_domain_whitelist:
   - 'sumofus.org'
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -16,7 +16,8 @@
      secret_key_base: 'a fake secret key'
      omniauth_client_secret: 'a fake client secret'
      omniauth_client_id: 'a fake client_id'
-     homepage_url: '//sumofus.org'
+     homepage_url: 'http://sumofus.org'
+     facebook_url: 'https://www.facebook.com/SumOfUs-181924628560212/'
      oauth_domain_whitelist:
        - 'example.com'
 


### PR DESCRIPTION
This fixes a host of small requested features -
- on twitter, the link preview wasn't loading the image because it used the wrong meta tag. this is now fixed.
- when people directly shared the link on facebook and twitter, the link preview showed the page title and body text, rather than the carefully crafted shares. We now use the most recently created facebook share, falling back to the title and description. this has a spec. 
    - note: this also means a round trip or two to the DB for every page load, which may adversely affect our performance.
- the page titles on mobile were too large, often resulting in hyphenation. they are now smaller.
- there were persistent inconsistencies between paragraph spacing here and in google docs. I'm trying to fix them by stripping the previous default margins I was applying to `<p>` tags, and really letting it be WYSIWYG. after experimentation with pasting from Google docs and with creation right in the editor, I think this will fix the issue.