### PR TITLE
Disable csrf for actions api, since user is not signed in.

### DIFF
--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -1,10 +1,6 @@
 class Api::ActionsController < ApplicationController
   before_filter :localize_from_page_id
-
-  rescue_from ActionController::InvalidAuthenticityToken do |exception|
-    reset_session
-    raise
-  end
+  skip_before_action :verify_authenticity_token
 
   def create
     @action_params = action_params
@@ -45,4 +41,3 @@ class Api::ActionsController < ApplicationController
     Form.find(params[:form_id]).form_elements.map(&:name)
   end
 end
-

--- a/spec/controllers/api/actions_controller_spec.rb
+++ b/spec/controllers/api/actions_controller_spec.rb
@@ -21,7 +21,12 @@ describe Api::ActionsController do
 
     describe "successful" do
       before do
+        allow(controller).to receive(:verify_authenticity_token)
         post :create, { page_id: 2, form_id: 3, foo: 'bar' }
+      end
+
+      it 'does not verify authenticity token' do
+        expect(controller).not_to have_received(:verify_authenticity_token)
       end
 
       it "finds form" do


### PR DESCRIPTION
and we're getting lots of errors on this - it's our busiest endpoint. 