### PR TITLE
Homepage signup

### DIFF
--- a/app/controllers/api/members_controller.rb
+++ b/app/controllers/api/members_controller.rb
@@ -1,19 +1,11 @@
 # frozen_string_literal: true
 class Api::MembersController < ApplicationController
   def create
-    validator = FormValidator.new(member_params, member_validation)
-
-    if validator.valid?
-      member = Member.find_or_initialize_by(email: member_params[:email])
-      member.assign_attributes(member_params)
-      if member.save
-        member.send_to_ak
-        render json: { member: member }
-      else
-        render json: { errors: member.errors }, status: :unprocessable_entity
-      end
+    workhorse = CreateMemberForApiMembersController.new(member_params)
+    if workhorse.create
+      render json: { member: workhorse.member }
     else
-      render json: { errors: validator.errors }, status: :unprocessable_entity
+      render json: { errors: workhorse.errors }, status: :unprocessable_entity
     end
   end
 
@@ -23,12 +15,4 @@ class Api::MembersController < ApplicationController
     params.permit(:name, :email, :country, :postal)
   end
 
-  def member_validation
-    [
-      { name: 'email', data_type: 'email', required: true },
-      { name: 'country', data_type: 'country', required: false },
-      { name: 'postal', data_type: 'postal', required: false },
-      { name: 'name', data_type: 'text', required: true }
-    ]
-  end
 end

--- a/app/controllers/api/members_controller.rb
+++ b/app/controllers/api/members_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class Api::MembersController < ApplicationController
-
   def create
     validator = FormValidator.new(member_params, member_validation)
 
@@ -26,10 +25,10 @@ class Api::MembersController < ApplicationController
 
   def member_validation
     [
-      {name: 'email', data_type: 'email', required: true },
-      {name: 'country', data_type: 'country', required: false },
-      {name: 'postal', data_type: 'postal', required: false },
-      {name: 'name', data_type: 'text', required: true },
+      { name: 'email', data_type: 'email', required: true },
+      { name: 'country', data_type: 'country', required: false },
+      { name: 'postal', data_type: 'postal', required: false },
+      { name: 'name', data_type: 'text', required: true }
     ]
   end
 end

--- a/app/controllers/api/members_controller.rb
+++ b/app/controllers/api/members_controller.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 class Api::MembersController < ApplicationController
+
   def create
-    member = Member.find_or_initialize_by(email: member_params[:email])
-    member.assign_attributes(member_params)
-    if member.save
-      member.send_to_ak
-      render json: { member: member }
+    validator = FormValidator.new(member_params, member_validation)
+
+    if validator.valid?
+      member = Member.find_or_initialize_by(email: member_params[:email])
+      member.assign_attributes(member_params)
+      if member.save
+        member.send_to_ak
+        render json: { member: member }
+      else
+        render json: { errors: member.errors }, status: :unprocessable_entity
+      end
     else
-      render json: member.errors, status: :unprocessable_entity
+      render json: { errors: validator.errors }, status: :unprocessable_entity
     end
   end
 
@@ -15,5 +22,14 @@ class Api::MembersController < ApplicationController
 
   def member_params
     params.permit(:name, :email, :country, :postal)
+  end
+
+  def member_validation
+    [
+      {name: 'email', data_type: 'email', required: true },
+      {name: 'country', data_type: 'country', required: false },
+      {name: 'postal', data_type: 'postal', required: false },
+      {name: 'name', data_type: 'text', required: true },
+    ]
   end
 end

--- a/app/services/create_member_for_api_members_controller.rb
+++ b/app/services/create_member_for_api_members_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+class CreateMemberForApiMembersController
+  attr_reader :member, :errors
+
+  def initialize(params)
+    @params = params
+  end
+
+  def create
+    validator = FormValidator.new(@params, member_validation)
+
+    if validator.valid?
+      @member = Member.find_or_initialize_by(email: @params[:email])
+      @member.assign_attributes(@params)
+      if @member.save
+        @member.send_to_ak
+        return true
+      else
+        @errors = member.errors
+        return false
+      end
+    else
+      @errors = validator.errors
+      return false
+    end
+  end
+
+  private
+
+  def member_validation
+    [
+      { name: 'email', data_type: 'email', required: true },
+      { name: 'country', data_type: 'country', required: false },
+      { name: 'postal', data_type: 'postal', required: false },
+      { name: 'name', data_type: 'text', required: true }
+    ]
+  end
+end

--- a/app/services/form_validator.rb
+++ b/app/services/form_validator.rb
@@ -1,20 +1,28 @@
 # frozen_string_literal: true
 class FormValidator
-  attr_reader :errors
 
   MAX_LENGTH = {
     PARAGRAPH: 10_000,
     TEXT: 250
   }.freeze
 
-  def initialize(params)
+  def initialize(params, form_elements=nil)
     @params = params.symbolize_keys
     @errors = Hash.new { |hash, key| hash[key] = [] }
+    @form_elements = form_elements unless form_elements.blank? # don't prevent memoization
     validate
   end
 
-  def form
-    @form ||= Form.includes(:form_elements).find(@params[:form_id])
+  def form_elements
+    return @form_elements if @form_elements.present?
+    if @params[:form_id].present?
+      form = Form.includes(:form_elements).find(@params[:form_id])
+      @form_elements = form.form_elements.map do |el|
+        { name: el.name.to_sym, required: el.required?, data_type: el.data_type }
+      end
+    else
+      []
+    end
   end
 
   def valid?
@@ -22,62 +30,65 @@ class FormValidator
   end
 
   def validate
-    form.form_elements.each do |element|
+    form_elements.each do |element|
       validate_field(element)
     end
   end
 
   def validate_field(form_element)
-    el_name = form_element.name.to_sym
+    value = @params[form_element[:name].to_sym]
+    validate_length(value, form_element)
+    validate_country(value, form_element)
+    validate_phone(value, form_element)
+    validate_email(value, form_element)
+    validate_postal(value, form_element)
+    validate_required(value, form_element)
+  end
 
-    validate_length(form_element, el_name)
-    validate_required(form_element, el_name)
-    validate_country(form_element, el_name)
-    validate_phone(form_element, el_name)
-    validate_email(form_element, el_name)
-    validate_postal(form_element, el_name)
+  def errors
+    @errors.symbolize_keys
   end
 
   private
 
-  def validate_length(form_element, el_name)
-    data_type = form_element.data_type.upcase.to_sym
-    return nil unless MAX_LENGTH[data_type] && (@params[el_name] || []).size >= MAX_LENGTH[data_type]
-    @errors[el_name] << I18n.t('validation.is_invalid_length', length: MAX_LENGTH[data_type])
-  end
-
-  def validate_required(form_element, el_name)
-    return nil unless form_element.required? && @params[el_name].blank?
-    @errors[el_name] << I18n.t('validation.is_required')
-  end
-
-  def validate_phone(form_element, el_name)
-    phone_number = @params[el_name]
-    if form_element.data_type == 'phone' && phone_number.present? && !is_phone(phone_number)
-      @errors[el_name] << I18n.t('validation.is_invalid_phone')
+  def validate_length(value, form_element)
+    if form_element[:data_type] == "text" && (value || []).size >= MAX_LENGTH[:TEXT]
+      @errors[form_element[:name]] << I18n.t('validation.is_invalid_length', length: MAX_LENGTH[:TEXT])
+    elsif form_element[:data_type] == "paragraph" && (value || []).size >= MAX_LENGTH[:PARAGRAPH]
+      @errors[form_element[:name]] << I18n.t('validation.is_invalid_length', length: MAX_LENGTH[:PARAGRAPH])
     end
   end
 
-  def validate_email(form_element, el_name)
-    email = @params[el_name].try(:encode, 'UTF-8', invalid: :replace, undef: :replace)
-    if form_element.data_type == 'email' && email.present? && !is_email(email)
-      @errors[el_name] << I18n.t('validation.is_invalid_email')
+  def validate_required(value, form_element)
+    if form_element[:required] && value.blank?
+      @errors[form_element[:name]] << I18n.t("validation.is_required")
     end
   end
 
-  def validate_country(form_element, el_name)
-    country = @params[el_name]
-    if form_element.data_type == 'country' && country.present? && !is_country_code(country)
-      @errors[el_name] << I18n.t('validation.is_invalid_country')
+  def validate_phone(phone_number, form_element)
+    if form_element[:data_type] == "phone" && phone_number.present? && !is_phone(phone_number)
+      @errors[form_element[:name]] << I18n.t("validation.is_invalid_phone")
     end
   end
 
-  def validate_postal(form_element, el_name)
-    postal = @params[el_name]
+  def validate_email(value, form_element)
+    email = value.try(:encode!, 'UTF-8', invalid: :replace, undef: :replace)
+    if form_element[:data_type] == "email" && email.present? && !is_email(email)
+      @errors[form_element[:name]] << I18n.t("validation.is_invalid_email")
+    end
+  end
+
+  def validate_country(country, form_element)
+    if form_element[:data_type] == "country" && country.present? && !is_country_code(country)
+      @errors[form_element[:name]] << I18n.t("validation.is_invalid_country")
+    end
+  end
+
+  def validate_postal(postal, form_element)
     country = (@params[:country].blank? ? :US : @params[:country].to_sym)
 
-    if form_element.data_type == 'postal' && postal.present? && !is_postal(postal, country)
-      @errors[el_name] << I18n.t('validation.is_invalid_postal')
+    if form_element[:data_type] == 'postal' && postal.present? && !is_postal(postal, country)
+      @errors[form_element[:name]] << I18n.t('validation.is_invalid_postal')
     end
   end
 

--- a/app/services/form_validator.rb
+++ b/app/services/form_validator.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 class FormValidator
-
   MAX_LENGTH = {
     PARAGRAPH: 10_000,
     TEXT: 250
   }.freeze
 
-  def initialize(params, form_elements=nil)
+  def initialize(params, form_elements = nil)
     @params = params.symbolize_keys
     @errors = Hash.new { |hash, key| hash[key] = [] }
     @form_elements = form_elements unless form_elements.blank? # don't prevent memoization
@@ -52,35 +51,34 @@ class FormValidator
   private
 
   def validate_length(value, form_element)
-    if form_element[:data_type] == "text" && (value || []).size >= MAX_LENGTH[:TEXT]
+    if form_element[:data_type] == 'text' && (value || []).size >= MAX_LENGTH[:TEXT]
       @errors[form_element[:name]] << I18n.t('validation.is_invalid_length', length: MAX_LENGTH[:TEXT])
-    elsif form_element[:data_type] == "paragraph" && (value || []).size >= MAX_LENGTH[:PARAGRAPH]
+    elsif form_element[:data_type] == 'paragraph' && (value || []).size >= MAX_LENGTH[:PARAGRAPH]
       @errors[form_element[:name]] << I18n.t('validation.is_invalid_length', length: MAX_LENGTH[:PARAGRAPH])
     end
   end
 
   def validate_required(value, form_element)
-    if form_element[:required] && value.blank?
-      @errors[form_element[:name]] << I18n.t("validation.is_required")
-    end
+    return unless form_element[:required] && value.blank?
+    @errors[form_element[:name]] << I18n.t('validation.is_required')
   end
 
   def validate_phone(phone_number, form_element)
-    if form_element[:data_type] == "phone" && phone_number.present? && !is_phone(phone_number)
-      @errors[form_element[:name]] << I18n.t("validation.is_invalid_phone")
+    if form_element[:data_type] == 'phone' && phone_number.present? && !is_phone(phone_number)
+      @errors[form_element[:name]] << I18n.t('validation.is_invalid_phone')
     end
   end
 
   def validate_email(value, form_element)
-    email = value.try(:encode!, 'UTF-8', invalid: :replace, undef: :replace)
-    if form_element[:data_type] == "email" && email.present? && !is_email(email)
-      @errors[form_element[:name]] << I18n.t("validation.is_invalid_email")
+    email = value.try(:encode, 'UTF-8', invalid: :replace, undef: :replace)
+    if form_element[:data_type] == 'email' && email.present? && !is_email(email)
+      @errors[form_element[:name]] << I18n.t('validation.is_invalid_email')
     end
   end
 
   def validate_country(country, form_element)
-    if form_element[:data_type] == "country" && country.present? && !is_country_code(country)
-      @errors[form_element[:name]] << I18n.t("validation.is_invalid_country")
+    if form_element[:data_type] == 'country' && country.present? && !is_country_code(country)
+      @errors[form_element[:name]] << I18n.t('validation.is_invalid_country')
     end
   end
 

--- a/app/services/form_validator.rb
+++ b/app/services/form_validator.rb
@@ -12,6 +12,22 @@ class FormValidator
     validate
   end
 
+  def valid?
+    @errors.empty?
+  end
+
+  def validate
+    form_elements.each do |element|
+      validate_field(element)
+    end
+  end
+
+  def errors
+    @errors.symbolize_keys
+  end
+
+  private
+
   def form_elements
     return @form_elements if @form_elements.present?
     if @params[:form_id].present?
@@ -24,16 +40,6 @@ class FormValidator
     end
   end
 
-  def valid?
-    @errors.empty?
-  end
-
-  def validate
-    form_elements.each do |element|
-      validate_field(element)
-    end
-  end
-
   def validate_field(form_element)
     value = @params[form_element[:name].to_sym]
     validate_length(value, form_element)
@@ -43,12 +49,6 @@ class FormValidator
     validate_postal(value, form_element)
     validate_required(value, form_element)
   end
-
-  def errors
-    @errors.symbolize_keys
-  end
-
-  private
 
   def validate_length(value, form_element)
     if form_element[:data_type] == 'text' && (value || []).size >= MAX_LENGTH[:TEXT]

--- a/spec/requests/api/members_spec.rb
+++ b/spec/requests/api/members_spec.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe 'api/members' do
-  def json
-    JSON.parse(response.body)
-  end
+describe "api/members" do
 
   let(:params) { { email: 'newbie@test.org', country: 'NZ', postal: '1A943', name: 'Anahera Parata' } }
 
@@ -43,12 +40,11 @@ describe 'api/members' do
       )
     end
 
-    it 'creates a new member also if the only field we get is an email address' do
-      expect { post api_members_path, email: 'private@email.com' }.to change { Member.count }.by(1)
-      expect(Member.last).to have_attributes(email: 'private@email.com',
-                                             country: nil,
-                                             name: '',
-                                             postal: nil)
+    it "returns validation errors if we only receive a bad email address", :focus do
+      expect { post api_members_path, email: "private" }.not_to change{Member.count}
+      expect(response.code).to eq '422'
+      json = JSON.parse(response.body).deep_symbolize_keys
+      expect(json).to eq({errors: {name: ["is required"], email: ["is not a valid email address"] }})
     end
   end
 end

--- a/spec/requests/api/members_spec.rb
+++ b/spec/requests/api/members_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe "api/members" do
-
+describe 'api/members' do
   let(:params) { { email: 'newbie@test.org', country: 'NZ', postal: '1A943', name: 'Anahera Parata' } }
 
   subject do
@@ -40,11 +39,11 @@ describe "api/members" do
       )
     end
 
-    it "returns validation errors if we only receive a bad email address" do
-      expect { post api_members_path, email: "private" }.not_to change{Member.count}
+    it 'returns validation errors if we only receive a bad email address' do
+      expect { post api_members_path, email: 'private' }.not_to change { Member.count }
       expect(response.code).to eq '422'
       json = JSON.parse(response.body).deep_symbolize_keys
-      expect(json).to eq({errors: {name: ["is required"], email: ["is not a valid email address"] }})
+      expect(json).to eq(errors: { name: ['is required'], email: ['is not a valid email address'] })
     end
   end
 end

--- a/spec/requests/api/members_spec.rb
+++ b/spec/requests/api/members_spec.rb
@@ -40,7 +40,7 @@ describe "api/members" do
       )
     end
 
-    it "returns validation errors if we only receive a bad email address", :focus do
+    it "returns validation errors if we only receive a bad email address" do
       expect { post api_members_path, email: "private" }.not_to change{Member.count}
       expect(response.code).to eq '422'
       json = JSON.parse(response.body).deep_symbolize_keys

--- a/spec/services/form_validator_spec.rb
+++ b/spec/services/form_validator_spec.rb
@@ -1,214 +1,233 @@
-# frozen_string_literal: true
 require 'rails_helper'
 
 describe FormValidator do
-  let(:form) { create :form }
 
-  subject { FormValidator.new(params) }
+  shared_examples 'is correctly validated' do
+    let(:form) { create :form }
 
-  context 'with required as true' do
-    let(:element) { create :form_element, form: form, required: true, label: 'Address', name: 'address1' }
-    let(:params) { { form_id: element.form_id } }
+    context "with required as true" do
+      let!(:element) { create :form_element, form: form, required: true, label: 'Address', name: 'address1' }
+      let(:params){ {} }
 
-    it 'is valid with value' do
-      params[:address1] = 'foo'
-      expect(subject).to be_valid
-    end
-
-    it 'is valid with value and string key' do
-      params['address1'] = 'bar'
-      expect(subject).to be_valid
-    end
-
-    context 'is invalid' do
-      it 'without value' do
-        expect(subject).to_not be_valid
-      end
-
-      it 'with nil' do
-        params[:address1] = nil
-        expect(subject).to_not be_valid
-      end
-
-      it 'with false' do
-        params[:address1] = false
-        expect(subject).to_not be_valid
-      end
-
-      it 'with empty string' do
-        params[:address1] = ''
-        expect(subject).to_not be_valid
-      end
-
-      it 'with paragraph data type and empty string' do
-        element.update_attributes(data_type: 'paragraph')
-        params[:address1] = ''
-        expect(subject).to_not be_valid
-      end
-    end
-  end
-
-  context 'with email as data_type' do
-    let(:element) { create :form_element, :email, form: form }
-    let(:params) { { form_id: element.form_id, email: 'foo@example.com' } }
-
-    context 'is valid' do
-      it 'with regular address' do
+      it "is valid with value" do
+        params.merge!(address1: 'foo')
         expect(subject).to be_valid
       end
 
-      it 'with multiple dots' do
-        params[:email] = 'neal.donnelly@cycles.cs.princeton.edu'
-        expect(subject).to be_valid
-      end
-    end
-
-    context 'is invalid' do
-      it 'with a basic sentence' do
-        params[:email] = "I'm not an email!"
-        expect(subject).to_not be_valid
-      end
-
-      it 'with missing the TLD' do
-        params[:email] = 'neal@sumofus'
-        expect(subject).to_not be_valid
-      end
-
-      it 'with two @ symbols' do
-        params[:email] = 'this@that@other.com'
-        expect(subject).to_not be_valid
-      end
-
-      it 'with ascii' do
-        params[:email] = "this\xC2@other.com"
-        expect(subject).to_not be_valid
-      end
-    end
-  end
-
-  context 'with phone as data_type' do
-    let(:element) { create :form_element, :phone, form: form }
-    let(:params) { { form_id: element.form_id, phone: '00 2323 12345' } }
-
-    context 'is valid' do
-      it 'with regular numbers' do
+      it 'is valid with value and string key' do
+        params.merge!('address1' => 'bar')
         expect(subject).to be_valid
       end
 
-      it 'has spaces, dashes, pluses, and parentheses' do
-        params[:phone] = '+1 (413)-555-1234'
+      context "is invalid" do
+        it "without value" do
+          expect(subject).to_not be_valid
+        end
+
+        it "with nil" do
+          params.merge!(address1: nil)
+          expect(subject).to_not be_valid
+        end
+
+        it "with false" do
+          params.merge!(address1: false)
+          expect(subject).to_not be_valid
+        end
+
+        it "with empty string" do
+          params.merge!(address1: "")
+          expect(subject).to_not be_valid
+        end
+
+        it "with paragraph data type and empty string" do
+          element.update_attributes(data_type: 'paragraph')
+          params.merge!(address1: "")
+          expect(subject).to_not be_valid
+        end
+      end
+    end
+
+    context "with email as data_type" do
+      let!(:element) { create :form_element, :email, form: form }
+      let(:params){ {email: "foo@example.com"} }
+
+      context "is valid" do
+        it "with regular address" do
+          expect(subject).to be_valid
+        end
+
+        it "with multiple dots" do
+          params.merge!(email: "neal.donnelly@cycles.cs.princeton.edu")
+          expect(subject).to be_valid
+        end
+      end
+
+      context "is invalid" do
+        it "with a basic sentence" do
+          params.merge!(email: "I'm not an email!")
+          expect(subject).to_not be_valid
+        end
+
+        it "with missing the TLD" do
+          params.merge!(email: "neal@sumofus")
+          expect(subject).to_not be_valid
+        end
+
+        it "with two @ symbols" do
+          params.merge!(email: "this@that@other.com")
+          expect(subject).to_not be_valid
+        end
+
+        it 'with ascii' do
+          params.merge!(email: "this\xC2@other.com")
+          expect(subject).to_not be_valid
+        end
+      end
+    end
+
+    context "with phone as data_type" do
+      let!(:element) { create :form_element, :phone, form: form }
+      let(:params){ { phone: '00 2323 12345' } }
+
+      context "is valid" do
+        it "with regular numbers" do
+          expect(subject).to be_valid
+        end
+
+        it "has spaces, dashes, pluses, and parentheses" do
+          params.merge!(phone: "+1 (413)-555-1234")
+          expect(subject).to be_valid
+        end
+      end
+
+      context "is invalid" do
+        it "if too short" do
+          params.merge!(phone: "12345")
+          expect(subject).to_not be_valid
+        end
+
+        it "with invalid special characters" do
+          params.merge!(phone: "(+) -- (+)")
+          expect(subject).to_not be_valid
+        end
+      end
+    end
+
+    context "with country as data_type" do
+      let!(:element) { create :form_element, :country, form: form }
+      let(:params){ { country: 'FR' } }
+
+      it "is valid" do
         expect(subject).to be_valid
       end
+
+      context "is invalid" do
+        it "with full country name" do
+          params.merge!(country: "France")
+          expect(subject).to_not be_valid
+        end
+
+        it "with a number" do
+          params.merge!(country: "33")
+          expect(subject).to_not be_valid
+        end
+
+        it "as lowercase" do
+          params.merge!(country: "fr")
+          expect(subject).to_not be_valid
+        end
+      end
     end
 
-    context 'is invalid' do
-      it 'if too short' do
-        params[:phone] = '12345'
-        expect(subject).to_not be_valid
+    context 'with zip as data type' do
+      let!(:element) { create :form_element, :postal, form: form }
+      let(:country_element) { create :form_element, :country, form: form}
+      let(:us_postal) { '12345' }
+      let(:uk_postal) { 'CR0 3RL' }
+      let(:params) { { postal: us_postal } }
+
+      context 'is valid' do
+        it 'without a country code' do
+          expect(subject).to be_valid
+        end
+
+        it 'with a valid country code in the UK' do
+          params.merge!(postal: uk_postal, country: :UK)
+          expect(subject).to be_valid
+        end
       end
 
-      it 'with invalid special characters' do
-        params[:phone] = '(+) -- (+)'
-        expect(subject).to_not be_valid
+      context 'is invalid' do
+        it 'with an incorrect code' do
+          params.merge!(postal: 'Not a valid zip')
+          expect(subject).to_not be_valid
+        end
+
+        it 'with a valid code but incorrect country code' do
+          country_element
+          params.merge!(country: :UK)
+          expect(subject).to_not be_valid
+        end
+      end
+    end
+
+    context 'with text as data type' do
+      let!(:element) { create :form_element, form: form, required: false, label: 'Address', name: 'address1' }
+      let(:params){  { address1: 'b'*249 } }
+
+      it 'is valid with a 249 character string' do
+        expect(subject.errors).to be_empty
+      end
+
+      it 'is invalid with a 250 character string' do
+        params.merge!(address1: 'b'*250)
+        expect(subject.errors).not_to be_empty
+        expect(subject.errors[:address1].first).to match(/less than 250/)
+      end
+    end
+
+    context 'with comment as data type' do
+      let!(:element) { create :form_element, :paragraph, form: form, required: false, label: 'Address', name: 'address1' }
+      let(:params){  { address1: 'b'*9_999 } }
+
+      it 'is valid with a 9,999 character string' do
+        expect(subject.errors).to be_empty
+      end
+
+      it 'is valid with a nil when element not required' do
+        params.merge!(address1: nil)
+        expect(subject.errors).to be_empty
+      end
+
+      it 'is valid with an empty string when element not required' do
+        params.merge!(address1: '')
+        expect(subject.errors).to be_empty
+      end
+
+      it 'is invalid with a 10,000 character string' do
+        params.merge!(address1: 'b'*10_000)
+        expect(subject.errors).not_to be_empty
+        expect(subject.errors[:address1].first).to match(/less than 10000/)
       end
     end
   end
 
-  context 'with country as data_type' do
-    let(:element) { create :form_element, :country, form: form }
-    let(:params) { { form_id: element.form_id, country: 'FR' } }
+  context 'passing a form id' do
+    subject { FormValidator.new(params.merge(form_id: element.form_id)) }
 
-    it 'is valid' do
-      expect(subject).to be_valid
-    end
-
-    context 'is invalid' do
-      it 'with full country name' do
-        params[:country] = 'France'
-        expect(subject).to_not be_valid
-      end
-
-      it 'with a number' do
-        params[:country] = '33'
-        expect(subject).to_not be_valid
-      end
-
-      it 'as lowercase' do
-        params[:country] = 'fr'
-        expect(subject).to_not be_valid
-      end
-    end
+    include_examples 'is correctly validated'
   end
 
-  context 'with zip as data type' do
-    let(:element) { create :form_element, :postal, form: form }
-    let(:country_element) { create :form_element, :country, form: form }
-    let(:us_postal) { '12345' }
-    let(:uk_postal) { 'CR0 3RL' }
-    let(:params) { { form_id: element.form_id, postal: us_postal } }
-
-    context 'is valid' do
-      it 'without a country code' do
-        expect(subject).to be_valid
-      end
-
-      it 'with a valid country code in the UK' do
-        params.merge!(postal: uk_postal, country: :UK)
-        expect(subject).to be_valid
+  context 'passing hashes' do
+    let(:hash_els) do
+      form.form_elements.map do |el| 
+        {name: el.name, required: el.required?, data_type: el.data_type }
       end
     end
 
-    context 'is invalid' do
-      it 'with an incorrect code' do
-        params[:postal] = 'Not a valid zip'
-        expect(subject).to_not be_valid
-      end
+    subject { FormValidator.new(params, hash_els) }
 
-      it 'with a valid code but incorrect country code' do
-        country_element
-        params[:country] = :UK
-        expect(subject).to_not be_valid
-      end
-    end
+    include_examples 'is correctly validated'
   end
 
-  describe 'with text as data type' do
-    let(:element) { create :form_element, form: form, required: false, label: 'Address', name: 'address1' }
-    let(:params) { { form_id: element.form_id, address1: 'b' * 249 } }
-
-    it 'is valid with a 249 character string' do
-      expect(subject.errors).to be_empty
-    end
-
-    it 'is invalid with a 250 character string' do
-      params[:address1] = 'b' * 250
-      expect(subject.errors).not_to be_empty
-      expect(subject.errors[:address1].first).to match(/less than 250/)
-    end
-  end
-
-  describe 'with comment as data type' do
-    let(:element) { create :form_element, :paragraph, form: form, required: false, label: 'Address', name: 'address1' }
-    let(:params) { { form_id: element.form_id, address1: 'b' * 9_999 } }
-
-    it 'is valid with a 9,999 character string' do
-      expect(subject.errors).to be_empty
-    end
-
-    it 'is valid with a nil when element not required' do
-      params[:address1] = nil
-      expect(subject.errors).to be_empty
-    end
-
-    it 'is valid with an empty string when element not required' do
-      params[:address1] = ''
-      expect(subject.errors).to be_empty
-    end
-
-    it 'is invalid with a 10,000 character string' do
-      params[:address1] = 'b' * 10_000
-      expect(subject.errors).not_to be_empty
-      expect(subject.errors[:address1].first).to match(/less than 10000/)
-    end
-  end
 end

--- a/spec/services/form_validator_spec.rb
+++ b/spec/services/form_validator_spec.rb
@@ -1,139 +1,141 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe FormValidator do
-
   shared_examples 'is correctly validated' do
     let(:form) { create :form }
 
-    context "with required as true" do
-      let!(:element) { create :form_element, form: form, required: true, label: 'Address', name: 'address1' }
-      let(:params){ {} }
+    context 'with required as true' do
+      let!(:element) do
+        create :form_element, form: form, required: true, label: 'Address', name: 'address1'
+      end
+      let(:params) { {} }
 
-      it "is valid with value" do
-        params.merge!(address1: 'foo')
+      it 'is valid with value' do
+        params[:address1] = 'foo'
         expect(subject).to be_valid
       end
 
       it 'is valid with value and string key' do
-        params.merge!('address1' => 'bar')
+        params['address1'] = 'bar'
         expect(subject).to be_valid
       end
 
-      context "is invalid" do
-        it "without value" do
+      context 'is invalid' do
+        it 'without value' do
           expect(subject).to_not be_valid
         end
 
-        it "with nil" do
-          params.merge!(address1: nil)
+        it 'with nil' do
+          params[:address1] = nil
           expect(subject).to_not be_valid
         end
 
-        it "with false" do
-          params.merge!(address1: false)
+        it 'with false' do
+          params[:address1] = false
           expect(subject).to_not be_valid
         end
 
-        it "with empty string" do
-          params.merge!(address1: "")
+        it 'with empty string' do
+          params[:address1] = ''
           expect(subject).to_not be_valid
         end
 
-        it "with paragraph data type and empty string" do
+        it 'with paragraph data type and empty string' do
           element.update_attributes(data_type: 'paragraph')
-          params.merge!(address1: "")
+          params[:address1] = ''
           expect(subject).to_not be_valid
         end
       end
     end
 
-    context "with email as data_type" do
+    context 'with email as data_type' do
       let!(:element) { create :form_element, :email, form: form }
-      let(:params){ {email: "foo@example.com"} }
+      let(:params) { { email: 'foo@example.com' } }
 
-      context "is valid" do
-        it "with regular address" do
+      context 'is valid' do
+        it 'with regular address' do
           expect(subject).to be_valid
         end
 
-        it "with multiple dots" do
-          params.merge!(email: "neal.donnelly@cycles.cs.princeton.edu")
+        it 'with multiple dots' do
+          params[:email] = 'neal.donnelly@cycles.cs.princeton.edu'
           expect(subject).to be_valid
         end
       end
 
-      context "is invalid" do
-        it "with a basic sentence" do
-          params.merge!(email: "I'm not an email!")
+      context 'is invalid' do
+        it 'with a basic sentence' do
+          params[:email] = "I'm not an email!"
           expect(subject).to_not be_valid
         end
 
-        it "with missing the TLD" do
-          params.merge!(email: "neal@sumofus")
+        it 'with missing the TLD' do
+          params[:email] = 'neal@sumofus'
           expect(subject).to_not be_valid
         end
 
-        it "with two @ symbols" do
-          params.merge!(email: "this@that@other.com")
+        it 'with two @ symbols' do
+          params[:email] = 'this@that@other.com'
           expect(subject).to_not be_valid
         end
 
         it 'with ascii' do
-          params.merge!(email: "this\xC2@other.com")
+          params[:email] = "this\xC2@other.com"
           expect(subject).to_not be_valid
         end
       end
     end
 
-    context "with phone as data_type" do
+    context 'with phone as data_type' do
       let!(:element) { create :form_element, :phone, form: form }
-      let(:params){ { phone: '00 2323 12345' } }
+      let(:params) { { phone: '00 2323 12345' } }
 
-      context "is valid" do
-        it "with regular numbers" do
+      context 'is valid' do
+        it 'with regular numbers' do
           expect(subject).to be_valid
         end
 
-        it "has spaces, dashes, pluses, and parentheses" do
-          params.merge!(phone: "+1 (413)-555-1234")
+        it 'has spaces, dashes, pluses, and parentheses' do
+          params[:phone] = '+1 (413)-555-1234'
           expect(subject).to be_valid
         end
       end
 
-      context "is invalid" do
-        it "if too short" do
-          params.merge!(phone: "12345")
+      context 'is invalid' do
+        it 'if too short' do
+          params[:phone] = '12345'
           expect(subject).to_not be_valid
         end
 
-        it "with invalid special characters" do
-          params.merge!(phone: "(+) -- (+)")
+        it 'with invalid special characters' do
+          params[:phone] = '(+) -- (+)'
           expect(subject).to_not be_valid
         end
       end
     end
 
-    context "with country as data_type" do
+    context 'with country as data_type' do
       let!(:element) { create :form_element, :country, form: form }
-      let(:params){ { country: 'FR' } }
+      let(:params) { { country: 'FR' } }
 
-      it "is valid" do
+      it 'is valid' do
         expect(subject).to be_valid
       end
 
-      context "is invalid" do
-        it "with full country name" do
-          params.merge!(country: "France")
+      context 'is invalid' do
+        it 'with full country name' do
+          params[:country] = 'France'
           expect(subject).to_not be_valid
         end
 
-        it "with a number" do
-          params.merge!(country: "33")
+        it 'with a number' do
+          params[:country] = '33'
           expect(subject).to_not be_valid
         end
 
-        it "as lowercase" do
-          params.merge!(country: "fr")
+        it 'as lowercase' do
+          params[:country] = 'fr'
           expect(subject).to_not be_valid
         end
       end
@@ -141,7 +143,7 @@ describe FormValidator do
 
     context 'with zip as data type' do
       let!(:element) { create :form_element, :postal, form: form }
-      let(:country_element) { create :form_element, :country, form: form}
+      let(:country_element) { create :form_element, :country, form: form }
       let(:us_postal) { '12345' }
       let(:uk_postal) { 'CR0 3RL' }
       let(:params) { { postal: us_postal } }
@@ -159,13 +161,13 @@ describe FormValidator do
 
       context 'is invalid' do
         it 'with an incorrect code' do
-          params.merge!(postal: 'Not a valid zip')
+          params[:postal] = 'Not a valid zip'
           expect(subject).to_not be_valid
         end
 
         it 'with a valid code but incorrect country code' do
           country_element
-          params.merge!(country: :UK)
+          params[:country] = :UK
           expect(subject).to_not be_valid
         end
       end
@@ -173,39 +175,41 @@ describe FormValidator do
 
     context 'with text as data type' do
       let!(:element) { create :form_element, form: form, required: false, label: 'Address', name: 'address1' }
-      let(:params){  { address1: 'b'*249 } }
+      let(:params) { { address1: 'b' * 249 } }
 
       it 'is valid with a 249 character string' do
         expect(subject.errors).to be_empty
       end
 
       it 'is invalid with a 250 character string' do
-        params.merge!(address1: 'b'*250)
+        params[:address1] = 'b' * 250
         expect(subject.errors).not_to be_empty
         expect(subject.errors[:address1].first).to match(/less than 250/)
       end
     end
 
     context 'with comment as data type' do
-      let!(:element) { create :form_element, :paragraph, form: form, required: false, label: 'Address', name: 'address1' }
-      let(:params){  { address1: 'b'*9_999 } }
+      let!(:element) do
+        create :form_element, :paragraph, form: form, required: false, label: 'Address', name: 'address1'
+      end
+      let(:params) { { address1: 'b' * 9_999 } }
 
       it 'is valid with a 9,999 character string' do
         expect(subject.errors).to be_empty
       end
 
       it 'is valid with a nil when element not required' do
-        params.merge!(address1: nil)
+        params[:address1] = nil
         expect(subject.errors).to be_empty
       end
 
       it 'is valid with an empty string when element not required' do
-        params.merge!(address1: '')
+        params[:address1] = ''
         expect(subject.errors).to be_empty
       end
 
       it 'is invalid with a 10,000 character string' do
-        params.merge!(address1: 'b'*10_000)
+        params[:address1] = 'b' * 10_000
         expect(subject.errors).not_to be_empty
         expect(subject.errors[:address1].first).to match(/less than 10000/)
       end
@@ -220,8 +224,8 @@ describe FormValidator do
 
   context 'passing hashes' do
     let(:hash_els) do
-      form.form_elements.map do |el| 
-        {name: el.name, required: el.required?, data_type: el.data_type }
+      form.form_elements.map do |el|
+        { name: el.name, required: el.required?, data_type: el.data_type }
       end
     end
 
@@ -229,5 +233,4 @@ describe FormValidator do
 
     include_examples 'is correctly validated'
   end
-
 end

--- a/spec/services/page_updater_spec.rb
+++ b/spec/services/page_updater_spec.rb
@@ -242,8 +242,9 @@ describe PageUpdater do
         allow(ShareProgressVariantBuilder).to receive(:update) { error_variant }
         allow(ShareProgressVariantBuilder).to receive(:create) { error_variant }
         expect(pupdater.update(update_params.merge(create_params))).to eq false
-        expect(pupdater.errors)
-          .to eq(share_twitter_12: { description: "can't be blank" }, share_twitter_1: { description: "can't be blank" })
+        expect(pupdater.errors).to eq(
+          share_twitter_12: { description: "can't be blank" }, share_twitter_1: { description: "can't be blank" }
+        )
       end
     end
   end

--- a/spec/services/search/page_searcher/multiple_criterion_search/multiple_search_spec.rb
+++ b/spec/services/search/page_searcher/multiple_criterion_search/multiple_search_spec.rb
@@ -45,13 +45,15 @@ describe 'Search ::' do
         end
 
         it 'finds all pages that match the specified array of campaigns' do
-          expect(finds_pages_for_all_campaigns.search).to match_array([
-                                                                        content_tag_plugin_layout_match,
-                                                                        title_language_campaign_match,
-                                                                        matches_by_content_language_campaign_tags_layout,
-                                                                        matches_by_content_language_campaign,
-                                                                        matches_by_content_language_tags_layout
-                                                                      ])
+          expect(
+            finds_pages_for_all_campaigns.search
+          ).to match_array([
+                            content_tag_plugin_layout_match,
+                            title_language_campaign_match,
+                            matches_by_content_language_campaign_tags_layout,
+                            matches_by_content_language_campaign,
+                            matches_by_content_language_tags_layout
+                          ])
         end
 
         it 'finds no pages when a search is done with a combination of tags that exists for no page' do


### PR DESCRIPTION
The validations on our Member model are extremely permissive. This is to allow the campaigners to put essentially whatever validation they want or don't want on the action form, and we will save it to the database. This works well, but the member signup endpoint used by the homepage needs to have some validation itself.

Rather than create a member signup form object in the database and making the endpoint count on that, I instead made the FormValidator service class accept either a form id or a hash of validations, as you can see in the controller and in the spec.