### PR TITLE
Make pages reflect the plugins of the follow-up layout too

### DIFF
--- a/app/liquid/page_plugin_switcher.rb
+++ b/app/liquid/page_plugin_switcher.rb
@@ -4,14 +4,19 @@ class PagePluginSwitcher
     @page = page
   end
 
-  def switch(new_layout)
-    keepers, quitters, starters = find_overlap(plugin_refs_from_plugins(@page.plugins), new_layout.plugin_refs)
+  def switch(new_layout, new_layout_2=nil)
+    keepers, quitters, starters = find_overlap(plugin_refs_from_plugins(@page.plugins), new_refs(new_layout, new_layout_2))
     delete_quitters(quitters)
     create_starters(starters)
     @page.liquid_layout = new_layout
   end
 
   private
+
+  def new_refs(layout_1, layout_2)
+    return layout_1.plugin_refs if layout_2.blank?
+    (layout_1.plugin_refs + layout_2.plugin_refs).uniq
+  end
 
   def delete_quitters(quitters)
     @page.plugins.each do |plugin|

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -87,8 +87,10 @@ class Page < ActiveRecord::Base
   private
 
   def switch_plugins
-    if changed.include?("liquid_layout_id")
-      PagePluginSwitcher.new(self).switch(liquid_layout)
+    fields = ["liquid_layout_id", "follow_up_liquid_layout_id", "follow_up_plan"]
+    if fields.any?{ |f| changed.include?(f) }
+      secondary = (follow_up_plan == 'with_liquid') ? follow_up_liquid_layout : nil
+      PagePluginSwitcher.new(self).switch(liquid_layout, secondary)
     end
   end
 

--- a/spec/liquid/page_plugin_switcher_spec.rb
+++ b/spec/liquid/page_plugin_switcher_spec.rb
@@ -49,6 +49,23 @@ describe PagePluginSwitcher do
         expect( created.ref ).to eq nil
       end
 
+      it 'can create a version of a plugin for each layout' do
+        expect{
+          switcher.switch(many_petition_layout, petition_ref_layout)
+        }.to change{
+          Plugins::Petition.count
+        }.from(1).to(4)
+        expect(page.plugins.map(&:class)).to match_array [Plugins::Petition]*4
+      end
+
+      it 'can share a plugin between the two layouts' do
+        expect {
+          switcher.switch(both_refless_layout, many_petition_layout)
+        }.to change {
+          Plugins::Petition.count
+        }.from(1).to(3)
+        expect(page.plugins.map(&:class)).to match_array([Plugins::Petition]*3 + [Plugins::Thermometer])
+      end
     end
 
     describe 'replacing' do


### PR DESCRIPTION
We decided a long time ago that the plugins should only be those from the primary layout, not those form the secondary layout. However, that's messing with Alex and Joe's sweet follow-up page innovations, so I've made it reflect the plugins in both.

If anyone remembers a good reason why we made it only the plugins from the primary layout, please say something. I remember it being a conscious decision, but can't remember any reasons that make sense now.