### PR TITLE
Allow custom addition of google verification page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 Rails.application.routes.draw do
+
+  if Settings.google_verification
+    match "/#{Settings.google_verification}.html", to: proc { |env| [200, {}, ["google-site-verification: #{Settings.google_verification}.html"]] }, via: :get
+  end
+
   ActiveAdmin.routes(self)
-  # We remove the sign_up path name so as not to allow users to sign in with username and password.
-  devise_for :users, :controllers => { :omniauth_callbacks => "omniauth_callbacks" }, path_names: { sign_up: ''}
+
+  devise_for :users, controllers: { omniauth_callbacks: "omniauth_callbacks" }
 
   root to: 'home#index'
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -84,6 +84,10 @@ host: <%= ENV["CHAMPAIGN_PAGE_HOST"] %>
 # Google Analytics Tracking Code
 ga_tracking_code: <%= ENV['GA_TRACKING_CODE'] %>
 
+# Google Verification Page
+google_verification: <%= ENV['GOOGLE_VERIFICATION_CODE'] %>
+
+
 gocardless:
   token: <%= ENV['GOCARDLESS_TOKEN'] %>
   environment: <%= ENV['GOCARDLESS_ENVIRONMENT'] %>
@@ -91,3 +95,5 @@ gocardless:
   secret: <%= ENV['GOCARDLESS_SECRET'] %>
 
 home_page_url: <%= ENV['HOME_PAGE_URL'] %>
+
+


### PR DESCRIPTION
To get access to google insights for actions.sumofus.org we need to verify ownership of that domain. The common way of doing that is to upload a file to the site which google can then access. 

This PR allows any organisation deploying champaign to include a verification ID. Champaign will then generate the expected html file.