### PR TITLE
Prevent member signing multiple petitions in campaign

### DIFF
--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -20,6 +20,15 @@ module ActionBuilder
   def previous_action
     return nil unless existing_member?
     @previous_action ||= Action.where(member: member, page_id: page).first
+
+    # looks up other actions the user might have taken on this campaign
+    if page.campaign.present? && @previous_action.blank?
+      page.campaign.pages.each do |connected_page|
+        next if connected_page.id == page.id
+        @previous_action ||= Action.where(member: member, page_id: connected_page.id).first
+      end
+    end
+    @previous_action
   end
 
   def existing_member

--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -96,6 +96,29 @@ describe "Api Actions" do
       end
     end
 
+    describe 'existing action' do
+      let!(:member) { create :member, actionkit_user_id: '7777', email: params[:email]}
+      let(:page2) { create :page }
+
+      subject{ post "/api/pages/#{page.id}/actions", params }
+
+      it 'creates a new action if existing action on a different page' do
+        create :action, member: member, page: page2
+        expect{ subject }.to change{ Action.count }.by 1
+      end
+
+      it 'does not create an action if existing action on this page' do
+        create :action, member: member, page: page
+        expect{ subject }.not_to change{ Action.count }
+      end
+
+      it 'does not create an action if existing action of different page in same campaign' do
+        create :action, member: member, page: page2
+        create :campaign, pages: [page, page2]
+        expect{ subject }.not_to change{ Action.count }
+      end
+    end
+
     describe 'akid manipulation' do
       context 'new member' do
         before do

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -56,12 +56,54 @@ describe ActionBuilder do
   it 'correctly builds and returns actions' do
     mab = MockActionBuilder.new(page_id: page.id, email: member.email)
     expect(mab.build_action).to eq(found_action)
+    expect(found_action).not_to be_blank
   end
 
   it 'correctly builds and finds previous actions' do
     mab = MockActionBuilder.new(page_id: page.id, email: member.email)
     mab.build_action
     expect(mab.previous_action).to eq(found_action)
+    expect(found_action).not_to be_blank
+  end
+
+  describe 'previous_action' do
+    let!(:page2) { create :page }
+    let!(:page3) { create :page }
+    let!(:page4) { create :page }
+    let(:mab) { MockActionBuilder.new(page_id: page.id, email: member.email) }
+
+    it "returns nil if no previous action on any page" do
+      expect(mab.previous_action).to eq nil
+    end
+
+    it "returns nil if previous action on another page" do
+      create :action, page: page2, member: member
+      expect(mab.previous_action).to eq nil
+    end
+
+    it "returns nil if previous action on another page in a different campaign" do
+      create :campaign, pages: [page2, page3]
+      create :action, page: page2, member: member
+      expect(mab.previous_action).to eq nil
+    end
+
+    it "returns action on current page if one exists" do
+      action = create :action, page: page, member: member
+      expect(mab.previous_action).to eq action
+    end
+
+    it "returns action on other page in campaign if one campaign" do
+      create :campaign, pages: [page, page2, page3]
+      action = create :action, page: page3, member: member
+      expect(mab.previous_action).to eq action
+    end
+
+    it "returns action on other page in campaign if multiple campaigns" do
+      create :campaign, pages: [page, page2]
+      create :campaign, pages: [page3, page4]
+      action = create :action, page: page2, member: member
+      expect(mab.previous_action).to eq action
+    end
   end
 
   describe 'donor_status' do


### PR DESCRIPTION
If a member has already signed a campaign in one language, we shouldn't allow them to resign on every page of that campaign. This logic should do that but it needs a spec. Hoping someone might pick this one up.