### PR TITLE
Remove include of NumberHelper into global namespace.

### DIFF
--- a/app/models/plugins/thermometer.rb
+++ b/app/models/plugins/thermometer.rb
@@ -1,5 +1,3 @@
-include ActionView::Helpers::NumberHelper
-
 class Plugins::Thermometer < ActiveRecord::Base
   belongs_to :page, touch: true
 
@@ -30,8 +28,8 @@ class Plugins::Thermometer < ActiveRecord::Base
   def liquid_data(supplemental_data={})
     attributes.merge(
       percentage: current_progress,
-      remaining: number_with_delimiter(goal - current_total),
-      signatures: number_with_delimiter(current_total),
+      remaining: ActionController::Base.helpers.number_with_delimiter(goal - current_total),
+      signatures: ActionController::Base.helpers.number_with_delimiter(current_total),
       goal_k: abbreviate_number(goal)
     )
   end

--- a/spec/models/plugins/thermometer_spec.rb
+++ b/spec/models/plugins/thermometer_spec.rb
@@ -46,6 +46,17 @@ describe Plugins::Thermometer do
       allow(thermometer).to receive(:goal).and_return(700)
       expect(thermometer.liquid_data[:goal_k]).to eq '700'
     end
+
+    it 'serializes the amount of remaining signatures as number with delimiter' do
+      allow(thermometer).to receive(:goal).and_return(5_000)
+      allow(thermometer).to receive(:current_total).and_return(1_300)
+      expect(thermometer.liquid_data[:remaining]).to eq "3,700"
+    end
+
+    it 'serializes the number of signatures as number with delimiter' do
+      allow(thermometer).to receive(:current_total).and_return(1_300)
+      expect(thermometer.liquid_data[:signatures]).to eq "1,300"
+    end
   end
 
   describe "#goal" do


### PR DESCRIPTION
```include ActionView::Helpers::NumberHelper``` polutes the global namespace. 

If those helpers are needed in a model, then they can be accessed through ```ActionController::Base.helpers```