### PR TITLE
Fix a bug in direct debit decider that showed it too often

### DIFF
--- a/app/services/direct_debit_decider.rb
+++ b/app/services/direct_debit_decider.rb
@@ -15,7 +15,7 @@ class DirectDebitDecider
 
   def decide
     return true if (@member_countries & ALWAYS_COUNTRIES).any?
-    member_country_shows_when_recurring = (@member_countries & ONLY_RECURRING_COUNTRIES)
+    member_country_shows_when_recurring = (@member_countries & ONLY_RECURRING_COUNTRIES).any?
     return true if (@recurring && member_country_shows_when_recurring)
     return false
   end

--- a/spec/services/direct_debit_decider_spec.rb
+++ b/spec/services/direct_debit_decider_spec.rb
@@ -71,17 +71,17 @@ describe DirectDebitDecider do
 
         it 'returns false when country list is empty' do
           decision = DirectDebitDecider.decide([], recurring_default)
-          expect(decision).to eq(recurring)
+          expect(decision).to eq(false)
         end
 
         it 'returns false when country is unknown' do
           decision = DirectDebitDecider.decide(['RD', ''], recurring_default)
-          expect(decision).to eq(recurring)
+          expect(decision).to eq(false)
         end
 
         it 'returns false when country list has no direct debit countries' do
           decision = DirectDebitDecider.decide(['US', 'MX', 'GH', 'IN'], recurring_default)
-          expect(decision).to eq(recurring)
+          expect(decision).to eq(false)
         end
       end
     end


### PR DESCRIPTION
This fixes a bug that was displaying the direct debit option to all users, regardless of country, for pages whose fundraisers were set as `recurring_default` or `recurring_only`. Two mistakes allowed this to happen -

- The tests that should have been testing for false were testing for a value that is set to be true or false whether the page is recurring only. 
- in the tested code, I forgot that `[]` is truthy and should have called `.any?`

😞 