### PR TITLE
2016 copyright, not 2015

### DIFF
--- a/app/liquid/views/partials/_small_image_footer.liquid
+++ b/app/liquid/views/partials/_small_image_footer.liquid
@@ -12,7 +12,7 @@
         <a href="http://sumofus.org/contact" class="simple-footer__link">{{ 'footer.contact' | t }}</a>
       </div>
       <div class="simple-footer__license simple-footer__license--left">
-        &copy; 2015 SumOfUs, {{ 'branding.license' | t }}
+        &copy; 2016 SumOfUs, {{ 'branding.license' | t }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
The page-with-small-image footer copyright should be 2016, not 2015.