### PR TITLE
404 webhook

### DIFF
--- a/app/controllers/api/members_controller.rb
+++ b/app/controllers/api/members_controller.rb
@@ -16,5 +16,4 @@ class Api::MembersController < ApplicationController
   def member_params
     params.permit(:name, :email, :country, :postal)
   end
-
 end

--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -8,8 +8,12 @@ class Api::Payment::BraintreeController < PaymentController
 
   def webhook
     webhook_notification = Braintree::WebhookNotification.parse(params[:bt_signature], params[:bt_payload])
-    client::WebhookHandler.handle(webhook_notification)
-    render json: { success: true }
+
+    if client::WebhookHandler.handle(webhook_notification)
+      head :ok
+    else
+      head :not_found
+    end
   end
 
   private

--- a/app/helpers/api/pages_helper.rb
+++ b/app/helpers/api/pages_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Api::PagesHelper
   def image_url(page)
     path = page.primary_image.try(:content).try(:url, :medium)
@@ -5,4 +6,3 @@ module Api::PagesHelper
     URI.join(ActionController::Base.asset_host, path).to_s
   end
 end
-

--- a/lib/payment_processor/braintree/webhook_handler.rb
+++ b/lib/payment_processor/braintree/webhook_handler.rb
@@ -56,7 +56,7 @@ module PaymentProcessor
           }
         )
 
-        return true
+        true
       end
 
       # This method should only be called if @notification.subscription is a subscription object

--- a/lib/payment_processor/braintree/webhook_handler.rb
+++ b/lib/payment_processor/braintree/webhook_handler.rb
@@ -41,7 +41,7 @@ module PaymentProcessor
       def handle_subscription_charged
         if original_action.blank?
           Rails.logger.info("Failed to handle Braintree::WebhookNotification for subscription_id '#{@notification.subscription.id}'")
-          return
+          return false
         end
 
         customer = Payment::Braintree::Customer.find_by(member_id: original_action.member_id)
@@ -55,6 +55,8 @@ module PaymentProcessor
             recurring_id: original_action.form_data['subscription_id']
           }
         )
+
+        return true
       end
 
       # This method should only be called if @notification.subscription is a subscription object

--- a/spec/controllers/api/payment/braintree_controller_spec.rb
+++ b/spec/controllers/api/payment/braintree_controller_spec.rb
@@ -179,7 +179,7 @@ describe Api::Payment::BraintreeController do
 
     before :each do
       allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle)
-      allow(Braintree::WebhookNotification).to receive(:parse){ notification }
+      allow(Braintree::WebhookNotification).to receive(:parse) { notification }
     end
 
     describe 'handling payload' do
@@ -192,16 +192,15 @@ describe Api::Payment::BraintreeController do
       end
 
       it 'handles webhook' do
-        expect(PaymentProcessor::Braintree::WebhookHandler).to have_received(:handle).
-          with(notification)
+        expect(PaymentProcessor::Braintree::WebhookHandler).to have_received(:handle)
+          .with(notification)
       end
     end
-
 
     describe 'response' do
       context 'successful handling' do
         before do
-          allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle){ true }
+          allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle) { true }
           post :webhook
         end
 
@@ -212,7 +211,7 @@ describe Api::Payment::BraintreeController do
 
       context 'unsuccessful handling' do
         before do
-          allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle){ false }
+          allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle) { false }
           post :webhook
         end
 

--- a/spec/controllers/api/payment/braintree_controller_spec.rb
+++ b/spec/controllers/api/payment/braintree_controller_spec.rb
@@ -175,39 +175,51 @@ describe Api::Payment::BraintreeController do
   end
 
   describe 'POST webhook' do
-    let(:supported_webhook) { Braintree::WebhookTesting.sample_notification(Braintree::WebhookNotification::Kind::SubscriptionChargedSuccessfully, 'test_id') }
-    let(:unsupported_webhook) { Braintree::WebhookTesting.sample_notification(Braintree::WebhookNotification::Kind::SubscriptionCanceled, 'test_id') }
+    let(:notification) { double }
 
     before :each do
       allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle)
+      allow(Braintree::WebhookNotification).to receive(:parse){ notification }
     end
 
-    it 'parses a supported webhook and passes it to the Webhook handler' do
-      post :webhook, supported_webhook
-      expect(
-        PaymentProcessor::Braintree::WebhookHandler
-      ).to have_received(:handle).with(
-        an_instance_of(Braintree::WebhookNotification)
-      )
+    describe 'handling payload' do
+      before do
+        post :webhook, bt_signature: 'foo', bt_payload: 'bar'
+      end
+      it 'parses webhook payload' do
+        expect(Braintree::WebhookNotification).to have_received(:parse)
+          .with('foo', 'bar')
+      end
+
+      it 'handles webhook' do
+        expect(PaymentProcessor::Braintree::WebhookHandler).to have_received(:handle).
+          with(notification)
+      end
     end
 
-    it 'parse an unsupported_webhook and passes it to the Webhook handler' do
-      post :webhook, unsupported_webhook
-      expect(
-        PaymentProcessor::Braintree::WebhookHandler
-      ).to have_received(:handle).with(
-        an_instance_of(Braintree::WebhookNotification)
-      )
-    end
 
-    it 'responds 200 to supported_webhook' do
-      post :webhook, supported_webhook
-      expect(response.status).to eq 200
-    end
+    describe 'response' do
+      context 'successful handling' do
+        before do
+          allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle){ true }
+          post :webhook
+        end
 
-    it 'responds 200 to unsupported_webhook' do
-      post :webhook, unsupported_webhook
-      expect(response.status).to eq 200
+        it 'returns OK' do
+          expect(response.status).to eq(200)
+        end
+      end
+
+      context 'unsuccessful handling' do
+        before do
+          allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle){ false }
+          post :webhook
+        end
+
+        it 'returns not found' do
+          expect(response.status).to eq(404)
+        end
+      end
     end
   end
 end

--- a/spec/helpers/api/pages_helper_spec.rb
+++ b/spec/helpers/api/pages_helper_spec.rb
@@ -1,7 +1,7 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe Api::PagesHelper do
-
   describe 'image_url' do
     describe 'returns empty string when page' do
       it 'has no image' do
@@ -21,7 +21,7 @@ describe Api::PagesHelper do
     end
 
     it 'raises NoMethodError if page is not a Page' do
-        expect{ helper.image_url(nil) }.to raise_error(NoMethodError)
+      expect { helper.image_url(nil) }.to raise_error(NoMethodError)
     end
 
     it 'returns image url when asset_host is a string and content url is a path' do

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -121,7 +121,6 @@ describe 'Braintree API' do
             subject
             expect(response.status).to eq 404
           end
-
         end
       end
 

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -109,6 +109,20 @@ describe 'Braintree API' do
         end
 
         include_examples 'has no unintended consequences'
+
+        context 'missing subscription' do
+          let(:notification) do
+            Braintree::WebhookTesting.sample_notification(
+              Braintree::WebhookNotification::Kind::SubscriptionChargedSuccessfully, 'xxx'
+            )
+          end
+
+          it 'returns not found' do
+            subject
+            expect(response.status).to eq 404
+          end
+
+        end
       end
 
       describe 'for paypal' do

--- a/spec/services/search/page_searcher/multiple_criterion_search/multiple_search_spec.rb
+++ b/spec/services/search/page_searcher/multiple_criterion_search/multiple_search_spec.rb
@@ -48,12 +48,12 @@ describe 'Search ::' do
           expect(
             finds_pages_for_all_campaigns.search
           ).to match_array([
-                            content_tag_plugin_layout_match,
-                            title_language_campaign_match,
-                            matches_by_content_language_campaign_tags_layout,
-                            matches_by_content_language_campaign,
-                            matches_by_content_language_tags_layout
-                          ])
+                             content_tag_plugin_layout_match,
+                             title_language_campaign_match,
+                             matches_by_content_language_campaign_tags_layout,
+                             matches_by_content_language_campaign,
+                             matches_by_content_language_tags_layout
+                           ])
         end
 
         it 'finds no pages when a search is done with a combination of tags that exists for no page' do


### PR DESCRIPTION
We're currently returning `200` for all webhook notifications posted by braintree. Occasionally we get a race-condition where we're trying to update a subscription that hasn't been created yet. By not returning `200`, the notification will be re-posted an hour later.