### PR TITLE
track direct debit events

### DIFF
--- a/app/assets/javascripts/sumofus.js
+++ b/app/assets/javascripts/sumofus.js
@@ -14,6 +14,7 @@
 //= require_directory ./plugins
 
 require("sumofus/scroll");
+require("sumofus/ga_event_reporting");
 window.sumofus = {};
 window.sumofus.PetitionBar = require('sumofus/backbone/petition_bar');
 window.sumofus.FundraiserBar = require('sumofus/backbone/fundraiser_bar');

--- a/app/assets/javascripts/sumofus/ga_event_reporting.js
+++ b/app/assets/javascripts/sumofus/ga_event_reporting.js
@@ -1,0 +1,16 @@
+(function(){
+  const EVENTS_TO_REPORT = [
+    "direct_debit:opened",
+    "direct_debit:donated_via_other",
+    "direct_debit:donated",
+  ];
+
+  $.subscribe(EVENTS_TO_REPORT.join(' '), function(ev){
+    let splitted = ev.type.split(':');
+    let eventCategory = (splitted.length > 1) ? splitted[0] : 'generic';
+    let eventAction =   (splitted.length > 1) ? splitted[1] : splitted[0];
+    if(typeof window.ga === 'function') {
+      window.ga('send', 'event', eventCategory, eventAction);
+    }
+  });
+})();


### PR DESCRIPTION
This will let us tell how many donors are falling off after opening the direct debit flow. I triple-checked that its using the ga API properly, but haven't been able to see events show up, presumably from URL filtering.