### PR TITLE
Provide UI for toggling featured attribute on page

### DIFF
--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -41,3 +41,7 @@
 .page-filter-form {
   margin-top: 20px
 }
+
+#pages-table .toggle-featured a {
+  color: black;
+}

--- a/app/controllers/featured_pages_controller.rb
+++ b/app/controllers/featured_pages_controller.rb
@@ -1,0 +1,25 @@
+class FeaturedPagesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :find_page, only: [:create, :destroy]
+
+  def create
+    @page.update(featured: true)
+    respond_to do |format|
+      format.js { render :show }
+    end
+  end
+
+  def destroy
+    @page.update(featured: false)
+
+    respond_to do |format|
+      format.js { render :show }
+    end
+  end
+
+  private
+
+  def find_page
+    @page ||= Page.find(params[:id])
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -94,6 +94,5 @@ class PagesController < ApplicationController
     params[:search] ||= {}
     params[:search].reverse_merge default_params
   end
-
 end
 

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -144,4 +144,16 @@ module PagesHelper
     end
     msg
   end
+
+  def toggle_featured_link(page)
+    method = page.featured? ? :delete : :post
+    klass = 'glyphicon glyphicon-star'
+    klass << '-empty' unless page.featured?
+
+    path = page.featured? ? featured_page_path(page) : featured_pages_path(id: page.id)
+
+    link_to path, method: method, remote: true do
+      content_tag :span, '', class: klass
+    end
+  end
 end

--- a/app/views/featured_pages/show.js.erb
+++ b/app/views/featured_pages/show.js.erb
@@ -1,0 +1,2 @@
+var html = "<%= j(render(partial: 'pages/featured_column', locals: {page: @page})) %>"
+$("#page-<%= @page.id %> .toggle-featured").replaceWith(html);

--- a/app/views/pages/_featured_column.slim
+++ b/app/views/pages/_featured_column.slim
@@ -1,0 +1,3 @@
+td.toggle-featured data={sort: "#{page.featured?}", search: "#{page.featured? ? 'featured' : ''}"}
+  = toggle_featured_link(page)
+

--- a/app/views/pages/index.slim
+++ b/app/views/pages/index.slim
@@ -17,20 +17,21 @@
             th = t('common.created')
             th = t('common.modified')
             th = t('.action_count')
-            th
+            th = t('.table.featured')
             th
             th
             th
             th
         tbody
           - @pages.each do |page|
-            tr
-              td = page.title
+            tr id="page-#{page.id}"
+              th = link_to page.title, member_facing_page_path(page)
+
               td = t('.' + page.publish_status)
               td = page.created_at.strftime('%Y-%b-%d')
               td = page.updated_at.strftime('%Y-%b-%d')
               td = page.action_count
-              td = link_to t('pages.edit.view'), member_facing_page_path(page)
+              = render(partial: 'featured_column', locals: {page: page})
               td = link_to_if !page.archived?, t('common.edit'), edit_page_path(page)
               td = link_to t('.stats'), analytics_page_path(page)
               td = link_to_if !page.archived?, t('menu.clone'), new_clone_page_path(id: page.id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-
   if Settings.google_verification
     match "/#{Settings.google_verification}.html", to: proc { |env| [200, {}, ["google-site-verification: #{Settings.google_verification}.html"]] }, via: :get
   end
@@ -38,6 +37,8 @@ Rails.application.routes.draw do
   resources :donation_bands, except: [:show, :destroy]
 
   resources :clone_pages
+
+  resources :featured_pages, except: [:show, :new, :edit]
 
   resources :pages do
     namespace :share do

--- a/spec/controllers/featured_pages_controller_spec.rb
+++ b/spec/controllers/featured_pages_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe FeaturedPagesController do
+  let(:user) { double('User') }
+  let(:page) { double('Page') }
+
+  before do
+    allow(request.env['warden']).to receive(:authenticate!) { user }
+    allow(Page).to receive(:find){ page }
+    allow(page).to receive(:update)
+  end
+
+  describe "POST #create" do
+    before do
+      post :create, id: '1', format: :js
+    end
+
+    it "finds page" do
+      expect(Page).to have_received(:find).with('1')
+    end
+
+    it 'sets page#featured to true' do
+      expect(page).to have_received(:update).with(featured: true)
+    end
+
+    it 'renders show template' do
+      expect(response).to render_template(:show)
+    end
+  end
+
+  describe "DELETE #destroy" do
+    before do
+      delete :destroy, id: '1', format: :js
+    end
+
+    it "finds page" do
+      expect(Page).to have_received(:find).with('1')
+    end
+
+    it 'sets page#featured to false' do
+      expect(page).to have_received(:update).with(featured: false)
+    end
+
+    it 'renders show template' do
+      expect(response).to render_template(:show)
+    end
+  end
+end

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -197,4 +197,36 @@ describe PagesHelper do
       )
     end
   end
+
+  describe 'toggle_featured_link' do
+    subject { helper.toggle_featured_link(page) }
+
+    context 'when page is featured' do
+      let(:page) { double(featured?: true, to_param: '1', id: '1') }
+
+      describe 'rendering' do
+        it 'with correct data-method' do
+          expect(subject).to match(/data-method="delete"/)
+        end
+
+        it 'with correct path' do
+          expect(subject).to match(/featured_pages\/1/)
+        end
+      end
+    end
+
+    context 'when page is not featured' do
+      let(:page) { double(featured?: false, to_param: '1', id: '1') }
+
+      describe 'rendering' do
+        it 'with correct data-method' do
+          expect(subject).to match(/data-method="post"/)
+        end
+
+        it 'with correct path' do
+          expect(subject).to match(/featured_pages\?id=1/)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Provides a toggle switch on the page's index view, allowing campaigners to organise what pages should appear on the homepage. The featured flag is searchable and sortable, so it's quick to search and filter on this attribute.