### PR TITLE
Fix tooltips on analytics page

### DIFF
--- a/app/assets/javascripts/tooltips.js
+++ b/app/assets/javascripts/tooltips.js
@@ -1,5 +1,5 @@
 (function(){
-  $.subscribe("pages:new pages:edit form:edit", function(){
-    $('[data-toggle="tooltip"]').tooltip()
+  $.subscribe("pages:new pages:edit form:edit pages:analytics", function(){
+    $('[data-toggle="tooltip"]').tooltip();
   });
 }());

--- a/app/views/pages/analytics.slim
+++ b/app/views/pages/analytics.slim
@@ -46,3 +46,4 @@ javascript:
     Analytics.makeDashboard("#{@page.id}");
   });
 
+  $.publish("pages:analytics");


### PR DESCRIPTION
@osahyoun I fixed it and tried to follow the existing pattern of triggering the tooltips via an event. However, I don't quite understand the reason for using events. I wanted to ask you why are you using events for this? Why not just run `tooltip()` on document.ready?