### PR TITLE
Mobile header

### DIFF
--- a/app/assets/stylesheets/sumofus/components/petition.scss
+++ b/app/assets/stylesheets/sumofus/components/petition.scss
@@ -159,7 +159,7 @@
 
   &__mobile-ui {
 
-    @media(min-width: $mobile-width) {
+    @media(min-width: $mobile-width + 1) {
       display: none;
     }
 

--- a/app/assets/stylesheets/sumofus/components/photos.scss
+++ b/app/assets/stylesheets/sumofus/components/photos.scss
@@ -51,6 +51,25 @@
     @include background-size(cover);
     background-position: center;
   }
+  &__titles {
+    @media(max-width: $mobile-width) {
+      display: none;
+    }
+  }
+  @media(max-width: $mobile-width) {
+    height: 220px;
+  }
+}
+.mobile-title {
+  @media(min-width: $mobile-width + 1) {
+    display: none;
+  }
+  padding: 20px 0;
+  background: $teal;
+  color: white;
+  h1 {
+    line-height: 1.1em;
+  }
 }
 
 .cover-photo--small, .header-logo__left-constraint {

--- a/app/assets/stylesheets/sumofus/components/photos.scss
+++ b/app/assets/stylesheets/sumofus/components/photos.scss
@@ -29,14 +29,15 @@
     width: 100%;
   }
   &__title {
+    font-size: 36px;
     @media(max-width: 900px) {
-      font-size: 36px;
+      font-size: 34px;
     }
     @media(max-width: 700px) {
-      font-size: 32px;
+      font-size: 30px;
     }
     @media(max-width: 500px) {
-      font-size: 27px;
+      font-size: 25px;
     }
   }
   &__target {
@@ -44,12 +45,16 @@
       display: none;
     }
   }
+  $cover-photo-mobile-height: 220px;
   &--small {
     height: 390px;
     overflow: hidden;
     position: relative;
     @include background-size(cover);
     background-position: center;
+    @media(max-width: $mobile-width) {
+      height: $cover-photo-mobile-height;
+    }
   }
   &__titles {
     @media(max-width: $mobile-width) {
@@ -57,7 +62,7 @@
     }
   }
   @media(max-width: $mobile-width) {
-    height: 220px;
+    height: $cover-photo-mobile-height;
   }
 }
 .mobile-title {
@@ -67,6 +72,7 @@
   padding: 20px 0;
   background: $teal;
   color: white;
+  float: left;
   h1 {
     line-height: 1.1em;
   }

--- a/app/assets/stylesheets/sumofus/pages/page.scss
+++ b/app/assets/stylesheets/sumofus/pages/page.scss
@@ -1,5 +1,5 @@
 .main-feature {
-  padding: 55px 0;
+  padding: 15px 0;
   min-height: 380px;
   &--close-top {
     padding-top: 30px;

--- a/app/liquid/views/layouts/fundraiser-with-small-image.liquid
+++ b/app/liquid/views/layouts/fundraiser-with-small-image.liquid
@@ -1,25 +1,4 @@
 {% comment %} Description: The fundraiser page with a small cover photo. {% endcomment %}
 {% comment %} Primary layout: true {% endcomment %}
 
-{% include 'Small Header' %}
-
-<div class="center-content center-content--accomodates-stuck-footer">
-  <div class="center-content__big-column">
-
-    <div class="body-text main-feature">
-      {{ content }}
-
-      {% unless link_list == blank %}
-        <hr class="stubby-hr" />
-        <h3>{{ 'page.more_info' | t }}</h3>
-        {% include 'Links' %}
-      {% endunless %}
-    </div>
-  </div>
-  <div class="center-content__fixed-right">
-    {% include 'Fundraiser', extra_class: 'stuck-right' %}
-  </div>
-</div>
-
-{% include 'Fundraiser Mobile Footer' %}
-{% include 'Small Image Footer' %}
+{% include 'Fundraiser With Small Image' %}

--- a/app/liquid/views/layouts/fundraiser-with-title-below-image.liquid
+++ b/app/liquid/views/layouts/fundraiser-with-title-below-image.liquid
@@ -1,0 +1,13 @@
+{% comment %} Description: The fundraiser page a title below a small cover photo. {% endcomment %}
+{% comment %} Primary layout: true {% endcomment %}
+
+{% include 'Fundraiser With Small Image' %}
+
+<style type="text/css">
+  .cover-photo__overlay {
+    display: none;
+  }
+  .mobile-title {
+    display: block !important;
+  }
+</style>

--- a/app/liquid/views/layouts/petition-with-title-below-image.liquid
+++ b/app/liquid/views/layouts/petition-with-title-below-image.liquid
@@ -2,3 +2,12 @@
 {% comment %} Primary layout: true {% endcomment %}
 
 {% include 'Petition With Small Image' %}
+
+<style type="text/css">
+  .cover-photo__overlay {
+    display: none;
+  }
+  .mobile-title {
+    display: block !important;
+  }
+</style>

--- a/app/liquid/views/partials/_full_width_header.liquid
+++ b/app/liquid/views/partials/_full_width_header.liquid
@@ -23,3 +23,5 @@
     </div>
   </div>
 </div>
+
+{% include 'Mobile Title' %}

--- a/app/liquid/views/partials/_fundraiser_with_small_image.liquid
+++ b/app/liquid/views/partials/_fundraiser_with_small_image.liquid
@@ -1,0 +1,22 @@
+{% include 'Small Header' %}
+
+<div class="center-content center-content--accomodates-stuck-footer">
+  <div class="center-content__big-column">
+
+    <div class="body-text main-feature">
+      {{ content }}
+
+      {% unless link_list == blank %}
+        <hr class="stubby-hr" />
+        <h3>{{ 'page.more_info' | t }}</h3>
+        {% include 'Links' %}
+      {% endunless %}
+    </div>
+  </div>
+  <div class="center-content__fixed-right">
+    {% include 'Fundraiser', extra_class: 'stuck-right' %}
+  </div>
+</div>
+
+{% include 'Fundraiser Mobile Footer' %}
+{% include 'Small Image Footer' %}

--- a/app/liquid/views/partials/_mobile_title.liquid
+++ b/app/liquid/views/partials/_mobile_title.liquid
@@ -1,0 +1,7 @@
+<div class="mobile-title">
+  <div class="center-content">
+    <div class="center-content__big-column">
+      <h1 class="cover-photo__title">{{ title }}</h1>
+    </div>
+  </div>
+</div>

--- a/app/liquid/views/partials/_petition_with_small_image.liquid
+++ b/app/liquid/views/partials/_petition_with_small_image.liquid
@@ -1,0 +1,25 @@
+{% include 'Small Header' %}
+
+<div class="center-content center-content--accomodates-stuck-footer">
+  <div class="center-content__big-column">
+    <div class="mobile-show pre-main-bar">
+      {% include 'Thermometer' %}
+    </div>
+
+    <div class="body-text main-feature">
+      {{ content }}
+
+      {% unless link_list == blank %}
+        <hr class="stubby-hr" />
+        <h3>{{ 'page.more_info' | t }}</h3>
+        {% include 'Links' %}
+      {% endunless %}
+    </div>
+  </div>
+  <div class="center-content__fixed-right center-content--push-down">
+    {% include 'Petition', extra_class: 'stuck-right' %}
+  </div>
+</div>
+
+{% include 'Petition Mobile Footer' %}
+{% include 'Small Image Footer' %}

--- a/app/liquid/views/partials/_small_header.liquid
+++ b/app/liquid/views/partials/_small_header.liquid
@@ -23,3 +23,5 @@
     </div>
   </div>
 </div>
+
+{% include 'Mobile Title' %}


### PR DESCRIPTION
<img width="337" alt="screenshot 2016-06-07 11 47 57" src="https://cloud.githubusercontent.com/assets/102218/15868587/b6de075e-2ca5-11e6-966b-25ac772df887.png">

Angus requested that we stop displaying the title over the image on mobile. This implements that change, as well as allowing campaigners to choose that display for desktop for images when its important to see the whole image.