### PR TITLE
URI masks

### DIFF
--- a/app/assets/stylesheets/page-edit.scss
+++ b/app/assets/stylesheets/page-edit.scss
@@ -236,6 +236,15 @@ body.page-edit-body {
     cursor: pointer;
   }
 
+  .four-ninths.form-group {
+    width: 43%;
+    margin-right: 1%;
+    float: left;
+    input {
+      width: 100%;
+    }
+  }
+
   .two-ninths.form-group {
     width: 21%;
     margin-right: 1%;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,4 +55,26 @@ class ApplicationController < ActionController::Base
   def referer_url
     {action_referer: request.referer}
   end
+
+  def render_liquid(liquid_layout, view)
+    return redirect_to(Settings.homepage_url) unless @page.published? || user_signed_in?
+    localize_by_page_language(@page)
+
+    @rendered = renderer(liquid_layout).render
+    @data = renderer(liquid_layout).personalization_data
+    render "pages/#{view}", layout: 'sumofus'
+  end
+
+  def renderer(layout)
+    @renderer ||= LiquidRenderer.new(@page, {
+      location: request.location,
+      member: recognized_member,
+      layout: layout,
+      url_params: params
+    })
+  end
+
+  def recognized_member
+    @recognized_member ||= Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
+  end
 end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,5 +1,7 @@
 class LinksController < ApplicationController
 
+  before_action :authenticate_user!
+
   def create
     link = Link.new(permitted_params)
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -57,28 +57,6 @@ class PagesController < ApplicationController
 
   private
 
-  def render_liquid(layout, view)
-    return redirect_to(Settings.homepage_url) unless @page.published? || user_signed_in?
-    localize_by_page_language(@page)
-
-    @rendered = renderer(layout).render
-    @data = renderer(layout).personalization_data
-    render view, layout: 'sumofus'
-  end
-
-  def renderer(layout)
-    @renderer ||= LiquidRenderer.new(@page, {
-      location: request.location,
-      member: recognized_member,
-      layout: layout,
-      url_params: params
-    })
-  end
-
-  def recognized_member
-    @recognized_member ||= Member.find_from_request(akid: params[:akid], id: cookies.signed[:member_id])
-  end
-
   def get_page
     @page = Page.find(params[:id])
   end

--- a/app/controllers/uris_controller.rb
+++ b/app/controllers/uris_controller.rb
@@ -1,0 +1,61 @@
+class UrisController < ApplicationController
+  before_action :authenticate_user!, except: [:show]
+  before_action :find_uri, only: [:edit, :update, :destroy]
+
+  def index
+    @uris = Uri.all
+  end
+
+  def create
+    @uri = Uri.new(permitted_params)
+
+    respond_to do |format|
+      if @uri.save
+        format.html { render partial: 'uri', locals: { uri: @uri }, status: :ok }
+      else
+        format.js { render json: { errors: @uri.errors, name: :uri }, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    @uri.assign_attributes(permitted_params)
+    
+    respond_to do |format|
+      if @uri.save
+        format.html { render partial: 'uri', locals: { uri: @uri }, status: :ok }
+      else
+        format.js { render json: { errors: @uri.errors, name: :uri }, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def show
+    uri = Uri.where(domain: request.host, path: request.path).first
+    if uri.present? && uri.page.present?
+      @page = uri.page
+      render_liquid(@page.liquid_layout, :show)
+    elsif user_signed_in?
+      redirect_to pages_path
+    else
+      redirect_to Settings.home_page_url
+    end
+  end
+
+  # Deactives campaign and its associated pages
+  def destroy
+    @uri.destroy
+    render json: { status: :ok }, status: :ok
+  end
+
+  private
+
+  def permitted_params
+    params.require(:uri).permit(:domain, :path, :page_id, :status)
+  end
+
+  def find_uri
+    @uri = Uri.find params['id']
+  end
+end
+

--- a/app/models/uri.rb
+++ b/app/models/uri.rb
@@ -1,0 +1,18 @@
+class Uri < ActiveRecord::Base
+
+  belongs_to :page
+
+  validates :domain, allow_nil: false, format: { with: /\A.+\..+\z/i }
+  validates :path, allow_nil: false, format: { with: /\A\/.*\z/i }
+  validates :page, presence: true
+
+  before_validation :format_path
+
+  private
+
+  def format_path
+    self.path = '/' if path.blank?
+    self.path = "/#{path}" if path.first != '/'
+  end
+
+end

--- a/app/views/pages/_show.slim
+++ b/app/views/pages/_show.slim
@@ -4,8 +4,8 @@
 - meta optimization_tags: @page.meta_tags
 
 = @rendered
-= render 'personalization', data: @data
-= render 'campaigner_overlay', page: @page
+= render 'pages/personalization', data: @data
+= render 'pages/campaigner_overlay', page: @page
 
 javascript:
   $(document).ready(function() {

--- a/app/views/pages/show.slim
+++ b/app/views/pages/show.slim
@@ -1,1 +1,1 @@
-= render partial: 'show'
+= render partial: 'pages/show'

--- a/app/views/uris/_uri.slim
+++ b/app/views/uris/_uri.slim
@@ -1,0 +1,12 @@
+li.list-group-item data-id=uri.id
+  = "#{uri.domain}#{uri.path} -> "
+  = link_to uri.page.title, uri.page
+
+  .control-bar
+    = link_to uri,
+      { method: :delete,
+        remote: true,
+        data: { confirm: t('common.confirm') } } do
+      small
+        span.glyphicon.glyphicon-remove
+

--- a/app/views/uris/index.html.slim
+++ b/app/views/uris/index.html.slim
@@ -1,0 +1,27 @@
+= render 'shared/sidebar', action: :index, resource: :campaigns
+
+.edit-block
+  h1.edit-block__title= t('.title')
+  .row.inline-editor
+    .col-md-12
+
+      .collection-editor
+        ul.list-group
+          - @uris.each do |uri|
+            = render 'uri', uri: uri
+
+        h4
+          = t('.new')
+        = form_for Uri.new, remote: true, html: {class: 'form-inline', id: 'new_collection_element'}  do |f|
+          .form-group.two-ninths
+            = f.text_field :domain, class: 'form-control', placeholder: t('uris.domain')
+          .form-group.two-ninths
+            = f.text_field :path, class: 'form-control', placeholder: t('uris.path')
+          .form-group.four-ninths
+            = f.select :page_id, options_from_collection_for_select(Page.all, 'id', 'title', f.object.page_id), {}, {class: 'selectize-container', multiple: false}
+          .form-group.one-ninth
+            = submit_tag t('common.save'), class: 'btn btn-primary xhr-feedback', 'data-disable-with' => t('common.saving')
+
+      javascript:
+        $.publish("collection:edit:loaded");
+

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: development
+    branch: domains
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/circle/specs-and-rake-tasks
+++ b/circle/specs-and-rake-tasks
@@ -23,7 +23,7 @@ echo "OK"
 
 # Run javascript tests
 RAILS_ENV=test rake db:schema:load
-RAILS_ENV=test bundle exec teaspoon
+RAILS_ENV=test JS_TEST=1 bundle exec teaspoon
 
 # Runs tests
 rspec spec

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -304,3 +304,12 @@ en:
     name: 'Name:'
     amounts: 'Amounts:'
 
+  uris:
+    index:
+      title: "URI masks"
+      new: "Create a new URI mask"
+    domain: 'Domain'
+    path: 'Path'
+    page: 'Page'
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   end
 
   # Standard resources
+  resources :uris, except: [:new, :edit]
   resources :campaigns
   resources :donation_bands, except: [:show, :destroy]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,6 @@ Rails.application.routes.draw do
   #     resources :products
   #   end
 
-  get '*path' => 'uris#show'
-  mount MagicLamp::Genie, at: "/magic_lamp" if defined?(MagicLamp)
+  mount MagicLamp::Genie, at: "/magic_lamp" if defined?(MagicLamp) && ENV['JS_TEST']
+  get '*path' => 'uris#show'unless defined?(MagicLamp) && ENV['JS_TEST']
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,6 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { omniauth_callbacks: "omniauth_callbacks" }
 
-  root to: 'home#index'
-
   # Tagging pages
   get '/tags/search/:search', to: 'tags#search'
   post '/tags/add', to: 'tags#add_tag_to_page'
@@ -158,5 +156,7 @@ Rails.application.routes.draw do
   #     # (app/controllers/admin/products_controller.rb)
   #     resources :products
   #   end
+
+  get '*path' => 'uris#show'
   mount MagicLamp::Genie, at: "/magic_lamp" if defined?(MagicLamp)
 end

--- a/db/migrate/20160731195009_create_uris.rb
+++ b/db/migrate/20160731195009_create_uris.rb
@@ -1,0 +1,11 @@
+class CreateUris < ActiveRecord::Migration
+  def change
+    create_table :uris do |t|
+      t.string :domain
+      t.string :path
+      t.references :page, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160726202331) do
+ActiveRecord::Schema.define(version: 20160731195009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -469,6 +469,16 @@ ActiveRecord::Schema.define(version: 20160726202331) do
     t.datetime "updated_at",    null: false
   end
 
+  create_table "uris", force: :cascade do |t|
+    t.string   "domain"
+    t.string   "path"
+    t.integer  "page_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "uris", ["page_id"], name: "index_uris_on_page_id", using: :btree
+
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
@@ -533,4 +543,5 @@ ActiveRecord::Schema.define(version: 20160726202331) do
   add_foreign_key "share_emails", "pages"
   add_foreign_key "share_facebooks", "images"
   add_foreign_key "share_twitters", "pages"
+  add_foreign_key "uris", "pages"
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -11,18 +11,4 @@ describe HomeController do
     expect(response.status).to be 200
   end
 
-  context 'get index' do
-    it 'routes to homepage  if requested by an unauthenticated user' do
-      allow(controller).to receive(:user_signed_in?) { false }
-      expect(get :index).to redirect_to(Settings.home_page_url)
-    end
-
-    it 'routes to /pages if requested by an authenticated user' do
-      allow(controller).to receive(:user_signed_in?) { true }
-      expect(get :index).to redirect_to(pages_path)
-    end
-
-  end
-
-
 end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 describe LinksController do
   let(:link) { instance_double('Link', save: true) }
+  let(:user) { instance_double('User', id: '1') }
+
+  before :each do
+    allow(request.env['warden']).to receive(:authenticate!) { user }
+  end
 
   describe 'POST #create' do
     let(:page) { instance_double('Page') }

--- a/spec/controllers/uris_controller_spec.rb
+++ b/spec/controllers/uris_controller_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+describe UrisController do
+  let(:uri) { instance_double('Uri', save: true) }
+  let(:user) { instance_double('User', id: '1') }
+
+  describe 'logged in' do
+
+    before :each do
+      allow(request.env['warden']).to receive(:authenticate!) { user }
+    end
+
+    describe "GET #index" do
+
+      let(:uris) { [build(:uri), build(:uri)] }
+
+      before :each do
+        allow(Uri).to receive(:all).and_return(uris)
+      end
+
+      it "assigns all uris as @uris" do
+        get :index
+        expect(assigns(:uris)).to eq(uris)
+      end
+    end
+
+    describe 'POST #create' do
+      let(:params) { { domain: "google.com", path: '/giddyup', page_id: '1' } }
+
+      before do
+        allow(Uri).to receive(:new) { uri }
+
+        post :create, uri: params
+      end
+
+      it 'creates uri' do
+        expect(Uri).to have_received(:new).with(params.stringify_keys)
+      end
+
+      it 'saves uri' do
+        expect(uri).to have_received(:save)
+      end
+
+      context "successfully created" do
+        it 'renders uri partial' do
+          expect(response).to render_template('_uri')
+        end
+      end
+    end
+
+    describe "DELETE #destroy" do
+      before do
+        allow(Uri).to receive(:find){ uri }
+        allow(uri).to receive(:destroy)
+
+        delete :destroy, id: '2', format: :json
+      end
+
+      it 'finds uri' do
+        expect(Uri).to have_received(:find).with('2')
+      end
+
+      it 'destroys uri' do
+        expect(uri).to have_received(:destroy)
+      end
+    end
+  end
+
+end

--- a/spec/factories/uris.rb
+++ b/spec/factories/uris.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :uri do
+    domain "google.com"
+    path "/"
+    page_id nil
+  end
+end

--- a/spec/models/uri_spec.rb
+++ b/spec/models/uri_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+describe Uri do
+
+  let(:page) { create :page }
+  let(:uri) { build :uri, page: page }
+
+  describe 'domain' do
+    it "is invalid if it's nil" do
+      uri.domain = nil
+      expect(uri).to be_invalid
+    end
+
+    it "is invalid if it's an empty string" do
+      uri.domain = ''
+      expect(uri).to be_invalid
+    end
+
+    it "is invalid if it doesn't have a period" do
+      uri.domain = 'crazytime'
+      expect(uri).to be_invalid
+    end
+
+    it "is valid if it's a domain name" do
+      uri.domain = 'hustle.life'
+      expect(uri).to be_valid
+    end
+
+    it "is valid if it's a domain name with a subdomain" do
+      uri.domain = 'google.abc.xyz'
+      expect(uri).to be_valid
+    end
+  end
+
+  describe 'path' do
+    it 'formats nil to /' do
+      uri.path = nil
+      expect(uri).to be_valid
+      expect(uri.path).to eq '/'
+    end
+
+    it 'automatically prepends / to an empty string' do
+      uri.path = ''
+      expect(uri).to be_valid
+      expect(uri.path).to eq '/'
+    end
+
+    it 'does not prepend / to /' do
+      uri.path = '/'
+      expect(uri).to be_valid
+      expect(uri.path).to eq '/'
+    end
+
+    it 'automatically prepends / to abc/def' do
+      uri.path = 'abc/def'
+      expect(uri).to be_valid
+      expect(uri.path).to eq '/abc/def'
+    end
+
+    it 'is valid with a long but reasonable path' do
+      path = '/maxi/45/pali?key=1&other=fun'
+      uri.path = path
+      expect(uri).to be_valid
+      expect(uri.path).to eq path
+    end
+  end
+
+  describe 'page' do
+
+    subject{ uri }
+    it { is_expected.to respond_to :page }
+    it { is_expected.to respond_to :page= }
+    it { is_expected.to respond_to :page_id }
+    it { is_expected.to respond_to :page_id= }
+
+    it 'is invalid without a page' do
+      uri.page_id = nil
+      expect(uri).to be_invalid
+    end
+
+    it 'is invalid with a non-existent page' do
+      uri.page_id = 456789
+      expect(uri).to be_invalid
+    end
+  end
+
+end

--- a/spec/requests/uris_spec.rb
+++ b/spec/requests/uris_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'URI masking' do
+
+  let(:user) { instance_double('User', id: '1') }
+  let(:page) { create :page }
+  let(:uri) { create :uri, domain: 'www.example.com', path: 'random', page: page }
+
+
+  describe 'when no record matches' do
+    it 'routes to homepage  if requested by an unauthenticated user' do
+      expect(get '/random').to redirect_to(Settings.home_page_url)
+    end
+
+    it 'routes to /pages if requested by an authenticated user' do
+      login_as(create(:user), scope: :user)
+      expect(get '/random').to redirect_to(pages_path)
+    end
+  end
+
+  it 'renders matching URI record' do
+    uri # lazy let
+    allow(LiquidRenderer).to receive(:new).and_call_original
+    get '/random'
+    expect(response.status).to eq 200
+    expect(response).to render_template('pages/show')
+    expect(LiquidRenderer).to have_received(:new)
+  end
+
+end

--- a/spec/routing/pages_routing_spec.rb
+++ b/spec/routing/pages_routing_spec.rb
@@ -74,7 +74,7 @@ describe PagesController, type: :routing do
       end
 
       it "does not route to #index" do
-        expect(:get => "/a" ).not_to be_routable
+        expect(:get => "/a" ).to route_to('uris#show', path: 'a')
       end
 
       it "does not route to #create" do


### PR DESCRIPTION
This PR allows us to make champaign pages render under other URLs. A catch-all route in routes.rb goes to the URIs#show action, which looks up if there's a URI record with the current path and (critically) the current host name. That lets us resolve `bayermonsanto.com/press` and `myothermicrosite.org/press` to two different champaign pages as long as both domains have a CNAME to point to `actions.sumofus.org`. 