### PR TITLE
Inconsistent spec

### DIFF
--- a/app/models/plugins.rb
+++ b/app/models/plugins.rb
@@ -38,7 +38,7 @@ module Plugins
       plugins_data = page.plugins.inject({}) do |memo, plugin|
         if plugin
           plugin_name = plugin.name.underscore
-          memo[plugin_name] = {} unless memo.include? plugin_name
+          memo[plugin_name] = {} unless memo.include? plugin_name # ||=
           ref = plugin.ref.present? ? plugin.ref : default_ref
           memo[plugin_name][ref] = plugin.liquid_data(supplemental_data)
         end

--- a/spec/models/plugins/thermometer_spec.rb
+++ b/spec/models/plugins/thermometer_spec.rb
@@ -106,4 +106,26 @@ describe Plugins::Thermometer do
     thermometer.update_goal
     expect(thermometer.goal).to eq(75000)
   end
+
+  describe "inconsistent behaviour" do
+    context "given the action count gets to 500 and then the thermometer updates" do
+      it "the goal increments to 1000" do
+        test_page.update! action_count: 500
+        thermometer.liquid_data #trigger update
+        expect(thermometer.goal).to eq 1000
+
+        test_page.update! action_count: 501
+        thermometer.liquid_data #trigger update
+        expect(thermometer.goal).to eq 1000
+      end
+    end
+
+    context "given the action count gets to 501 and then the thermometer updates" do
+      it "increments the goal to 2000" do
+        test_page.update! action_count: 501
+        thermometer.liquid_data #trigger update
+        expect(thermometer.goal).to eq 2000
+      end
+    end
+  end
 end


### PR DESCRIPTION
@osahyoun @NealJMD 
Hey guys! I'm trying to make sense of the thermometer logic, and I found what it seems to be an inconsistent behaviour. I added a couple of specs to prove my point.

If a page that has a thermometer with goal 100 gets 500 signatures, then the goal jumps to 1000. If this page then gets one more signature reaching 501, the goal stays at 1000.

On the other hand, if a page with a thermometer with goal 100 gets 501 signatures, then the goal jumps to 2000. 

