### PR TITLE
Stop required checkbox in action forms accepting unchecked boxes

### DIFF
--- a/app/services/form_validator.rb
+++ b/app/services/form_validator.rb
@@ -48,6 +48,7 @@ class FormValidator
     validate_email(value, form_element)
     validate_postal(value, form_element)
     validate_required(value, form_element)
+    validate_checkbox(value, form_element)
   end
 
   def validate_length(value, form_element)
@@ -60,6 +61,12 @@ class FormValidator
 
   def validate_required(value, form_element)
     return unless form_element[:required] && value.blank?
+    @errors[form_element[:name]] << I18n.t('validation.is_required')
+  end
+
+  def validate_checkbox(value, form_element)
+    return unless form_element[:data_type] == 'checkbox' && form_element[:required]
+    return if value.present? && !!value && value.to_s != '0'
     @errors[form_element[:name]] << I18n.t('validation.is_required')
   end
 

--- a/spec/factories/form_elements.rb
+++ b/spec/factories/form_elements.rb
@@ -54,5 +54,11 @@ FactoryGirl.define do
       name      'comment'
       data_type 'paragraph'
     end
+
+    trait :checkbox do
+      label     'I agree'
+      name      'agrees'
+      data_type 'checkbox'
+    end
   end
 end

--- a/spec/services/form_validator_spec.rb
+++ b/spec/services/form_validator_spec.rb
@@ -49,7 +49,7 @@ describe FormValidator do
       end
     end
 
-    context 'with checkbox as data_type', :focus do
+    context 'with checkbox as data_type' do
       let!(:element) { create :form_element, :checkbox, form: form, required: true, name: 'action_box_agrees' }
       let(:params) { {} }
 

--- a/spec/services/form_validator_spec.rb
+++ b/spec/services/form_validator_spec.rb
@@ -49,6 +49,40 @@ describe FormValidator do
       end
     end
 
+    context 'with checkbox as data_type', :focus do
+      let!(:element) { create :form_element, :checkbox, form: form, required: true, name: 'action_box_agrees' }
+      let(:params) { {} }
+
+      it 'is valid with value 1' do
+        params[:action_box_agrees] = 1
+        expect(subject).to be_valid
+      end
+
+      it 'is valid with string value' do
+        params[:action_box_agrees] = 'true'
+        expect(subject).to be_valid
+      end
+
+      it 'is invalid when nil' do
+        params[:action_box_agrees] = nil
+        expect(subject).not_to be_valid
+      end
+
+      it 'is invalid when not included' do
+        expect(subject).not_to be_valid
+      end
+
+      it 'is invalid when number 0' do
+        params[:action_box_agrees] = 0
+        expect(subject).not_to be_valid
+      end
+
+      it 'is invalid when string 0' do
+        params[:action_box_agrees] = '0'
+        expect(subject).not_to be_valid
+      end
+    end
+
     context 'with email as data_type' do
       let!(:element) { create :form_element, :email, form: form }
       let(:params) { { email: 'foo@example.com' } }


### PR DESCRIPTION
Checkboxes by default submit `'0'` which was an acceptable value for required fields. This checks against it to prevent that happening.