### PR TITLE
Moving GC forward

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -1,26 +1,8 @@
-class Api::Payment::BraintreeController < ApplicationController
+class Api::Payment::BraintreeController < PaymentController
   skip_before_action :verify_authenticity_token
 
   def token
     render json: { token: ::Braintree::ClientToken.generate }
-  end
-
-  def transaction
-    builder = if recurring?
-                client::Subscription.make_subscription(payment_options)
-              else
-                client::Transaction.make_transaction(payment_options)
-              end
-
-    if builder.result.success?
-      write_member_cookie(builder.action.member_id) unless builder.action.blank?
-      id = recurring? ? { subscription_id: builder.result.subscription.id } : { transaction_id: builder.result.transaction.id }
-
-      render json: { success: true }.merge(id)
-    else
-      errors = client::ErrorProcessing.new(builder.result).process
-      render json: { success: false, errors: errors }, status: 422
-    end
   end
 
   def webhook

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -1,0 +1,27 @@
+class PaymentController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def transaction
+    builder = if recurring?
+                client::Subscription.make_subscription(payment_options)
+              else
+                client::Transaction.make_transaction(payment_options)
+              end
+
+    if builder.success?
+      write_member_cookie(builder.action.member_id) unless builder.action.blank?
+      id = recurring? ? { subscription_id: builder.subscription_id } : { transaction_id: builder.transaction_id }
+
+      render json: { success: true }.merge(id)
+    else
+      errors = client::ErrorProcessing.new(builder.result).process
+      render json: { success: false, errors: errors }, status: 422
+    end
+  end
+
+  private
+
+  def recurring?
+    @recurring ||= ActiveRecord::Type::Boolean.new.type_cast_from_user( params[:recurring] )
+  end
+end

--- a/app/models/payment/go_cardless.rb
+++ b/app/models/payment/go_cardless.rb
@@ -4,141 +4,30 @@ module Payment::GoCardless
       'payment_go_cardless_'
     end
 
-    def write_transaction(gc_mandate, gc_payment, page_id, member, save_customer=true)
-      GoCardlessTransactionBuilder.build(gc_mandate, gc_payment, page_id, member, save_customer)
+    def write_customer(customer_gc_id, member_id)
+      local_customer = Payment::GoCardless::Customer.find_or_initialize_by(go_cardless_id: customer_gc_id)
+      local_customer.update_attributes(member_id: member_id)
+      local_customer
     end
 
-    def write_subscription(gc_mandate, gc_subscription, page_id, member, save_customer=true)
-      # TODO: implement
-      # if response is successful...
-      Payment::GoCardless::Subscription.create!(subscription_attrs)
+    def write_mandate(mandate_gc_id, scheme, next_possible_charge_date, customer_id)
+      local_mandate = Payment::GoCardless::PaymentMethod.find_or_initialize_by(go_cardless_id: mandate_gc_id)
+      local_mandate.update_attributes(scheme: scheme, next_possible_charge_date: next_possible_charge_date, customer_id: customer_id)
+      # action = Payment::GoCardless::PaymentMethod::ACTION_FROM_STATE[ status.to_sym ]
+      # local_mandate.send("run_#{action}!")
+      local_mandate
     end
 
-    def write_customer(gc_customer, member)
-      GoCardlessCustomerBuilder.build(gc_customer, member)
+    def write_transaction(transaction_gc_id, amount, currency, page_id)
+      local_transaction = Payment::GoCardless::Transaction.find_or_initialize_by(go_cardless_id: transaction_gc_id)
+      local_transaction.update_attributes(amount: amount, currency: currency, page_id: page_id)
+      local_transaction
     end
 
-    def customer(email)
-      customer = Payment::GoCardless::Customer.find_by(email: email)
-      return customer if customer.present?
-      member = Member.find_by(email: email)
-      member.try(:go_cardless_customer)
-    end
-
-    class GoCardlessCustomerBuilder
-      #
-      # Stores and associates a GoCardless customer as +Payment::GoCardless::Customer+.
-      #
-      # === Options
-      #
-      # * +:gc_customer+ - A GoCardless::Customer response object for getting a single customer by ID.
-      #                    (see https://developer.gocardless.com/pro/2015-07-06/#customers-get-a-single-customer)
-      # * +:member_id+   - the member_id to associate with the customer record
-      #
-      def self.build(gc_customer, member)
-        new(gc_customer, member).build
-      end
-
-      def initialize(gc_customer, member)
-        @gc_customer = gc_customer
-        @member = member
-        @customer = member.go_cardless_customer
-      end
-
-      def build
-        if @customer.present?
-          @customer.update(customer_attrs)
-        else
-          Payment::GoCardless::Customer.create!(customer_attrs)
-        end
-      end
-
-      def customer_attrs
-        {
-          member_id: @member.id,
-          go_cardless_id: @gc_customer.id,
-          email: @gc_customer.email,
-          given_name: @gc_customer.given_name,
-          family_name: @gc_customer.family_name,
-          postal_code: @gc_customer.postal_code,
-          country_code: @gc_customer.country_code,
-          language: @gc_customer.language
-        }
-      end
-    end
-
-    class GoCardlessTransactionBuilder
-      #
-      # Stores and associates a GoCardless payment as +Payment::GoCardless::Transaction+.
-      #
-      # === Options
-      #
-      # * +:gc_payment+   - A GoCardless::Payment response object
-      #                    (see https://developers.braintreepayments.com/reference/response/transaction/ruby)
-      # * +:page_id+     - the id of the Page to associate with the transaction record
-      # * +:member_id+   - the member_id to associate with the customer record
-      # * +:existing_customer+ - if passed, this customer is updated instead of creating a new one
-      # * +:save_customer+     - optional, default true. whether to save the customer info too
-      #
-
-      def self.build(gc_mandate, gc_payment, page_id, member, save_customer)
-        new(gc_mandate, gc_payment, page_id, member, save_customer).build
-      end
-
-      def initialize(gc_mandate, gc_payment, page_id, member, save_customer)
-        @gc_mandate = gc_mandate
-        @gc_payment = gc_payment
-        @page_id = page_id
-        @member = member
-        @customer = member.go_cardless_customer
-        @save_customer = save_customer
-      end
-
-      def build
-        if @customer.present?
-          @customer.update_attributes(customer_attrs)
-        else
-          @customer = ::Payment::GoCardless::Customer.create(customer_attrs)
-        end
-        @mandate = ::Payment::GoCardless::PaymentMethod.find_or_initialize_by({
-           go_cardless_id: @gc_payment.links.mandate,
-           customer_id: @customer.id,
-         })
-        @mandate.status = @gc_mandate.status.to_sym
-        @mandate.save
-        ::Payment::GoCardless::Transaction.create(transaction_attrs)
-      end
-
-     private
-
-      def customer_attrs
-        {
-          member_id: @member.id,
-          go_cardless_id: @gc_payment.metadata["customer_id"]
-        }
-      end
-
-      def transaction_attrs
-        {
-          go_cardless_id: @gc_payment.id,
-          charge_date: @gc_payment.charge_date,
-          amount: @gc_payment.amount,
-          description: @gc_payment.description,
-          currency: @gc_payment.currency,
-          reference: @gc_payment.reference,
-          amount_refunded: @gc_payment.amount_refunded,
-          page_id: @page_id,
-          customer_id: @customer.id,
-          payment_method_id: @mandate.id,
-        }
-      end
-
-      def subscription_attrs
-        {
-
-        }
-      end
-
+    def write_subscription(subscription_gc_id, amount, currency, page_id)
+      local_subscription = Payment::GoCardless::Subscription.find_or_initialize_by(go_cardless_id: subscription_gc_id)
+      local_subscription.update_attributes(amount: amount, currency: currency, page_id: page_id)
+      local_subscription
     end
   end
 end

--- a/app/services/action_queue.rb
+++ b/app/services/action_queue.rb
@@ -151,7 +151,7 @@ module ActionQueue
     end
 
     def split_expire_date
-      if data[:card_expiration_date] == '/'
+      if data[:card_expiration_date] == '/' || data[:card_expiration_date].blank?
         # We weren't given an expiration, probably because it's a PayPal transaction, so set a fake expiration five years
         # in the future.
         [Time.now.month.to_s, (Time.now.year + 5).to_s]

--- a/app/services/direct_debit_decider.rb
+++ b/app/services/direct_debit_decider.rb
@@ -8,7 +8,6 @@ class DirectDebitDecider
   end
 
   def initialize(member_countries, recurring_default)
-    puts member_countries
     @member_countries = member_countries.map{ |country| country.to_s.upcase.to_sym }
     recurring_default = recurring_default.try(:to_sym)
     @recurring = (recurring_default == :only_recurring || recurring_default == :recurring)

--- a/app/services/manage_donation.rb
+++ b/app/services/manage_donation.rb
@@ -1,0 +1,16 @@
+class ManageDonation
+  include ActionBuilder
+
+  def self.create(params:)
+    new(params: params).create
+  end
+
+  def initialize(params:)
+    @params = params
+  end
+
+  def create
+    build_action(donation: true)
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,7 @@ Rails.application.routes.draw do
 
     namespace :go_cardless do
       get ':page_id/start_flow', action: 'start_flow'
-      get 'payment_complete'
+      get 'transaction'
       post 'webhook'
     end
 

--- a/lib/payment_processor/clients/braintree/populator.rb
+++ b/lib/payment_processor/clients/braintree/populator.rb
@@ -39,6 +39,10 @@ module PaymentProcessor
         def existing_customer
           @existing_customer ||= Payment.customer(@user[:email])
         end
+
+        def success?
+          @result.success?
+        end
       end
     end
   end

--- a/lib/payment_processor/clients/braintree/subscription.rb
+++ b/lib/payment_processor/clients/braintree/subscription.rb
@@ -49,6 +49,10 @@ module PaymentProcessor
           end
         end
 
+        def subscription_id
+          @result.try(:subscription).try(:id)
+        end
+
         private
 
         # if the customer was updated, we have to create the payment method separately,

--- a/lib/payment_processor/clients/braintree/transaction.rb
+++ b/lib/payment_processor/clients/braintree/transaction.rb
@@ -22,7 +22,7 @@ module PaymentProcessor
 
         def self.make_transaction(nonce:, amount:, currency:, user:, page_id:)
           builder = new(nonce, amount, currency, user, page_id)
-          builder.transaction
+          builder.transact
           builder
         end
 
@@ -34,7 +34,7 @@ module PaymentProcessor
           @page_id = page_id
         end
 
-        def transaction
+        def transact
           @result = ::Braintree::Transaction.sale(options)
           if @result.success?
             @action = ManageBraintreeDonation.create(params: @user.merge(page_id: @page_id), braintree_result: result, is_subscription: false)
@@ -42,6 +42,10 @@ module PaymentProcessor
           else
             Payment.write_transaction(result, @page_id, nil, existing_customer)
           end
+        end
+
+        def transaction_id
+          @result.try(:transaction).try(:id)
         end
 
         private

--- a/lib/payment_processor/go_cardless/populator.rb
+++ b/lib/payment_processor/go_cardless/populator.rb
@@ -4,13 +4,13 @@ module PaymentProcessor
 
       def transaction_params
         {
-          amount: amount,
+          amount: amount_in_cents,
           currency: currency,
           links: {
-              mandate: mandate.id
+            mandate: mandate.id
           },
           metadata: {
-              customer_id: complete_redirect_flow.links.customer
+            customer_id: customer_id
           }
         }
       end
@@ -21,18 +21,26 @@ module PaymentProcessor
             name: "donation",
             interval_unit: "monthly",
             day_of_month:  "1",
-          })
+          }
+        )
       end
 
       def mandate
         @mandate ||= client.mandates.get(complete_redirect_flow.links.mandate)
       end
 
+      def customer_id
+        complete_redirect_flow.links.customer
+      end
 
-      def amount
+      def amount_in_cents
         # we let the donor pick any amount and currency, then convert it to the right currency
         # for their bank according to the current exchange rate
-        @amount ||= PaymentProcessor::Currency.convert(@original_amount, currency, @original_currency).cents
+        @amount ||= PaymentProcessor::Currency.convert(@original_amount_in_cents, currency, @original_currency).cents
+      end
+
+      def amount_in_whole_currency
+        amount_in_cents.to_f / 100
       end
 
       def currency
@@ -45,7 +53,7 @@ module PaymentProcessor
       def complete_redirect_flow
         @complete_redirect_flow ||= client.redirect_flows.complete(@redirect_flow_id, params: { session_token: @session_token })
       rescue GoCardlessPro::InvalidStateError => e
-        @errors = e.errors unless e.message =~ /already completed/
+        raise e unless e.message =~ /already completed/
         @complete_redirect_flow = client.redirect_flows.get(@redirect_flow_id)
       end
 
@@ -56,7 +64,7 @@ module PaymentProcessor
         )
       end
 
-      def self.success?
+      def success?
         @errors.blank?
       end
 

--- a/lib/payment_processor/go_cardless/populator.rb
+++ b/lib/payment_processor/go_cardless/populator.rb
@@ -67,17 +67,6 @@ module PaymentProcessor
       def success?
         @errors.blank?
       end
-
-      def create_or_update_member(params)
-        splitter = NameSplitter.new(full_name: params[:user][:name])
-        member_params = params[:user].except(:form_id, :name).merge({
-                                                                         first_name: splitter.first_name,
-                                                                         last_name: splitter.last_name
-                                                                     })
-        member = Member.find_or_create_by(email: member_params[:email])
-        member.update_attributes(member_params.permit(:first_name, :last_name, :country, :postal, :email))
-        member
-      end
     end
   end
 end

--- a/lib/payment_processor/go_cardless/subscription.rb
+++ b/lib/payment_processor/go_cardless/subscription.rb
@@ -12,7 +12,7 @@ module PaymentProcessor
       def initialize(amount:, currency:, user:, page_id:, redirect_flow_id:, session_token:)
         @page_id = page_id
         @original_amount_in_cents = (amount.to_f * 100).to_i # Price in pence/cents
-        @original_currency = currency.upcase
+        @original_currency = currency.try(:upcase)
         @redirect_flow_id = redirect_flow_id
         @user = user
         @session_token = session_token
@@ -30,7 +30,7 @@ module PaymentProcessor
       end
 
       def subscription_id
-        @local_subscription.try(:subscription_id)
+        @local_subscription.try(:go_cardless_id)
       end
 
       private

--- a/lib/payment_processor/go_cardless/subscription.rb
+++ b/lib/payment_processor/go_cardless/subscription.rb
@@ -13,20 +13,45 @@ module PaymentProcessor
       attr_reader :result, :action
 
       def self.make_subscription(params, session_id)
-        new(params, session_id).subscription
+        builder = new(params, session_id)
+        builder.subscription
+        builder
       end
 
       def initialize(params, session_id)
-        @original_amount = (params[:amount].to_f * 100).to_i # Price in pence/cents
+        @page_id = params[:page_id]
+        @original_amount_in_cents = (params[:amount].to_f * 100).to_i # Price in pence/cents
         @original_currency = params[:currency].upcase
         @redirect_flow_id = params[:redirect_flow_id]
+        @user = params[:user]
         @session_token = session_id
+        @member = create_or_update_member(params)
       end
 
       def subscription
-        # We're going to need to write some logic reconciling currency, quantity, and DD scheme
         subscription = client.subscriptions.create(params: subscription_params)
-        # TODO: persist subscription locally
+
+        @local_customer = Payment::GoCardless.write_customer(customer_id, @member_id)
+        @local_mandate = Payment::GoCardless.write_mandate(mandate.id, mandate.scheme, mandate.next_possible_charge_date, @local_customer.id)
+        @local_subscription = Payment::GoCardless.write_subscription(subscription.id, amount_in_whole_currency, currency, @page_id)
+        @action = ManageDonation.create(params: action_params)
+      rescue GoCardlessPro::Error => e
+        @errors = e.errors
+      end
+
+      private
+
+      def action_params
+        @user.merge!(
+          page_id:              @page_id,
+          amount:               amount_in_whole_currency.to_s,
+          card_num:             mandate.id,
+          currency:             currency,
+          subscription_id:      @local_subscription.go_cardless_id,
+          is_subscription:      true,
+          recurrence_number:    0,
+          card_expiration_date: nil
+        )
       end
 
     end

--- a/lib/payment_processor/go_cardless/subscription.rb
+++ b/lib/payment_processor/go_cardless/subscription.rb
@@ -1,42 +1,36 @@
 module PaymentProcessor
   module GoCardless
     class Subscription < Populator
-      # = GoCardless::Subscription
-      #
-      # Wrapper around GoCardless's Ruby SDK. This class essentially just stuffs parameters
-      # into the keys that are expected by GoCardless's class.
-      #
-      # == Usage
-      #
-      # Call <tt>PaymentProcessor::Clients::GoCardless::Subscription.make_subscription</tt>
-      #
       attr_reader :result, :action
 
-      def self.make_subscription(params, session_id)
-        builder = new(params, session_id)
-        builder.subscription
+      def self.make_subscription(params)
+        builder = new(params)
+        builder.subscribe
         builder
       end
 
-      def initialize(params, session_id)
-        @page_id = params[:page_id]
-        @original_amount_in_cents = (params[:amount].to_f * 100).to_i # Price in pence/cents
-        @original_currency = params[:currency].upcase
-        @redirect_flow_id = params[:redirect_flow_id]
-        @user = params[:user]
-        @session_token = session_id
-        @member = create_or_update_member(params)
+      def initialize(amount:, currency:, user:, page_id:, redirect_flow_id:, session_token:)
+        @page_id = page_id
+        @original_amount_in_cents = (amount.to_f * 100).to_i # Price in pence/cents
+        @original_currency = currency.upcase
+        @redirect_flow_id = redirect_flow_id
+        @user = user
+        @session_token = session_token
       end
 
-      def subscription
+      def subscribe
         subscription = client.subscriptions.create(params: subscription_params)
 
-        @local_customer = Payment::GoCardless.write_customer(customer_id, @member_id)
-        @local_mandate = Payment::GoCardless.write_mandate(mandate.id, mandate.scheme, mandate.next_possible_charge_date, @local_customer.id)
         @local_subscription = Payment::GoCardless.write_subscription(subscription.id, amount_in_whole_currency, currency, @page_id)
         @action = ManageDonation.create(params: action_params)
+        @local_customer = Payment::GoCardless.write_customer(customer_id, @action.member_id)
+        @local_mandate = Payment::GoCardless.write_mandate(mandate.id, mandate.scheme, mandate.next_possible_charge_date, @local_customer.id)
       rescue GoCardlessPro::Error => e
         @errors = e.errors
+      end
+
+      def subscription_id
+        @local_subscription.try(:subscription_id)
       end
 
       private

--- a/lib/payment_processor/go_cardless/transaction.rb
+++ b/lib/payment_processor/go_cardless/transaction.rb
@@ -14,25 +14,59 @@ module PaymentProcessor
       # * +:amount+   - Billing amount (required)
       # * +:currency+ - Billing currency (required)
       # * +:user+     - Hash of information describing the customer. Must include email, and name (required)
-      # * +:customer+ - Instance of existing GoCardless customer. Must respond to +customer_id+ (optional)
-      attr_reader :success, :action
+      # * +:customer+ - Instance of existing GoCardless customer. Must respond to +go_cardless_id+ (optional)
+      # 
+        # def payment_options
+        #   {
+        #     nonce: params[:payment_method_nonce],
+        #     amount: params[:amount].to_f,
+        #     user: params[:user],
+        #     currency: params[:currency],
+        #     page_id: params[:page_id]
+        #   }
+        # end
+
+      attr_reader :errors, :action
 
       def self.make_transaction(params, session_id)
-        new(params, session_id).transaction
+        builder = new(params, session_id)
+        builder.transaction
+        builder
       end
 
       def initialize(params, session_id)
         @page_id = params[:page_id]
-        @original_amount = (params[:amount].to_f * 100).to_i # Price in pence/cents
+        @original_amount_in_cents = (params[:amount].to_f * 100).to_i # Price in pence/cents
         @original_currency = params[:currency].upcase
         @redirect_flow_id = params[:redirect_flow_id]
+        @user = params[:user]
         @session_token = session_id
-        @existing_member = create_or_update_member(params)
+        @member = create_or_update_member(params)
       end
 
       def transaction
         transaction = client.payments.create(params: transaction_params)
-        Payment::GoCardless.write_transaction(@mandate, transaction, @page_id, @existing_member, true)
+
+        @local_customer = Payment::GoCardless.write_customer(customer_id, @member_id)
+        @local_mandate = Payment::GoCardless.write_mandate(mandate.id, mandate.scheme, mandate.next_possible_charge_date, @local_customer.id)
+        @local_transaction = Payment::GoCardless.write_transaction(transaction.id, amount_in_whole_currency, currency, @page_id)
+        @action = ManageDonation.create(params: action_params)
+      rescue GoCardlessPro::Error => e
+        @errors = e.errors
+      end
+
+      private
+
+      def action_params
+        @user.merge!(
+          page_id:              @page_id,
+          amount:               amount_in_whole_currency.to_s,
+          card_num:             mandate.id,
+          currency:             currency,
+          transaction_id:       @local_transaction.go_cardless_id,
+          is_subscription:      false,
+          card_expiration_date: nil
+        )
       end
 
     end

--- a/lib/payment_processor/go_cardless/transaction.rb
+++ b/lib/payment_processor/go_cardless/transaction.rb
@@ -30,20 +30,20 @@ module PaymentProcessor
 
       def self.make_transaction(params)
         builder = new(params)
-        builder.transaction
+        builder.transact
         builder
       end
 
       def initialize(amount:, currency:, user:, page_id:, redirect_flow_id:, session_token:)
         @page_id = page_id
         @original_amount_in_cents = (amount.to_f * 100).to_i # Price in pence/cents
-        @original_currency = currency.upcase
+        @original_currency = currency.try(:upcase)
         @redirect_flow_id = redirect_flow_id
         @user = user
         @session_token = session_token
       end
 
-      def transaction
+      def transact
         transaction = client.payments.create(params: transaction_params)
 
         @local_transaction = Payment::GoCardless.write_transaction(transaction.id, amount_in_whole_currency, currency, @page_id)

--- a/spec/fixtures/vcr_cassettes/go_cardless_successful_subscription.yml
+++ b/spec/fixtures/vcr_cassettes/go_cardless_successful_subscription.yml
@@ -1,0 +1,205 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api-sandbox.gocardless.com/mandates/MD0000PSV8N7FR
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - gocardless_pro/v1.0.3 ruby/2.3.0p0 ruby/2.3.0 x86_64-darwin14 faraday/0.9.1
+      Gocardless-Version:
+      - '2015-07-06'
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <gocardless_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Tue, 19 Apr 2016 22:00:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd980aa6e827da6ef8240fb1f93dcdf1d1461103212; expires=Wed, 19-Apr-17
+        22:00:12 GMT; path=/; domain=.gocardless.com; HttpOnly
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-store
+      Etag:
+      - W/"15d4136ed0e060b85683faf3f3e11c0d"
+      X-Request-Id:
+      - bd4877ad-a0db-478a-b12a-d534ae3e1d4c
+      Vary:
+      - Origin
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Ratelimit-Limit:
+      - '1000'
+      Ratelimit-Remaining:
+      - '999'
+      Ratelimit-Reset:
+      - Tue, 19 Apr 2016 22:01:00 GMT
+      Cf-Ray:
+      - 2963a0c6ab2107c7-MIA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"mandates":{"id":"MD0000PSV8N7FR","created_at":"2016-04-11T19:16:56.421Z","reference":"OMAR-JMEKNM53MREX3","status":"active","scheme":"bacs","next_possible_charge_date":"2016-04-25","payments_require_approval":false,"metadata":{},"links":{"customer_bank_account":"BA0000P8MREF5F","creditor":"CR000045KKQEY8"}}}'
+    http_version: 
+  recorded_at: Tue, 19 Apr 2016 22:00:13 GMT
+- request:
+    method: post
+    uri: https://api-sandbox.gocardless.com/payments
+    body:
+      encoding: UTF-8
+      string: '{"payments":{"amount":1155,"currency":"GBP","links":{"mandate":"MD0000PSV8N7FR"},"metadata":{"customer_id":"CU0000RR39FMVB"}}}'
+    headers:
+      User-Agent:
+      - gocardless_pro/v1.0.3 ruby/2.3.0p0 ruby/2.3.0 x86_64-darwin14 faraday/0.9.1
+      Gocardless-Version:
+      - '2015-07-06'
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <gocardless_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Tue, 19 Apr 2016 22:00:14 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d15a42ecb3c2b28f0432959cd8e672af81461103213; expires=Wed, 19-Apr-17
+        22:00:13 GMT; path=/; domain=.gocardless.com; HttpOnly
+      Location:
+      - https://api-sandbox.gocardless.com/payments/PM000181BRQHM4
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-store
+      Etag:
+      - W/"59e2f72990017093b477c8e16f023f16"
+      X-Request-Id:
+      - dfd07d8b-08bf-4cae-84b8-b05b248f0e55
+      Vary:
+      - Origin
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Ratelimit-Limit:
+      - '1000'
+      Ratelimit-Remaining:
+      - '998'
+      Ratelimit-Reset:
+      - Tue, 19 Apr 2016 22:01:00 GMT
+      Cf-Ray:
+      - 2963a0cc271017f8-MIA
+    body:
+      encoding: UTF-8
+      string: '{"payments":{"id":"PM000181BRQHM4","created_at":"2016-04-19T22:00:13.890Z","charge_date":"2016-04-25","amount":1155,"description":null,"currency":"GBP","status":"pending_submission","amount_refunded":0,"reference":null,"metadata":{"customer_id":"CU0000RR39FMVB"},"links":{"mandate":"MD0000PSV8N7FR","creditor":"CR000045KKQEY8"}}}'
+    http_version: 
+  recorded_at: Tue, 19 Apr 2016 22:00:14 GMT
+- request:
+    method: post
+    uri: https://api-sandbox.gocardless.com/subscriptions
+    body:
+      encoding: UTF-8
+      string: '{"subscriptions":{"amount":1155,"currency":"GBP","links":{"mandate":"MD0000PSV8N7FR"},"metadata":{"customer_id":"CU0000RR39FMVB"},"name":"donation","interval_unit":"monthly","day_of_month":"1"}}'
+    headers:
+      User-Agent:
+      - gocardless_pro/v1.0.3 ruby/2.3.0p0 ruby/2.3.0 x86_64-darwin14 faraday/0.9.1
+      Gocardless-Version:
+      - '2015-07-06'
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <gocardless_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Tue, 19 Apr 2016 22:02:59 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d41c32bae8d5fba5283245d8fb1abb9bc1461103378; expires=Wed, 19-Apr-17
+        22:02:58 GMT; path=/; domain=.gocardless.com; HttpOnly
+      Location:
+      - https://api-sandbox.gocardless.com/subscriptions/SB00002PH85Z89
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-store
+      Etag:
+      - W/"62b54c38045227543079b9bf5ccf6746"
+      X-Request-Id:
+      - 1ff536d6-f000-4955-8f7e-eb937eeae2b6
+      Vary:
+      - Origin
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Ratelimit-Limit:
+      - '1000'
+      Ratelimit-Remaining:
+      - '999'
+      Ratelimit-Reset:
+      - Tue, 19 Apr 2016 22:03:00 GMT
+      Cf-Ray:
+      - 2963a4d5e08d2ec3-MIA
+    body:
+      encoding: UTF-8
+      string: '{"subscriptions":{"id":"SB00002PH85Z89","created_at":"2016-04-19T22:02:59.304Z","amount":1155,"currency":"GBP","status":"active","name":"donation","start_date":"2016-05-03","end_date":null,"interval":1,"interval_unit":"monthly","day_of_month":1,"month":null,"metadata":{"customer_id":"CU0000RR39FMVB"},"payment_reference":null,"upcoming_payments":[{"charge_date":"2016-05-03","amount":1155},{"charge_date":"2016-06-01","amount":1155},{"charge_date":"2016-07-01","amount":1155},{"charge_date":"2016-08-01","amount":1155},{"charge_date":"2016-09-01","amount":1155},{"charge_date":"2016-10-03","amount":1155},{"charge_date":"2016-11-01","amount":1155},{"charge_date":"2016-12-01","amount":1155},{"charge_date":"2017-01-02","amount":1155},{"charge_date":"2017-02-01","amount":1155}],"links":{"mandate":"MD0000PSV8N7FR"}}}'
+    http_version: 
+  recorded_at: Tue, 19 Apr 2016 22:02:59 GMT
+recorded_with: VCR 3.0.0

--- a/spec/fixtures/vcr_cassettes/go_cardless_successful_transaction.yml
+++ b/spec/fixtures/vcr_cassettes/go_cardless_successful_transaction.yml
@@ -1134,4 +1134,137 @@ http_interactions:
       string: '{"payments":{"id":"PM00017SXSS6Z4","created_at":"2016-04-15T23:18:59.028Z","charge_date":"2016-04-21","amount":9001,"description":null,"currency":"GBP","status":"pending_submission","amount_refunded":0,"reference":null,"metadata":{"customer_id":"CU0000RR39FMVB"},"links":{"mandate":"MD0000PSV8N7FR","creditor":"CR000045KKQEY8"}}}'
     http_version: 
   recorded_at: Fri, 15 Apr 2016 23:18:59 GMT
+- request:
+    method: post
+    uri: https://api-sandbox.gocardless.com/payments
+    body:
+      encoding: UTF-8
+      string: '{"payments":{"amount":1155.0,"currency":"GBP","links":{"mandate":"MD0000PSV8N7FR"},"metadata":{"customer_id":"CU0000RR39FMVB"}}}'
+    headers:
+      User-Agent:
+      - gocardless_pro/v1.0.3 ruby/2.3.0p0 ruby/2.3.0 x86_64-darwin14 faraday/0.9.1
+      Gocardless-Version:
+      - '2015-07-06'
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <gocardless_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Tue, 19 Apr 2016 20:26:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d3e7f68ec68ccac7d9bfab00c008bc72f1461097571; expires=Wed, 19-Apr-17
+        20:26:11 GMT; path=/; domain=.gocardless.com; HttpOnly
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-store
+      X-Request-Id:
+      - 15732bb2-5076-46a5-a771-c8371bc4097c
+      Vary:
+      - Origin
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Ratelimit-Limit:
+      - '1000'
+      Ratelimit-Remaining:
+      - '999'
+      Ratelimit-Reset:
+      - Tue, 19 Apr 2016 20:27:00 GMT
+      Cf-Ray:
+      - 2963170d10c907c7-MIA
+    body:
+      encoding: UTF-8
+      string: '{"error":{"message":"One of your parameters was incorrectly typed","errors":[{"message":"1155.0
+        is not a string or integer.","field":"amount","request_pointer":"/payments/amount"}],"documentation_url":"https://developer.gocardless.com/pro#invalid_type","type":"invalid_api_usage","request_id":"15732bb2-5076-46a5-a771-c8371bc4097c","code":422}}'
+    http_version: 
+  recorded_at: Tue, 19 Apr 2016 20:26:11 GMT
+- request:
+    method: post
+    uri: https://api-sandbox.gocardless.com/payments
+    body:
+      encoding: UTF-8
+      string: '{"payments":{"amount":1155,"currency":"GBP","links":{"mandate":"MD0000PSV8N7FR"},"metadata":{"customer_id":"CU0000RR39FMVB"}}}'
+    headers:
+      User-Agent:
+      - gocardless_pro/v1.0.3 ruby/2.3.0p0 ruby/2.3.0 x86_64-darwin14 faraday/0.9.1
+      Gocardless-Version:
+      - '2015-07-06'
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <gocardless_token>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - cloudflare-nginx
+      Date:
+      - Tue, 19 Apr 2016 20:27:31 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d6aca36f5bf43b9aa0c5f1bc2b64efb9e1461097650; expires=Wed, 19-Apr-17
+        20:27:30 GMT; path=/; domain=.gocardless.com; HttpOnly
+      Location:
+      - https://api-sandbox.gocardless.com/payments/PM000181BGH1Y8
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-store
+      Etag:
+      - W/"715a2bceed540752741818fb7edbc6db"
+      X-Request-Id:
+      - bf4ab90e-89b2-4330-b8c6-9b1fc88e7b4b
+      Vary:
+      - Origin
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Ratelimit-Limit:
+      - '1000'
+      Ratelimit-Remaining:
+      - '999'
+      Ratelimit-Reset:
+      - Tue, 19 Apr 2016 20:28:00 GMT
+      Cf-Ray:
+      - 296318fe1e6d17f8-MIA
+    body:
+      encoding: UTF-8
+      string: '{"payments":{"id":"PM000181BGH1Y8","created_at":"2016-04-19T20:27:31.336Z","charge_date":"2016-04-25","amount":1155,"description":null,"currency":"GBP","status":"pending_submission","amount_refunded":0,"reference":null,"metadata":{"customer_id":"CU0000RR39FMVB"},"links":{"mandate":"MD0000PSV8N7FR","creditor":"CR000045KKQEY8"}}}'
+    http_version: 
+  recorded_at: Tue, 19 Apr 2016 20:27:31 GMT
 recorded_with: VCR 3.0.0

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 describe "GoCardless API" do
+  let(:usd_amount) { 9.99 }
+  let(:gbp_amount) { 11.55 }
+  before :each do
+    allow_any_instance_of(Money).to receive(:exchange_to).and_return(
+      instance_double(Money, cents: (gbp_amount*100).to_i)
+    )
+  end
 
   describe "triggering a redirect flow" do
 
@@ -80,8 +87,6 @@ describe "GoCardless API" do
     let(:customer_id)      { "CU0000RR39FMVB" }
     let(:customer_bank_account_id) { "BA0000P8MREF5F" }
 
-    let(:usd_amount) { 11 }
-    let(:gbp_amount) { 15 } # probably needs to be changed
     let(:page) { create :page }
     let(:email) { "nealjmd@gmail.com" }
 
@@ -154,14 +159,6 @@ describe "GoCardless API" do
       it 'increments action count on Page' do
         expect{ subject }.to change{ page.reload.action_count }.by 1
       end
-
-      it 'creates a Transaction record associated with the Page' do
-        expect{ subject }.to change{ Payment::GoCardless::Transaction.count }.by 1
-        payment = Payment::GoCardless::Transaction.last
-        expect(payment.go_cardless_id).to match(/^PM[0-9A-Z]+/)
-        expect(payment.currency).to eq 'GBP'
-        expect(payment.amount).to gbp_amount
-      end
     end
 
     describe 'transaction' do
@@ -180,23 +177,19 @@ describe "GoCardless API" do
           allow(PaymentProcessor::Currency).to receive(:convert).and_return converted_money
           allow_any_instance_of(GoCardlessPro::Services::PaymentsService).to receive(:create).and_call_original
           expect_any_instance_of(GoCardlessPro::Services::PaymentsService).to receive(:create).with(
-              params: {
-                  payments: {
-                      amount: converted_money.cents,
-                      currency: 'GBP',
-                      links: {
-                          mandate: /[0-9A-Z]+/
-                      },
-                      metadata: {
-                          customer_id: /[0-9A-Z]+/
-                      }
-                  }
+            params: {
+              'payments' => {
+                amount: converted_money.cents,
+                currency: 'GBP',
+                links: {
+                  mandate: a_string_matching(/\AMD[0-9A-Z]+\z/)
+                },
+                metadata: {
+                  customer_id: a_string_matching(/\ACU[0-9A-Z]+\z/)
+                }
               }
+            }
           )
-          # This should work otherwise, but the key "payments" is a string whereas all other keys are symbols.
-          # It might be an issue with it being a hash with indifferent access - but how do I fix it for the spec?
-          # got: ({:params=>{"payments"=>{:amount=>9001, :currency=>"GBP", :links=>{:mandate=>"MD0000PSV8N7FR"}, :metadata=>{:customer_id=>"CU0000RR39FMVB"}}}})
-
           subject
         end
 
@@ -210,7 +203,7 @@ describe "GoCardless API" do
           expect{ subject }.to change{ Action.count }.by 1
           form_data = Action.last.form_data
           expect(form_data['is_subscription']).to eq false
-          expect(form_data['amount'].to_i).to gbp_amount
+          expect(form_data['amount']).to eq gbp_amount.to_s
           expect(form_data['currency']).to eq 'GBP'
           expect(form_data['transaction_id']).to eq Payment::GoCardless::Transaction.last.go_cardless_id
           
@@ -223,10 +216,18 @@ describe "GoCardless API" do
           expect(response.status).to eq 200
           expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
         end
+
+        it 'creates a Transaction record associated with the Page' do
+          expect{ subject }.to change{ Payment::GoCardless::Transaction.count }.by 1
+          payment = Payment::GoCardless::Transaction.last
+          expect(payment.go_cardless_id).to match(/^PM[0-9A-Z]+/)
+          expect(payment.currency).to eq 'GBP'
+          expect(payment.amount).to eq gbp_amount
+        end
       end
 
       describe 'when Member exists' do
-        let(:member) { create :member, email: email }
+        let!(:member) { create :member, email: email }
 
         include_examples 'successful transaction'
         include_examples 'donation action'
@@ -262,10 +263,9 @@ describe "GoCardless API" do
       let(:params) { base_params.merge(recurring: true) }
 
       subject do
-        # I don't want to create the cassette yet
-        # VCR.use_cassette('go_cardless successful subscription') do
-        #   get api_go_cardless_payment_complete_path, params
-        # end
+        VCR.use_cassette('go_cardless successful subscription') do
+          get api_go_cardless_payment_complete_path, params
+        end
       end
 
       shared_examples 'successful subscription' do
@@ -285,14 +285,14 @@ describe "GoCardless API" do
           expect( ChampaignQueue ).to receive(:push).with(donation_push_params)
         end
 
-        it 'stores amount, currency, is_subscription, subscription_id, and transaction_id in form_data on the Action' do
+        it 'stores amount, currency, is_subscription, and subscription_id in form_data on the Action' do
           expect{ subject }.to change{ Action.count }.by 1
           form_data = Action.last.form_data
           expect(form_data['is_subscription']).to eq true
-          expect(form_data['amount'].to_i).to gbp_amount
+          expect(form_data['amount']).to eq gbp_amount.to_s
           expect(form_data['currency']).to eq 'GBP'
           expect(form_data['subscription_id']).to eq Payment::GoCardless::Subscription.last.go_cardless_id
-          expect(form_data['transaction_id']).to eq Payment::GoCardless::Transaction.last.go_cardless_id
+          expect(form_data).not_to have_key('transaction_id')
         end
 
         it 'responds successfully with subscription_id' do
@@ -301,10 +301,14 @@ describe "GoCardless API" do
           expect(response.status).to eq 200
           expect(response.body).to eq({ success: true, subscription_id: subscription_id }.to_json)
         end
+
+        it 'does not yet create a transaction record' do
+          expect{ subject }.not_to change{ Payment::GoCardless::Transaction.count }
+        end
       end
 
       describe 'when Member exists' do
-        let(:member) { create :member, email: email }
+        let!(:member) { create :member, email: email }
 
         include_examples 'successful subscription'
         include_examples 'donation action'

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -35,7 +35,7 @@ describe "GoCardless API" do
 
     subject do
       VCR.use_cassette("go_cardless redirect_flow_post_back_payment") do
-        get api_go_cardless_payment_complete_path, go_cardless_params
+        get api_go_cardless_transaction_path, go_cardless_params
       end
     end
 
@@ -168,7 +168,7 @@ describe "GoCardless API" do
 
       subject do
         VCR.use_cassette('go_cardless successful transaction') do
-          get api_go_cardless_payment_complete_path, params
+          get api_go_cardless_transaction_path, params
         end
       end
 
@@ -264,7 +264,7 @@ describe "GoCardless API" do
 
       subject do
         VCR.use_cassette('go_cardless successful subscription') do
-          get api_go_cardless_payment_complete_path, params
+          get api_go_cardless_transaction_path, params
         end
       end
 


### PR DESCRIPTION
Just a bunch of coding, mostly simplifications, to get the GoCardless integration a lot closer to where it should be. The state of the spec is shown below (failures are indicated by asterisks in the left column). It works for both subscriptions and transactions, and it uses the same controller action for both Braintree and GoCardless, though I'm currently doing it by inheritance to avoid changing the routes. Tomorrow, I think I'll start writing specs for the error cases. @osahyoun I've also changed the call signature for the writer methods in `go_cardless.rb` to the minimum, and I think you'll want to check those out.
```
GoCardless API
  after successful redirect flow
    transaction
      when Member exists
        creates a PaymentMethod record that stores the mandate id
        leaves a cookie with the member_id
        passes the correct data to the GoCardless Payment SDK
        increments redis counters
        responds successfully with transaction_id
*       posts donation action to queue with correct data (FAILED - 3)
        creates a Transaction record associated with the Page
        creates an Action associated with the Page and Member
        increments action count on Page
        updates the Member's fields with any new data
        stores amount, currency, is_subscription, and transaction_id in form_data on the Action
      when Member is new
        populates the Member’s fields with form data
        creates a PaymentMethod record that stores the mandate id
        passes the correct data to the GoCardless Payment SDK
        creates a Transaction record associated with the Page
        creates an Action associated with the Page and Member
        increments redis counters
*       posts donation action to queue with correct data (FAILED - 4)
        stores amount, currency, is_subscription, and transaction_id in form_data on the Action
        responds successfully with transaction_id
        increments action count on Page
        leaves a cookie with the member_id
    subscription
      when Member exists
        passes the correct data to the GoCardless Payment SDK
        increments action count on Page
        responds successfully with subscription_id
        stores amount, currency, is_subscription, and subscription_id in form_data on the Action
        does not yet create a transaction record
*       posts donation action to queue with correct data (FAILED - 5)
        leaves a cookie with the member_id
        increments redis counters
        creates a PaymentMethod record that stores the mandate id
        creates an Action associated with the Page and Member
        updates the Member's fields with any new data
      when Member is new
        leaves a cookie with the member_id
        creates a PaymentMethod record that stores the mandate id
        responds successfully with subscription_id
        populates the Member’s fields with form data
        increments redis counters
        creates an Action associated with the Page and Member
        stores amount, currency, is_subscription, and subscription_id in form_data on the Action
        does not yet create a transaction record
        passes the correct data to the GoCardless Payment SDK
        increments action count on Page
*       posts donation action to queue with correct data (FAILED - 6)
  GoCardless posting back from a redirect flow with not having completed the form
*   responds with an error because customer has not filled the payment form (FAILED - 1)
  triggering a redirect flow
*   redirects to a GoCardless hosted a redirect flow page (FAILED - 2)

```