### PR TITLE
fix up bookkeeping on gocardless

### DIFF
--- a/app/models/payment/go_cardless.rb
+++ b/app/models/payment/go_cardless.rb
@@ -16,15 +16,17 @@ module Payment::GoCardless
       local_mandate
     end
 
-    def write_transaction(transaction_gc_id, amount, currency, page_id, subscription = nil)
+    def write_transaction(transaction_gc_id, amount, currency, charge_date, page_id, customer_id, payment_method_id, subscription=nil)
       local_transaction = Payment::GoCardless::Transaction.find_or_initialize_by(go_cardless_id: transaction_gc_id)
-      local_transaction.update_attributes(amount: amount, currency: currency, page_id: page_id, subscription: subscription)
+      local_transaction.update_attributes(amount: amount, currency: currency, page_id: page_id, subscription: subscription,
+        charge_date: charge_date, customer_id: customer_id, payment_method_id: payment_method_id)
       local_transaction
     end
 
-    def write_subscription(subscription_gc_id, amount, currency, page_id)
+    def write_subscription(subscription_gc_id, amount, currency, page_id, action_id, customer_id, payment_method_id)
       local_subscription = Payment::GoCardless::Subscription.find_or_initialize_by(go_cardless_id: subscription_gc_id)
-      local_subscription.update_attributes(amount: amount, currency: currency, page_id: page_id)
+      local_subscription.update_attributes(amount: amount, currency: currency, page_id: page_id,
+              action_id: action_id, customer_id: customer_id, payment_method_id: payment_method_id)
       local_subscription
     end
   end

--- a/app/models/payment/go_cardless.rb
+++ b/app/models/payment/go_cardless.rb
@@ -16,10 +16,20 @@ module Payment::GoCardless
       local_mandate
     end
 
-    def write_transaction(transaction_gc_id, amount, currency, charge_date, page_id, customer_id, payment_method_id, subscription=nil)
-      local_transaction = Payment::GoCardless::Transaction.find_or_initialize_by(go_cardless_id: transaction_gc_id)
-      local_transaction.update_attributes(amount: amount, currency: currency, page_id: page_id, subscription: subscription,
-        charge_date: charge_date, customer_id: customer_id, payment_method_id: payment_method_id)
+    #def write_transaction(transaction_gc_id, amount, currency, charge_date, page_id, customer_id, payment_method_id, subscription=nil)
+    def write_transaction(uuid:, amount:, currency:, charge_date:, page_id:, customer_id:, payment_method_id:, subscription: nil)
+
+      local_transaction = Payment::GoCardless::Transaction.find_or_initialize_by(go_cardless_id: uuid)
+
+      local_transaction.update(
+        amount: amount,
+        currency: currency,
+        page_id: page_id,
+        subscription: subscription,
+        charge_date: charge_date,
+        customer_id: customer_id,
+        payment_method_id: payment_method_id
+      )
       local_transaction
     end
 

--- a/app/models/payment/go_cardless/subscription.rb
+++ b/app/models/payment/go_cardless/subscription.rb
@@ -10,8 +10,17 @@ class Payment::GoCardless::Subscription < ActiveRecord::Base
     end
 
     def call
-      Payment::GoCardless.write_transaction(event['links']['payment'], amount, currency,
-        event['created_at'], page_id, customer_id, payment_method_id, subscription)
+      Payment::GoCardless.write_transaction(
+        uuid: event['links']['payment'],
+        amount: amount,
+        currency: currency,
+        charge_date: event['created_at'],
+        page_id: page_id,
+        customer_id: customer_id,
+        payment_method_id: payment_method_id,
+        subscription: subscription
+      )
+
       ChampaignQueue.push(
         type: 'subscription-payment',
         params: {

--- a/app/models/payment/go_cardless/subscription.rb
+++ b/app/models/payment/go_cardless/subscription.rb
@@ -2,7 +2,7 @@ class Payment::GoCardless::Subscription < ActiveRecord::Base
   class Charge
     attr_reader :subscription, :event
 
-    delegate :page, :amount, :currency, to: :subscription
+    delegate :page_id, :amount, :currency, :payment_method_id, :customer_id, to: :subscription
 
     def initialize(subscription, event = {})
       @event = event
@@ -10,8 +10,8 @@ class Payment::GoCardless::Subscription < ActiveRecord::Base
     end
 
     def call
-      Payment::GoCardless.write_transaction(event['links']['payment'], amount, currency, page.id, subscription)
-
+      Payment::GoCardless.write_transaction(event['links']['payment'], amount, currency,
+        event['created_at'], page_id, customer_id, payment_method_id, subscription)
       ChampaignQueue.push(
         type: 'subscription-payment',
         params: {

--- a/lib/payment_processor/go_cardless/transaction.rb
+++ b/lib/payment_processor/go_cardless/transaction.rb
@@ -43,8 +43,16 @@ module PaymentProcessor
         @action = ManageDonation.create(params: action_params)
         @local_customer = Payment::GoCardless.write_customer(customer_id, @action.member_id)
         @local_mandate = Payment::GoCardless.write_mandate(mandate.id, mandate.scheme, mandate.next_possible_charge_date, @local_customer.id)
-        @local_transaction = Payment::GoCardless.write_transaction(@transaction.id, amount_in_whole_currency, 
-          currency, @transaction.charge_date, @page_id, @local_customer.id, @local_mandate.id)
+
+        @local_transaction = Payment::GoCardless.write_transaction(
+          uuid: @transaction.id,
+          amount: amount_in_whole_currency,
+          currency: currency,
+          charge_date: @transaction.charge_date,
+          page_id: @page_id,
+          customer_id: @local_customer.id,
+          payment_method_id: @local_mandate.id
+        )
       rescue GoCardlessPro::Error => e
         @error = e
       end

--- a/lib/payment_processor/go_cardless/transaction.rb
+++ b/lib/payment_processor/go_cardless/transaction.rb
@@ -38,18 +38,19 @@ module PaymentProcessor
       end
 
       def transact
-        transaction = client.payments.create(params: transaction_params)
+        @transaction = client.payments.create(params: transaction_params)
 
-        @local_transaction = Payment::GoCardless.write_transaction(transaction.id, amount_in_whole_currency, currency, @page_id)
         @action = ManageDonation.create(params: action_params)
         @local_customer = Payment::GoCardless.write_customer(customer_id, @action.member_id)
         @local_mandate = Payment::GoCardless.write_mandate(mandate.id, mandate.scheme, mandate.next_possible_charge_date, @local_customer.id)
+        @local_transaction = Payment::GoCardless.write_transaction(@transaction.id, amount_in_whole_currency, 
+          currency, @transaction.charge_date, @page_id, @local_customer.id, @local_mandate.id)
       rescue GoCardlessPro::Error => e
         @error = e
       end
 
       def transaction_id
-        @local_transaction.try(:go_cardless_id)
+        @transaction.try(:id)
       end
 
       private

--- a/spec/lib/payment_processor/go_cardless/subscription_spec.rb
+++ b/spec/lib/payment_processor/go_cardless/subscription_spec.rb
@@ -20,10 +20,10 @@ module PaymentProcessor
           allow(ManageDonation).to receive(:create){ action }
         end
 
-        let(:action) { instance_double('Action', member_id: 2) }
-        let(:local_subscription) { instance_double('Payment::GoCardless::Subscription', go_cardless_id: 'SU00000') }
+        let(:action) { instance_double('Action', member_id: 2, id: 1234) }
+        let(:local_subscription) { instance_double('Payment::GoCardless::Subscription', go_cardless_id: 'SU00000', id: 567) }
         let(:local_customer) { instance_double('Payment::GoCardless::Customer', id: 7) }
-        let(:local_mandate) { instance_double('Payment::GoCardless::PaymentMethod') }
+        let(:local_mandate) { instance_double('Payment::GoCardless::PaymentMethod', id: 543) }
 
         let(:gc_error) { GoCardlessPro::ValidationError.new('invalid') }
 
@@ -78,7 +78,7 @@ module PaymentProcessor
         describe 'bookkeeping' do
           it 'delegates to Payment::GoCardless.write_subscription' do
             expect(Payment::GoCardless).to receive(:write_subscription).with(
-              local_subscription.go_cardless_id, amount_in_euros, 'EUR', page_id)
+              local_subscription.go_cardless_id, amount_in_euros, 'EUR', page_id, action.id, local_customer.id, local_mandate.id)
             subject
           end
 

--- a/spec/lib/payment_processor/go_cardless/transaction_spec.rb
+++ b/spec/lib/payment_processor/go_cardless/transaction_spec.rb
@@ -172,7 +172,15 @@ your GBP charge date is invalid! Resorting to the mandate's next possible charge
         describe 'bookkeeping' do
           it 'delegates to Payment::GoCardless.write_transaction' do
             expect(Payment::GoCardless).to receive(:write_transaction).with(
-              local_transaction.go_cardless_id, amount_in_euros, 'EUR', payment.charge_date, page_id, local_customer.id, local_mandate.id)
+              uuid: local_transaction.go_cardless_id,
+              amount: amount_in_euros,
+              currency: 'EUR',
+              charge_date: payment.charge_date,
+              page_id: page_id,
+              customer_id: local_customer.id,
+              payment_method_id: local_mandate.id
+            )
+
             subject
           end
 

--- a/spec/lib/payment_processor/go_cardless/transaction_spec.rb
+++ b/spec/lib/payment_processor/go_cardless/transaction_spec.rb
@@ -23,12 +23,12 @@ module PaymentProcessor
         let(:action) { instance_double('Action', member_id: 2) }
         let(:local_transaction) { instance_double('Payment::GoCardless::Transaction', go_cardless_id: 'PA00000') }
         let(:local_customer) { instance_double('Payment::GoCardless::Customer', id: 7) }
-        let(:local_mandate) { instance_double('Payment::GoCardless::PaymentMethod') }
+        let(:local_mandate) { instance_double('Payment::GoCardless::PaymentMethod', id: 1234) }
 
         let(:gc_error) { GoCardlessPro::ValidationError.new('invalid') }
 
         let(:completed_flow) do
-          instance_double('GoCardlessPro::Resources::RedirectFlow', 
+          instance_double('GoCardlessPro::Resources::RedirectFlow',
                           links: double(customer: 'CU00000', mandate: 'MA00000')
                          )
         end
@@ -38,7 +38,7 @@ module PaymentProcessor
                          )
         end
 
-        let(:payment) { instance_double('GoCardlessPro::Resources::Payment', id: 'PA00000') }
+        let(:payment) { instance_double('GoCardlessPro::Resources::Payment', id: 'PA00000', charge_date: '2016-05-20') }
 
         let(:amount_in_dollars){ 12.5 }
         let(:amount_in_euros){ 10.98 }
@@ -172,7 +172,7 @@ your GBP charge date is invalid! Resorting to the mandate's next possible charge
         describe 'bookkeeping' do
           it 'delegates to Payment::GoCardless.write_transaction' do
             expect(Payment::GoCardless).to receive(:write_transaction).with(
-              local_transaction.go_cardless_id, amount_in_euros, 'EUR', page_id)
+              local_transaction.go_cardless_id, amount_in_euros, 'EUR', payment.charge_date, page_id, local_customer.id, local_mandate.id)
             subject
           end
 

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe "GoCardless API" do
   let(:page) { create :page }
-
   let(:usd_amount) { 9.99 }
   let(:gbp_amount) { 11.55 }
 
@@ -20,11 +19,9 @@ describe "GoCardless API" do
   end
 
   describe "redirect flow" do
-
     let(:page) { create :page, slug: 'implement-synergistic-cooperation', id: 1 }
 
     describe 'successful' do
-
       before :each do
         allow(SecureRandom).to receive(:uuid).and_return('the-session-id')
       end
@@ -54,13 +51,13 @@ describe "GoCardless API" do
 
       it 'passes the description to go_cardless' do
         subject
-        expect(assigns(:flow).redirect_flow_instance.description).to match /You are donating €3.00 to SumOfUs/
+        expect(assigns(:flow).redirect_flow_instance.description).to match(/You are donating €3.00 to SumOfUs/)
       end
 
       it "redirects to a page hosted on GoCardless" do
         subject
         expect(response.status).to be 302
-        expect(response.body).to match /You are being <a href=\"https:\/\/pay-sandbox.gocardless.com\/flow\/RE[0-9A-Z]+\">redirected<\/a>/
+        expect(response.body).to match(/You are being <a href=\"https:\/\/pay-sandbox.gocardless.com\/flow\/RE[0-9A-Z]+\">redirected<\/a>/)
       end
     end
 
@@ -159,7 +156,7 @@ describe "GoCardless API" do
 
       shared_examples 'donation action' do
         it 'creates a PaymentMethod record with relevant data and associations' do
-          expect{ subject }.to change{ Payment::GoCardless::PaymentMethod.count }.by 1
+          expect{ subject }.to change{ Payment::GoCardless::PaymentMethod.count }.by(1)
           mandate = Payment::GoCardless::PaymentMethod.last
           expect(mandate.go_cardless_id).to eq mandate_id
           expect(mandate.scheme).to eq 'bacs'
@@ -190,7 +187,7 @@ describe "GoCardless API" do
         end
 
         it 'increments action count on Page' do
-          expect{ subject }.to change{ page.reload.action_count }.by 1
+          expect{ subject }.to change{ page.reload.action_count }.by(1)
         end
 
         it "redirects to the page's follow-up path" do
@@ -199,7 +196,7 @@ describe "GoCardless API" do
         end
 
         it "creates a Customer record with relevant data and associations" do
-          expect{ subject }.to change{ Payment::GoCardless::Customer.count }.by 1
+          expect{ subject }.to change{ Payment::GoCardless::Customer.count }.by(1)
           customer = Payment::GoCardless::Customer.last
           expect(customer.go_cardless_id).to eq customer_id
           expect(customer.member).not_to be_blank
@@ -260,10 +257,10 @@ describe "GoCardless API" do
                 amount: (gbp_amount * 100).to_i,
                 currency: 'GBP',
                 links: {
-                    mandate: mandate_id # a_string_matching(/\AMD[0-9A-Z]+\z/)
+                  mandate: mandate_id # a_string_matching(/\AMD[0-9A-Z]+\z/)
                 },
                 metadata: {
-                    customer_id: customer_id # a_string_matching(/\ACU[0-9A-Z]+\z/)
+                  customer_id: customer_id # a_string_matching(/\ACU[0-9A-Z]+\z/)
                 },
                 charge_date: "2016-05-20"
               }
@@ -341,14 +338,14 @@ describe "GoCardless API" do
           include_examples 'donation action'
 
           it "populates the Member’s fields with form data" do
-            expect{ subject }.to change{ Member.count }.by 1
+            expect{ subject }.to change{ Member.count }.by(1)
             member = Member.last
             expect(member.country).to eq "US"
             expect(member.postal).to eq "11225"
           end
 
           it "associates the Member with a Customer" do
-            expect{ subject }.to change{ Payment::GoCardless::Customer.count }.by 1
+            expect{ subject }.to change{ Payment::GoCardless::Customer.count }.by(1)
             expect(Payment::GoCardless::Customer.last.member_id).to eq Member.last.id
           end
         end
@@ -420,9 +417,9 @@ describe "GoCardless API" do
           end
 
           it 'stores amount, currency, is_subscription, and subscription_id in form_data on the Action' do
-            expect{ subject }.to change{ Action.count }.by 1
+            expect{ subject }.to change{ Action.count }.by(1)
             form_data = Action.last.form_data
-            expect(form_data['is_subscription']).to eq true
+            expect(form_data['is_subscription']).to be true
             expect(form_data['amount']).to eq gbp_amount.to_s
             expect(form_data['currency']).to eq 'GBP'
             expect(form_data['subscription_id']).to eq Payment::GoCardless::Subscription.last.go_cardless_id
@@ -434,14 +431,14 @@ describe "GoCardless API" do
           end
 
           it 'creates a Subscription record with associations and data' do
-            expect{ subject }.to change{ Payment::GoCardless::Subscription.count }.by 1
+            expect{ subject }.to change{ Payment::GoCardless::Subscription.count }.by(1)
             subscription = Payment::GoCardless::Subscription.last
             expect(subscription.go_cardless_id).to match(subscription_id_regexp)
             expect(subscription.currency).to eq 'GBP'
             expect(subscription.amount).to eq gbp_amount
             expect(subscription.page).to eq page
-            expect(subscription.payment_method).not_to be_blank
-            expect(subscription.customer).not_to be_blank
+            expect(subscription.payment_method).to be_a Payment::GoCardless::PaymentMethod
+            expect(subscription.customer).to be_a Payment::GoCardless::Customer
             expect(subscription.action).to eq Action.last
             expect(subscription.aasm_state).to eq "pending"
           end
@@ -487,7 +484,7 @@ describe "GoCardless API" do
           end
 
           it "associates the Member with a Customer" do
-            expect{ subject }.to change{ Payment::GoCardless::Customer.count }.by 1
+            expect{ subject }.to change{ Payment::GoCardless::Customer.count }.by(1)
             expect(Payment::GoCardless::Customer.last.member_id).to eq Member.last.id
           end
         end
@@ -650,7 +647,5 @@ describe "GoCardless API" do
         include_examples 'displays bad request errors'
       end
     end
-
   end
-
 end

--- a/spec/requests/api/go_cardless/webhooks_spec.rb
+++ b/spec/requests/api/go_cardless/webhooks_spec.rb
@@ -51,7 +51,11 @@ describe "subscriptions" do
           ).to include({
             go_cardless_id: 'payment_ID_123',
             page_id: page.id,
-            amount: 100
+            amount: 100,
+            charge_date: Date.new(2016, 4, 20),
+            customer_id: subscription.customer_id,
+            payment_method_id: subscription.payment_method_id,
+            subscription_id: subscription.id
           })
         end
 


### PR DESCRIPTION
We were failing to store some important associations on GoCardless records. This fixes it and updates the spec to ensure that we are.