### PR TITLE
ignore gemset and version files used by rvm and rbenv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ public/system
 config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
+
+.ruby-gemset
+.ruby-version


### PR DESCRIPTION
lets developers use these tools easily. 