### PR TITLE
Video page

### DIFF
--- a/app/assets/javascripts/configure_wysiwyg.js
+++ b/app/assets/javascripts/configure_wysiwyg.js
@@ -33,7 +33,7 @@
     // or to fit on screen on mobile, you have to apply style to the iframe
     // and to the containing element. This adds a class to the containing element
     // that our CSS is looking for.
-    encapsulateIframes = function(html) {
+    var encapsulateIframes = function(html) {
       if( html.indexOf('iframe') === -1 ) {
         return html; // don't do anything if there's no iframe
       }
@@ -44,7 +44,7 @@
       return $('<div></div>').append($html).html();
     }
 
-    updateContentBeforeSave = function(){
+    var updateContentBeforeSave = function(){
       var content = encapsulateIframes($editor.summernote('code'));
       $contentField.val(content);
     };

--- a/app/assets/javascripts/configure_wysiwyg.js
+++ b/app/assets/javascripts/configure_wysiwyg.js
@@ -29,8 +29,23 @@
     $editor.summernote('fontSize', '16'); // default
     $editor.summernote('code', $contentField.val());
 
+    // In order to make an iframe size down with the containing column
+    // or to fit on screen on mobile, you have to apply style to the iframe
+    // and to the containing element. This adds a class to the containing element
+    // that our CSS is looking for.
+    encapsulateIframes = function(html) {
+      if( html.indexOf('iframe') === -1 ) {
+        return html; // don't do anything if there's no iframe
+      }
+      var $html = $(html);
+      // addClass is idempotent so we just call it every time we save
+      $html.find('iframe').parent().addClass('iframe-responsive-container');
+      // this little goof is just cause jquery doesn't have $el.outerHtml();
+      return $('<div></div>').append($html).html();
+    }
+
     updateContentBeforeSave = function(){
-      var content = $editor.summernote('code');
+      var content = encapsulateIframes($editor.summernote('code'));
       $contentField.val(content);
     };
 

--- a/app/assets/stylesheets/sumofus/components/petition.scss
+++ b/app/assets/stylesheets/sumofus/components/petition.scss
@@ -171,7 +171,7 @@
       padding: 20px 8%;
       height: 60px;
       width: 92%;
-      z-index: 1100;
+      z-index: 300;
 
       text-align: center;
       background-color: $overcast-gray;

--- a/app/assets/stylesheets/sumofus/components/photos.scss
+++ b/app/assets/stylesheets/sumofus/components/photos.scss
@@ -29,8 +29,14 @@
     width: 100%;
   }
   &__title {
-    @media(max-width: $mobile-width) {
+    @media(max-width: 900px) {
+      font-size: 36px;
+    }
+    @media(max-width: 700px) {
       font-size: 32px;
+    }
+    @media(max-width: 500px) {
+      font-size: 27px;
     }
   }
   &__target {

--- a/app/assets/stylesheets/sumofus/pages/page.scss
+++ b/app/assets/stylesheets/sumofus/pages/page.scss
@@ -1,6 +1,13 @@
 .main-feature {
   padding: 55px 0;
   min-height: 380px;
+  &--close-top {
+    padding-top: 30px;
+  }
+}
+
+.imageless-title {
+  margin-top: 30px;
 }
 
 .page-link {

--- a/app/assets/stylesheets/sumofus/pages/page.scss
+++ b/app/assets/stylesheets/sumofus/pages/page.scss
@@ -28,3 +28,20 @@
 .noscript-notice {
   line-height: 1.3em;
 }
+
+.iframe-responsive-container {
+
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 35px;
+  height: 0;
+  overflow: hidden;
+
+  iframe {
+    position: absolute;
+    top:0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/app/controllers/liquid_layouts_controller.rb
+++ b/app/controllers/liquid_layouts_controller.rb
@@ -24,7 +24,7 @@ class LiquidLayoutsController < ApplicationController
 
     respond_to do |format|
       if @liquid_layout.save
-        format.html { redirect_to @liquid_layout, notice: 'Liquid layout was successfully created.' }
+        format.html { redirect_to edit_liquid_layout_path(@liquid_layout), notice: 'Liquid layout was successfully created.' }
         format.json { render :show, status: :created, location: @liquid_layout }
       else
         format.html { render :new }

--- a/app/liquid/views/layouts/petition-without-image.liquid
+++ b/app/liquid/views/layouts/petition-without-image.liquid
@@ -1,0 +1,31 @@
+{% comment %} Description: A petition without an image.{% endcomment %}
+{% comment %} Primary layout: true {% endcomment %}
+
+<div class="center-content center-content--accomodates-stuck-footer">
+  <div class="center-content__big-column">
+
+    <div class="imageless-title">
+      <div class="typography__highlight-wrapper">
+        <h1 class="typography__highlight">
+          <span>{{ title }}</span>
+        </h1>
+      </div>
+    </div>
+
+    <div class="body-text main-feature main-feature--close-top">
+      {{ content }}
+
+      {% unless link_list == blank %}
+        <hr class="stubby-hr" />
+        <h3>{{ 'page.more_info' | t }}</h3>
+        {% include 'Links' %}
+      {% endunless %}
+    </div>
+  </div>
+  <div class="center-content__fixed-right center-content--push-down">
+    {% include 'Petition', extra_class: 'stuck-right' %}
+  </div>
+</div>
+
+{% include 'Petition Mobile Footer' %}
+{% include 'Small Image Footer' %}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    title Champaign
+    title= content_for?(:title) ? content_for(:title) : 'Champaign'
     meta name="viewport" content="width=device-width, initial-scale=1.0"
 
     = stylesheet_link_tag    "application", media: 'all'

--- a/app/views/liquid_layouts/index.html.slim
+++ b/app/views/liquid_layouts/index.html.slim
@@ -1,3 +1,5 @@
+- content_for(:title, "Templates")
+
 = render 'shared/sidebar', action: :index, resource: :liquid_layouts
 
 .edit-block

--- a/app/views/pages/analytics.slim
+++ b/app/views/pages/analytics.slim
@@ -1,3 +1,6 @@
+- content_for(:title, "Analyze | #{@page.title}")
+
+
 = stylesheet_link_tag "analytics/application", media: 'all'
 
 = render "sidebar", action: :analytics, id: @page.id

--- a/app/views/pages/edit.slim
+++ b/app/views/pages/edit.slim
@@ -1,3 +1,5 @@
+- content_for(:title, @page.title)
+
 = render 'edit_sidebar', page: @page
 - low_priority_plugins = [Plugins::Thermometer]
 

--- a/app/views/pages/index.slim
+++ b/app/views/pages/index.slim
@@ -1,3 +1,4 @@
+- content_for(:title, t('.title'))
 = render "pages/sidebar", action: :index
 
 .edit-block

--- a/app/views/pages/new.slim
+++ b/app/views/pages/new.slim
@@ -1,3 +1,5 @@
+- content_for(:title, t('.title'))
+
 = render "pages/sidebar", action: :new
 
 .edit-block

--- a/spec/controllers/liquid_layouts_controller_spec.rb
+++ b/spec/controllers/liquid_layouts_controller_spec.rb
@@ -84,9 +84,9 @@ describe LiquidLayoutsController do
         expect(assigns(:liquid_layout)).to be_persisted
       end
 
-      it "redirects to the created liquid_layout" do
+      it "redirects to the edit page for the created liquid_layout" do
         post :create, {:liquid_layout => valid_attributes}
-        expect(response).to redirect_to(LiquidLayout.last)
+        expect(response).to redirect_to(edit_liquid_layout_path(LiquidLayout.last))
       end
     end
 


### PR DESCRIPTION
This PR adds a SOU template for pages without a cover image. Ideal for page with a video as the feature or maybe like what Angus wanted with a portrait inline. Most of the actual coding was to ensure that embedded YouTube iframes properly size themselves when the page is skinnier, such as on mobile.

<img width="1236" alt="screenshot 2016-04-21 15 37 47" src="https://cloud.githubusercontent.com/assets/102218/14725067/079c7f0c-07d7-11e6-8fb0-c15c4aeeaf84.png">
