### PR TITLE
Wrap in fields hash

### DIFF
--- a/app/services/action_queue.rb
+++ b/app/services/action_queue.rb
@@ -49,15 +49,6 @@ module ActionQueue
     def data
       @action.form_data.symbolize_keys
     end
-
-    def extra_fields_for_subscription
-      {}.tap do |action|
-        if @action.form_data['is_subscription']
-          action[:skip_confirmation] = 1 if @action.form_data['recurrence_number'].to_i > 0
-          action[:fields] = action_fields
-        end
-      end
-    end
   end
 
   class Pusher
@@ -153,9 +144,11 @@ module ActionQueue
 
     def action_data
       {
-        action_account_number_ending: data[:account_number_ending],
-        action_mandate_reference: data[:mandate_reference],
-        action_bank_name: data[:bank_name],
+        fields: {
+          account_number_ending:  data[:account_number_ending],
+          mandate_reference:      data[:mandate_reference],
+          bank_name:              data[:bank_name]
+        },
         source: data[:source]
       }
     end
@@ -171,14 +164,6 @@ module ActionQueue
 
     def get_payment_account
       "GoCardless #{data[:currency]}"
-    end
-
-    def action_fields
-      {
-        recurring_id:      @action.member_id,
-        recurrence_number: @action.form_data['recurrence_number'],
-        payment_provider:  @action.form_data['payment_provider'],
-      }
     end
   end
 
@@ -247,14 +232,6 @@ module ActionQueue
 
     end
 
-    def action_fields
-      {
-        recurring_id:      @action.member_id,
-        recurrence_number: @action.form_data['recurrence_number'],
-        payment_provider:  @action.form_data['payment_provider'],
-        exp_date:          "#{expire_month}#{expire_year.to_s.gsub(/^(\d\d)(\d\d)/,'\2')}"
-      }
-    end
     # ActionKit can accept one of the following:
     #
     # PayPal USD


### PR DESCRIPTION
custom action fields need to be inside `fields: {}` - tested this here: https://act.sumofus.org/rest/v1/donationaction/69409296/

Specs are going to break.

We're not passing device data at all to any donation action, and it isn't trivial to do. Would need some thought on how we can do it elegantly. 