### PR TITLE
Create member API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem 'font-awesome-sass'
 gem 'money'
 gem 'google_currency'
 
+# to make parts of the API accessible to JS apps
+gem 'rack-cors', :require => 'rack/cors'
+
 # Sprockets 3 breaks Teaspoon.
 # see https://github.com/modeset/teaspoon/issues/443
 gem 'sprockets-rails', '< 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,7 @@ GEM
       slop (~> 3.4)
     puma (2.15.3)
     rack (1.6.4)
+    rack-cors (0.4.0)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.5)
@@ -542,6 +543,7 @@ DEPENDENCIES
   paperclip
   pg
   puma (~> 2.15.3)
+  rack-cors
   rails (= 4.2.5)
   rails-assets-backbone!
   rails-assets-braintree-web!

--- a/app/controllers/api/members_controller.rb
+++ b/app/controllers/api/members_controller.rb
@@ -1,13 +1,14 @@
 class Api::MembersController < ApplicationController
 
+  skip_before_action :verify_authenticity_token
+
   def create
-    member = Member.find_or_initialize_by(email: member_params[:email])
-    member.assign_attributes(member_params)
+    member = Member.new(member_params)
     if member.save
       member.send_to_ak
       render json: { member: member }
     else
-      render json: member.errors, status: :unprocessable_entity
+      render json: { errors: member.errors }, status: :unprocessable_entity
     end
   end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -3,7 +3,7 @@ class Member < ActiveRecord::Base
   has_many :go_cardless_customers, class_name: "Payment::GoCardless::Customer"
   has_paper_trail on: [:update, :destroy]
 
-  validates :email, uniqueness: true, allow_nil: true
+  validates :email, uniqueness: true, allow_blank: false
   before_save { self.email.try(:downcase!) }
 
   def self.find_from_request(akid: nil, id: nil)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,5 +58,17 @@ Rails.application.configure do
   Paperclip.options[:command_path] = '/usr/bin/'
 
   config.cache_store = :null_store
+
+  # allow cross domain requests in development from other localhosts
+  config.middleware.insert_before 0, 'Rack::Cors', logger: (-> { Rails.logger }) do
+    allow do
+      origins /localhost:[0-9]+/
+
+      resource '*',
+        headers: :any,
+        methods: [:get, :post, :delete, :put, :patch, :options, :head],
+        max_age: 0
+    end
+  end
 end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,5 +119,15 @@ Rails.application.configure do
                  port: Settings.redis.port, drive: :hiredis }
   }
 
+  config.middleware.insert_before 0, 'Rack::Cors', logger: (-> { Rails.logger }) do
+    allow do
+      origins /[a-z0-9]+\.sumofus\.org/Z/i
+
+      resource '*',
+        headers: :any,
+        methods: [:get, :post, :delete, :put, :patch, :options, :head],
+        max_age: 0
+    end
+  end
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,11 +152,10 @@ Rails.application.routes.draw do
 
     resources :members 
   end
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
+
+  # for CORS preflight check
+  match '*path', via: [:options], to:  lambda {|_| [204, {'Content-Type' => 'text/plain'}, []]}
+
+  # for JS test suite
   mount MagicLamp::Genie, at: "/magic_lamp" if defined?(MagicLamp)
 end


### PR DESCRIPTION
This does a few things. It sets up our API to allow us to take cross-domain API requests, and it adds validation on Member email to prevent blank emails.

Right now, our Member model has no validation. I think we should at least check it has an email address that matches an email regex. Why didn't we do that before? will that mess something up?