### PR TITLE
Made share page titles smaller for mobile devices

### DIFF
--- a/app/assets/stylesheets/sumofus/pages/share.scss
+++ b/app/assets/stylesheets/sumofus/pages/share.scss
@@ -3,13 +3,22 @@
     font-size: 42px;
     font-weight: normal;
     margin: 20px 0 10px;
-  }
-  &__thanks {
+    
     @media(max-width: 450px) {
       font-size: 24px;
-      line-height: 32px;
-      font-weight: normal;
-      color: $slate-gray;
+      line-height: 28px;
+    }
+  }
+  &__thanks {
+
+    font-size: 24px;
+    line-height: 32px;
+    font-weight: normal;
+    color: $slate-gray;
+ 
+    @media(max-width: 450px) {
+      font-size: 12px;
+      line-height: 18px;
     }
   }
 }


### PR DESCRIPTION
This helps ensure share buttons aren't pushed down too far on mobile phone screens. (I don't have local dev setup yet, but these CSS tweaks look fine when done in my browser.)