### PR TITLE
Change default post-petition share to use commitment gap ui

### DIFF
--- a/app/assets/stylesheets/sumofus/pages/share.scss
+++ b/app/assets/stylesheets/sumofus/pages/share.scss
@@ -71,3 +71,10 @@
     }
   }
 }
+
+.two-step {
+  &__button {
+    width: 145px;
+    float: left;
+  }
+}

--- a/app/liquid/views/layouts/post-petition-share.liquid
+++ b/app/liquid/views/layouts/post-petition-share.liquid
@@ -1,7 +1,7 @@
-{% comment %} Description: A follow-up page thanking for signing a petition and asking to share {% endcomment %}
+{% comment %} Description: A follow-up page asking two share with a two step UI {% endcomment %}
 {% comment %} Post-action layout: true {% endcomment %}
 
 {% capture confirmation %}{{ 'petition.confirmation' | t }}{% endcapture %}
 {% capture message %}{{ 'petition.thank_you' | val: 'petition_title', title | t }}{% endcapture %}
-{% include 'Share Page', message: message, confirmation: confirmation %}
-{% include 'Simple Footer', extra_class: 'simple-footer--stuck-to-bottom' %}
+{% include 'Two Step Share Page', message: message, confirmation: confirmation %}
+{% include 'Small Image Footer', extra_class: 'simple-footer--stuck-to-bottom' %}

--- a/app/liquid/views/layouts/simple-post-petition-share.html
+++ b/app/liquid/views/layouts/simple-post-petition-share.html
@@ -1,0 +1,7 @@
+{% comment %} Description: A follow-up page thanking for signing a petition and asking to share {% endcomment %}
+{% comment %} Post-action layout: true {% endcomment %}
+
+{% capture confirmation %}{{ 'petition.confirmation' | t }}{% endcapture %}
+{% capture message %}{{ 'petition.thank_you' | val: 'petition_title', title | t }}{% endcapture %}
+{% include 'Share Page', message: message, confirmation: confirmation %}
+{% include 'Simple Footer', extra_class: 'simple-footer--stuck-to-bottom' %}

--- a/app/liquid/views/partials/_share.liquid
+++ b/app/liquid/views/partials/_share.liquid
@@ -1,3 +1,15 @@
+<style type="text/css">
+  .button--facebook a::before{
+    content: "{{ 'share.share' | t }}";
+  }
+  .button--twitter a::before{
+    content: "{{ 'share.tweet' | t }}";
+  }
+  .share-buttons__simple-email-link.sp_em_small a::before, .share-buttons__simple-email-link.sp_em_large a::before {
+    content: "{{ 'share.send_email' | t }}";
+  }
+</style>
+
 <div class="share-buttons">
   {% unless shares['facebook'] == blank %}
     <div class="share-buttons__button button--facebook {{ shares['facebook'] }}"></div>

--- a/app/liquid/views/partials/_share_page.liquid
+++ b/app/liquid/views/partials/_share_page.liquid
@@ -1,16 +1,3 @@
-<style type="text/css">
-  .button--facebook a::before{
-    content: "{{ 'share.share' | t }}";
-  }
-  .button--twitter a::before{
-    content: "{{ 'share.tweet' | t }}";
-  }
-  .share-buttons__simple-email-link.sp_em_small a::before, .share-buttons__simple-email-link.sp_em_large a::before {
-    content: "{{ 'share.send_email' | t }}";
-  }
-</style>
-
-
 <div class="header-logo header-logo--light">
   <a href="{{ 'footer.home_url' | t }}">
     <div class="header-logo__logo sumofus-logo--positive"></div>
@@ -25,7 +12,7 @@
       <h1 class="thank-you__thanks">{{ message }}</h1>
       <div class="thank-you__cta">{{ 'share.cta' | t }}</div>
 
-      <div class="medium-photo center-content__centered-element">
+      <div class="center-content__centered-element">
         {% include 'Share' %}
       </div>
     </div>

--- a/app/liquid/views/partials/_simple_footer.liquid
+++ b/app/liquid/views/partials/_simple_footer.liquid
@@ -1,4 +1,4 @@
-<div class="simple-footer">
+<div class="simple-footer {{ extra_class }}">
   <div class="center-content">
     <div class="center-content__one-column">
       <div class="simple-footer__logo sumofus-logo--negative"></div>

--- a/app/liquid/views/partials/_two_step_share_page.liquid
+++ b/app/liquid/views/partials/_two_step_share_page.liquid
@@ -1,0 +1,54 @@
+<div class="header-logo header-logo--light">
+  <a href="{{ 'footer.home_url' | t }}">
+    <div class="header-logo__logo sumofus-logo--positive"></div>
+  </a>
+</div>
+
+<div class="center-content">
+  <div class="center-content__one-column">
+
+    <div class="center-content__central-square">
+
+      <h1 class="thank-you__thanks">{{ message }}</h1>
+      <div class="thank-you__cta">
+        <span class="two-step__question">{{ 'share.two_step.cta' | t }}</span>
+        <span class="two-step__declined hidden-closed">{{ 'share.two_step.declined' | t }}</span>
+        <span class="two-step__accepted hidden-closed">{{ 'share.two_step.accepted' | t }}</span>
+      </div>
+
+      <div class="center-content__centered-element">
+        <div class="two-step__question">
+          <div class="share-buttons">
+            <div class="share-buttons__button button two-step__button two-step__accept">
+              {{ 'share.two_step.accept' | t }}
+            </div>
+            <div class="share-buttons__button button two-step__button two-step__decline">
+              {{ 'share.two_step.decline' | t }}
+            </div>
+          </div>
+        </div>
+        </div>
+        <div class="two-step__accepted hidden-closed">
+          {% include 'Share' %}
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script type="text/javascript">
+  $(document).ready(function(){
+    $('.two-step__accept').on('click', function(){
+      $('.two-step__question').addClass('hidden-closed');
+      $('.two-step__declined').addClass('hidden-closed');
+      $('.two-step__accepted').removeClass('hidden-closed');
+    });
+    $('.two-step__decline').on('click', function(){
+      $('.two-step__question').addClass('hidden-closed');
+      $('.two-step__accepted').addClass('hidden-closed');
+      $('.two-step__declined').removeClass('hidden-closed');
+    });
+  });
+</script>
+

--- a/config/locales/sumofus.de.yml
+++ b/config/locales/sumofus.de.yml
@@ -75,6 +75,12 @@ de:
     share: Facebook
     tweet: Twitter
     twitter_handle: '@sumofus_de'
+    two_step:
+      cta: "Würden Sie die Kampagne jetzt auch mit Ihren Freunden teilen?"
+      accept: 'Ja'
+      decline: 'Nein'
+      declined: "Sie möchten die Kampagne nicht teilen? Kein Problem. Vielen Dank für Ihre Unterstützung!"
+      accepted: "Herzlichen Dank! Je mehr Menschen sich engagieren, desto mehr können wir bewegen!"
   errors:
     probably_invalid: sieht nicht richtig aus
     is_invalid: ist ungültig

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -75,6 +75,12 @@ en:
     share: Share
     tweet: Tweet
     twitter_handle: '@sumofus'
+    two_step:
+      cta: Now, will you share the campaign with your friends to help us win?
+      accept: 'Yes'
+      decline: 'No'
+      declined: "Not a sharer? No problem. Thanks for your support!"
+      accepted: "Thanks so much! The more of us we have, the stronger our movement."
   errors:
     probably_invalid: doesn't look right
     is_invalid: is invalid

--- a/config/locales/sumofus.en.yml
+++ b/config/locales/sumofus.en.yml
@@ -80,7 +80,7 @@ en:
       accept: 'Yes'
       decline: 'No'
       declined: "Not a sharer? No problem. Thanks for your support!"
-      accepted: "Thanks so much! The more of us we have, the stronger our movement."
+      accepted: "Thanks so much! The more of us who stand together, the stronger our movement."
   errors:
     probably_invalid: doesn't look right
     is_invalid: is invalid

--- a/config/locales/sumofus.fr.yml
+++ b/config/locales/sumofus.fr.yml
@@ -75,6 +75,12 @@ fr:
     share: Partagez
     tweet: Tweetez
     twitter_handle: '@sumofus_fr'
+    two_step:
+      cta: 'Pouvez-vous partager maintenant la campagne avec vos ami-e-s afin de nous aider à gagner ?'
+      accept: 'Oui'
+      decline: 'Non'
+      declined: "Vous ne souhaitez pas partager ? Aucun problème. Merci de votre soutien !"
+      accepted: "Merci beaucoup ! Plus nous serons nombreux à nous mobiliser, plus notre mouvement sera fort."
   errors:
     probably_invalid: semble invalide
     is_invalid: est invalide


### PR DESCRIPTION
Testing found a >25% increase in sharing rates if we asked people if they would share befoe showing them the share buttons, so that UI is going out standard to all the SumOfUs share pages. 
![two-step-share](https://cloud.githubusercontent.com/assets/102218/17681698/8372e6d8-6304-11e6-9fea-be6225135324.gif)
