### PR TITLE
make Member -> GC Customer has_many

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,6 +1,6 @@
 class Member < ActiveRecord::Base
   has_one :customer, class_name: "Payment::BraintreeCustomer"
-  has_one :go_cardless_customer, class_name: "Payment::GoCardless::Customer"
+  has_many :go_cardless_customers, class_name: "Payment::GoCardless::Customer"
   has_paper_trail on: [:update, :destroy]
 
   validates :email, uniqueness: true, allow_nil: true

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -116,15 +116,12 @@ describe Member do
 
     it 'can have one go_cardless_customer' do
       customer = create :payment_go_cardless_customer, member_id: member.id
-      expect(member.reload.go_cardless_customers.to_a).to eq [customer]
+      expect(member.reload.go_cardless_customers).to match_array [customer]
     end
 
     it 'can have several go_cardless_customers' do
-      customers = []
-      3.times do
-        customers << create(:payment_go_cardless_customer, member_id: member.id)
-      end
-      expect(member.reload.go_cardless_customers.to_a).to match_array customers
+      customers = 3.times.map { create(:payment_go_cardless_customer, member_id: member.id) }
+      expect(member.reload.go_cardless_customers).to match_array customers
     end
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -109,4 +109,22 @@ describe Member do
       expect(m.liquid_data[:welcome_name]).to eq 'me@sexualintellectual.com'
     end
   end
+
+  describe 'go_cardless_customer' do
+
+    let(:member){ create :member }
+
+    it 'can have one go_cardless_customer' do
+      customer = create :payment_go_cardless_customer, member_id: member.id
+      expect(member.reload.go_cardless_customers.to_a).to eq [customer]
+    end
+
+    it 'can have several go_cardless_customers' do
+      customers = []
+      3.times do
+        customers << create(:payment_go_cardless_customer, member_id: member.id)
+      end
+      expect(member.reload.go_cardless_customers.to_a).to match_array customers
+    end
+  end
 end

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -307,6 +307,15 @@ describe "GoCardless API" do
             expect(member.country).to eq "US"
             expect(member.postal).to eq "11225"
           end
+
+          it 'adds the first Customer to the Member' do
+            expect{ subject }.to change{ member.reload.go_cardless_customers.size }.from(0).to(1)
+          end
+
+          it 'can add a second Customer to the Member' do
+            create :payment_go_cardless_customer, member_id: member.id
+            expect{ subject }.to change{ member.go_cardless_customers.size }.from(1).to(2)
+          end
         end
 
         describe 'when Member is new' do
@@ -320,6 +329,11 @@ describe "GoCardless API" do
             member = Member.last
             expect(member.country).to eq "US"
             expect(member.postal).to eq "11225"
+          end
+
+          it "associates the Member with a Customer" do
+            expect{ subject }.to change{ Payment::GoCardless::Customer.count }.by 1
+            expect(Payment::GoCardless::Customer.last.member_id).to eq Member.last.id
           end
         end
       end
@@ -363,7 +377,6 @@ describe "GoCardless API" do
             }
           }
         end
-
 
         subject do
           VCR.use_cassette('go_cardless successful subscription') do
@@ -420,6 +433,15 @@ describe "GoCardless API" do
             expect(member.country).to eq "US"
             expect(member.postal).to eq "11225"
           end
+
+          it 'adds the first customer to the member' do
+            expect{ subject }.to change{ member.reload.go_cardless_customers.size }.from(0).to(1)
+          end
+
+          it 'can add a second customer to the member' do
+            create :payment_go_cardless_customer, member_id: member.id
+            expect{ subject }.to change{ member.go_cardless_customers.size }.from(1).to(2)
+          end
         end
 
         describe 'when Member is new' do
@@ -433,6 +455,11 @@ describe "GoCardless API" do
             member = Member.last
             expect(member.country).to eq "US"
             expect(member.postal).to eq "11225"
+          end
+
+          it "associates the Member with a Customer" do
+            expect{ subject }.to change{ Payment::GoCardless::Customer.count }.by 1
+            expect(Payment::GoCardless::Customer.last.member_id).to eq Member.last.id
           end
         end
       end


### PR DESCRIPTION
Per the email from GoCardless, we should expect GC to make a bunch of Customers for the same member. I want to add a quick request spec to this too.