### PR TITLE
set action_count to 0 when cloning a page

### DIFF
--- a/app/services/page_cloner.rb
+++ b/app/services/page_cloner.rb
@@ -18,6 +18,7 @@ class PageCloner
       plugins
       tags
       images
+      actions
     end
   end
 
@@ -72,5 +73,9 @@ class PageCloner
         cloned_page.primary_image = new_image
       end
     end
+  end
+
+  def actions
+    cloned_page.action_count = 0
   end
 end

--- a/spec/services/page_cloner_spec.rb
+++ b/spec/services/page_cloner_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe PageCloner do
   let!(:tag)  { create(:tag) }
   let(:campaign) { create(:campaign) }
-  let(:page)  { create(:page, tags: [tag], campaign: campaign, title: 'foo bar') }
+  let(:page)  { create(:page, tags: [tag], campaign: campaign, title: 'foo bar', action_count: 12345) }
   let!(:link) { create(:link, page: page) }
 
   subject(:cloned_page) { PageCloner.clone(page) }
@@ -29,6 +29,15 @@ describe PageCloner do
 
   it 'associates with the same campaign' do
     expect(cloned_page.campaign).to eq(campaign)
+  end
+
+  it 'duplicates content' do
+    expect(cloned_page.content).to eq page.content
+  end
+
+  it 'sets the new pages action_count to 0' do
+    expect(page.action_count).not_to eq 0
+    expect(cloned_page.action_count).to eq 0
   end
 
   describe 'title and slug' do

--- a/spec/services/page_cloner_spec.rb
+++ b/spec/services/page_cloner_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe PageCloner do
   let!(:tag)  { create(:tag) }
   let(:campaign) { create(:campaign) }
-  let(:page)  { create(:page, tags: [tag], campaign: campaign, title: 'foo bar', action_count: 12345) }
+  let(:page)  { create(:page, tags: [tag], campaign: campaign, title: 'foo bar', content: 'Foo Bar', action_count: 12345) }
   let!(:link) { create(:link, page: page) }
 
   subject(:cloned_page) { PageCloner.clone(page) }
@@ -32,12 +32,12 @@ describe PageCloner do
   end
 
   it 'duplicates content' do
-    expect(cloned_page.content).to eq page.content
+    expect(cloned_page.content).to eq('Foo Bar')
   end
 
   it 'sets the new pages action_count to 0' do
-    expect(page.action_count).not_to eq 0
-    expect(cloned_page.action_count).to eq 0
+    expect(page.action_count).not_to eq(0)
+    expect(cloned_page.action_count).to eq(0)
   end
 
   describe 'title and slug' do


### PR DESCRIPTION
Sondya realized that our cloned pages cloned the action counts, and there's nothing the campaigner to do to bring that number back down. This PR fixes that.