### PR TITLE
Model for storing braintree webhook notifications

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -7,9 +7,7 @@ class Api::Payment::BraintreeController < PaymentController
   end
 
   def webhook
-    webhook_notification = Braintree::WebhookNotification.parse(params[:bt_signature], params[:bt_payload])
-
-    if client::WebhookHandler.handle(webhook_notification)
+    if client::WebhookHandler.handle(params[:bt_signature], params[:bt_payload])
       head :ok
     else
       head :not_found

--- a/app/models/payment/braintree/notification.rb
+++ b/app/models/payment/braintree/notification.rb
@@ -1,0 +1,2 @@
+class Payment::Braintree::Notification < ActiveRecord::Base
+end

--- a/db/migrate/20160906155851_create_payment_braintree_notifications.rb
+++ b/db/migrate/20160906155851_create_payment_braintree_notifications.rb
@@ -1,0 +1,10 @@
+class CreatePaymentBraintreeNotifications < ActiveRecord::Migration
+  def change
+    create_table :payment_braintree_notifications do |t|
+      t.text :payload
+      t.text :signature
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160802225329) do
+ActiveRecord::Schema.define(version: 20160906155851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -233,6 +233,13 @@ ActiveRecord::Schema.define(version: 20160802225329) do
   end
 
   add_index "payment_braintree_customers", ["member_id"], name: "index_payment_braintree_customers_on_member_id", using: :btree
+
+  create_table "payment_braintree_notifications", force: :cascade do |t|
+    t.text     "payload"
+    t.text     "signature"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "payment_braintree_payment_methods", force: :cascade do |t|
     t.string   "token"

--- a/spec/controllers/api/payment/braintree_controller_spec.rb
+++ b/spec/controllers/api/payment/braintree_controller_spec.rb
@@ -175,25 +175,18 @@ describe Api::Payment::BraintreeController do
   end
 
   describe 'POST webhook' do
-    let(:notification) { double }
-
     before :each do
       allow(PaymentProcessor::Braintree::WebhookHandler).to receive(:handle)
-      allow(Braintree::WebhookNotification).to receive(:parse) { notification }
     end
 
     describe 'handling payload' do
       before do
         post :webhook, bt_signature: 'foo', bt_payload: 'bar'
       end
-      it 'parses webhook payload' do
-        expect(Braintree::WebhookNotification).to have_received(:parse)
-          .with('foo', 'bar')
-      end
 
-      it 'handles webhook' do
+      it 'handles webhook notification' do
         expect(PaymentProcessor::Braintree::WebhookHandler).to have_received(:handle)
-          .with(notification)
+          .with('foo', 'bar')
       end
     end
 

--- a/spec/factories/payment_braintree_notifications.rb
+++ b/spec/factories/payment_braintree_notifications.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :payment_braintree_notification, class: 'Payment::Braintree::Notification' do
+    payload "MyText"
+    signature "MyText"
+  end
+end


### PR DESCRIPTION
To keep track of ALL notifications from braintree for good book keeping and event replaying.