### PR TITLE
fix bug where user agent headers caused encoding error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,15 +49,14 @@ class ApplicationController < ActionController::Base
 
   def mobile_value
     device = MobileDetect.new({
-        HTTP_USER_AGENT: request.user_agent,
-        HTTP_ACCEPT: request.accept,
-        HTTP_ACCEPT_LANGUAGE: request.accept_language,
-        HTTP_ACCEPT_ENCODING: request.accept_encoding
-    }, request.user_agent)
+      HTTP_USER_AGENT:      request.user_agent.try(:force_encoding, 'utf-8'),
+      HTTP_ACCEPT:          request.accept.try(:force_encoding, 'utf-8'),
+      HTTP_ACCEPT_LANGUAGE: request.accept_language.try(:force_encoding, 'utf-8'),
+      HTTP_ACCEPT_ENCODING: request.accept_encoding.try(:force_encoding, 'utf-8')
+    }, request.user_agent.try(:force_encoding, 'utf-8'))
 
-    device_hash = {
-        mobile: nil
-    }
+    device_hash = {}
+
     if device.mobile?
       device_hash[:mobile] = 'mobile'
     elsif device.tablet?

--- a/spec/lib/payment_processor/currency_spec.rb
+++ b/spec/lib/payment_processor/currency_spec.rb
@@ -6,7 +6,7 @@ describe PaymentProcessor::Currency do
     VCR.use_cassette('money_google_bank') do
       expect(
         PaymentProcessor::Currency.convert(100, 'eur').format
-      ).to match( /€0\.\d\d/ )
+      ).to match( /€0[.,]\d\d/ )
     end
   end
 


### PR DESCRIPTION
The [mobile detection library](https://github.com/ktaragorn/mobile_detect) we're using forces utf-8 regexes, but some user agent strings are ASCII-8BIT and can't be transcoded. This adds a test case showing the bug which fails with the old code and passes with the new code.