### PR TITLE
Fix bug where clone page double-created plugins

### DIFF
--- a/app/services/page_cloner.rb
+++ b/app/services/page_cloner.rb
@@ -29,6 +29,7 @@ class PageCloner
     @cloned_page.title = @title unless @title.blank?
 
     ActiveRecord::Base.transaction do
+      @cloned_page.save # so the new page will have an id to associate with
       yield(self)
       @cloned_page.save
     end


### PR DESCRIPTION
The PageCloner had a bug where the cloned page wasn't saved before it started duplicating associations, so if a page had no links, the first time the cloned page was saved was when the first duplicated plugin was associated with the cloned page. Because pages check for their plugins on save, the plugins were getting created twice, and cloned pages had double all the plugins.