### PR TITLE
make toggle switches work for both plugin state and page publishing

### DIFF
--- a/app/assets/javascripts/plugins_toggle.js
+++ b/app/assets/javascripts/plugins_toggle.js
@@ -39,8 +39,12 @@ const setupOnce = require('setup_once');
       this.toggleState();
     },
 
-    toggleState: function(){
-      this.state = this.state === 'published' ? 'unpublished' : 'published';
+    toggleState: function(e){
+      if ($(e.target).find('input.onoffswitch__checkbox').hasClass('use-publish-states')) {
+        this.state = (this.state === 'published') ? 'unpublished' : 'published';
+      } else {
+        this.state = (this.state === 'true') ? 'false' : 'true';
+      }
       this.$stateInput.val(this.state);
     },
   });

--- a/app/views/pages/_edit_sidebar.slim
+++ b/app/views/pages/_edit_sidebar.slim
@@ -19,7 +19,7 @@
           = f.hidden_field :publish_status, class: 'activation-toggle-field', value: page.publish_status, "data-confirm-turning-off" => "Are you sure you want to unpublish this page? It will become inaccessible except to logged-in campaigners."
           .page-edit-bar__toggle-title Publish
           .page-edit-bar__toggle-btns
-            = render 'shared/binary_switch', checked: page.published?
+            = render 'shared/binary_switch', checked: page.published?, publish: true
     .page-edit-bar__last-saved
     .page-edit-bar__error-message
     .page-edit-bar__btn-holder.page-edit-bar__btn-holder--hidden

--- a/app/views/shared/_binary_switch.slim
+++ b/app/views/shared/_binary_switch.slim
@@ -1,6 +1,8 @@
+- publish ||= false
+- publish_class = publish ? 'use-publish-states' : ''
 - uuid = rand(10000)
 .onoffswitch
-  input.onoffswitch__checkbox type="checkbox" name="onoffswitch__#{uuid}" id="myonoffswitch__#{uuid}" checked=checked
+  input.onoffswitch__checkbox type="checkbox" name="onoffswitch__#{uuid}" class="#{publish_class}" id="myonoffswitch__#{uuid}" checked=checked
   label.onoffswitch__label for="myonoffswitch__#{uuid}"
     span.onoffswitch__inner
     span.onoffswitch__switch


### PR DESCRIPTION
Currently, the plugin on-off switches are broken on prod. Rodrigo's change to allow featured pages didn't take those switches into account, and this PR fixes that up.