### PR TITLE
Sharer ID

### DIFF
--- a/app/assets/javascripts/member-facing/backbone/action_form.js
+++ b/app/assets/javascripts/member-facing/backbone/action_form.js
@@ -160,8 +160,8 @@ const ActionForm = Backbone.View.extend({
     }
   },
 
-  handleSuccess(){
-    Backbone.trigger('form:submitted');
+  handleSuccess(e, data){
+    Backbone.trigger('form:submitted', e, data);
   },
 
   handleFailure(e, data) {

--- a/app/assets/javascripts/member-facing/backbone/action_form.js
+++ b/app/assets/javascripts/member-facing/backbone/action_form.js
@@ -5,6 +5,7 @@ const GlobalEvents = require('shared/global_events');
 const ActionForm = Backbone.View.extend({
 
   el: 'form.action-form',
+  HIDDEN_FIELDS: ['source', 'akid', 'referrer_id'],
 
   events: {
     'click .action-form__clear-form': 'clearForm',
@@ -26,8 +27,7 @@ const ActionForm = Backbone.View.extend({
   //    location: a hash of location values inferred from the user's request
   //    skipPrefill: boolean, will not prefill if true
   initialize(options={}) {
-    this.insertActionKitId(options.akid);
-    this.insertSource(options.source);
+    this.insertHiddenFields(options);
     if (!options.skipPrefill) {
       this.prefillAsPossible(options);
     }
@@ -136,15 +136,12 @@ const ActionForm = Backbone.View.extend({
     $('.action-form__welcome-text').removeClass('hidden-irrelevant');
   },
 
-  insertActionKitId(akid) {
-    if(akid && this.$el) {
-      this.insertHiddenInput('akid', akid, this.$el)
-    }
-  },
-
-  insertSource(source) {
-    if(source && this.$el) {
-      this.insertHiddenInput('source', source, this.$el)
+  insertHiddenFields(options) {
+    for(var ii = 0; ii < this.HIDDEN_FIELDS.length; ii++) {
+      let field = this.HIDDEN_FIELDS[ii];
+      if(options[field] && this.$el) {
+        this.insertHiddenInput(field, options[field], this.$el);
+      }
     }
   },
 

--- a/app/assets/javascripts/member-facing/backbone/action_form.js
+++ b/app/assets/javascripts/member-facing/backbone/action_form.js
@@ -5,7 +5,7 @@ const GlobalEvents = require('shared/global_events');
 const ActionForm = Backbone.View.extend({
 
   el: 'form.action-form',
-  HIDDEN_FIELDS: ['source', 'akid', 'referrer_id'],
+  HIDDEN_FIELDS: ['source', 'akid', 'referrer_id', 'bucket'],
 
   events: {
     'click .action-form__clear-form': 'clearForm',
@@ -24,6 +24,8 @@ const ActionForm = Backbone.View.extend({
   //    outstandingFields: the names of step 2 form fields that aren't satisfied by
   //      the values in the member hash.
   //    member: an object with fields that will prefill the form
+  //    referrer_id: if passed, submitted to the server in the form
+  //    bucket: if passed, submitted to the server in the form
   //    location: a hash of location values inferred from the user's request
   //    skipPrefill: boolean, will not prefill if true
   initialize(options={}) {

--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -237,12 +237,13 @@ const Fundraiser = Backbone.View.extend(_.extend(
     if (hasCallbackFunction) {
       this.submissionCallback(data, status);
     }
-    if (this.followUpUrl) {
+    if (data && data.follow_up_url) {
+      this.redirectTo(data.follow_up_url);
+    } else if (this.followUpUrl) {
       this.redirectTo(this.followUpUrl);
-    }
-    if (!this.followUpUrl && !hasCallbackFunction) {
+    } else if(!hasCallbackFunction) {
       // only do this option if no redirect or callback supplied
-      alert(I18n.t('fundraiser.thank_you'));
+      alert(I18n.t('petition.excited_confirmation'));
     }
   },
 

--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -1,4 +1,3 @@
-const ActionForm  = require('member-facing/backbone/action_form');
 const CurrencyMethods     = require('member-facing/backbone/currency_methods');
 const OverlayToggle       = require('member-facing/backbone/overlay_toggle')
 const BraintreeHostedFields = require('member-facing/backbone/braintree_hosted_fields');

--- a/app/assets/javascripts/member-facing/backbone/petition.js
+++ b/app/assets/javascripts/member-facing/backbone/petition.js
@@ -22,10 +22,11 @@ const Petition = Backbone.View.extend({
     if (hasCallbackFunction) {
       this.submissionCallback(e, data);
     }
-    if (this.followUpUrl) {
+    if (data && data.follow_up_url) {
+      this.redirectTo(data.follow_up_url);
+    } else if (this.followUpUrl) {
       this.redirectTo(this.followUpUrl);
-    }
-    if (!this.followUpUrl && !hasCallbackFunction) {
+    } else if(!hasCallbackFunction) {
       // only do this option if no redirect or callback supplied
       alert(I18n.t('petition.excited_confirmation'));
     }

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -4,15 +4,14 @@ class Api::ActionsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
-    @action_params = action_params
-    validator = FormValidator.new(@action_params)
+    validator = FormValidator.new(action_params)
 
     if validator.valid?
-      @action_params.merge!(mobile_value)
-      @action_params.merge!(referer_url)
-      action = ManageAction.create(@action_params)
+      action = ManageAction.create(action_params.merge(referer_url).merge(mobile_value))
       write_member_cookie(action.member_id)
-      render json: {}, status: 200
+      render json: {
+        follow_up_url: PageFollower.new_from_page(page, action.member_id).follow_up_path
+      }, status: 200
     else
       render json: { errors: validator.errors }, status: 422
     end
@@ -30,7 +29,7 @@ class Api::ActionsController < ApplicationController
   private
 
   def action_params
-    @action_params = params.permit(fields + base_params)
+    @action_params ||= params.permit(fields + base_params)
   end
 
   def base_params
@@ -39,5 +38,9 @@ class Api::ActionsController < ApplicationController
 
   def fields
     Form.find(params[:form_id]).form_elements.map(&:name)
+  end
+
+  def page
+    @page ||= Page.find(action_params[:page_id])
   end
 end

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -34,7 +34,7 @@ class Api::ActionsController < ApplicationController
   end
 
   def base_params
-    %w(page_id form_id name source akid referring_akid)
+    %w(page_id form_id name source akid referring_akid referrer_id)
   end
 
   def fields

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -10,7 +10,7 @@ class Api::ActionsController < ApplicationController
       action = ManageAction.create(action_params.merge(referer_url).merge(mobile_value))
       write_member_cookie(action.member_id)
       render json: {
-        follow_up_url: PageFollower.new_from_page(page, action.member_id).follow_up_path
+        follow_up_url: PageFollower.new_from_page(page, action_params.merge(member_id: action.member_id)).follow_up_path
       }, status: 200
     else
       render json: { errors: validator.errors }, status: 422
@@ -33,7 +33,7 @@ class Api::ActionsController < ApplicationController
   end
 
   def base_params
-    %w(page_id form_id name source akid referring_akid referrer_id)
+    %w(page_id form_id name source akid referring_akid referrer_id bucket)
   end
 
   def fields

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -39,6 +39,9 @@ class PagesController < ApplicationController
   end
 
   def follow_up
+    if !params[:member_id].present? && recognized_member.try(:id).present?
+      return redirect_to follow_up_member_facing_page_path(@page.id, member_id: recognized_member.id)
+    end
     liquid_layout = @page.follow_up_liquid_layout || @page.liquid_layout
     render_liquid(liquid_layout, :follow_up)
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -39,6 +39,12 @@ class PagesController < ApplicationController
   end
 
   def follow_up
+    # currently, we use ShareProgress to evaluate and track shares. The only method they
+    # have to allow us to tell who referred who is by adding URL parameters (in this case,
+    # member_id) to the url of the page that the share button is clicked on. The
+    # conditional below ensures that the member_id is present if it should be, but it is
+    # usually already included because of the logic to pass member_id to the follow_up_url
+    # returned when an action is taken.
     if !params[:member_id].present? && recognized_member.try(:id).present?
       return redirect_to follow_up_member_facing_page_path(@page.id, member_id: recognized_member.id)
     end

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -12,7 +12,8 @@ class PaymentController < ApplicationController
     if builder.success?
       write_member_cookie(builder.action.member_id) unless builder.action.blank?
       id = recurring? ? { subscription_id: builder.subscription_id } : { transaction_id: builder.transaction_id }
-      follow_up_url = PageFollower.new_from_page(page, builder.action.member_id).follow_up_path
+      follow_up_params = params[:user].merge(member_id: builder.action.member_id)
+      follow_up_url = PageFollower.new_from_page(page, follow_up_params).follow_up_path
 
       respond_to do |format|
         format.html { redirect_to follow_up_page_path(page) }

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -12,10 +12,11 @@ class PaymentController < ApplicationController
     if builder.success?
       write_member_cookie(builder.action.member_id) unless builder.action.blank?
       id = recurring? ? { subscription_id: builder.subscription_id } : { transaction_id: builder.transaction_id }
+      follow_up_url = PageFollower.new_from_page(page, builder.action.member_id).follow_up_path
 
       respond_to do |format|
         format.html { redirect_to follow_up_page_path(page) }
-        format.json { render json: { success: true }.merge(id) }
+        format.json { render json: { success: true, follow_up_url: follow_up_url }.merge(id) }
       end
     else
       @errors = client::ErrorProcessing.new(builder.error_container, locale: locale).process

--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -6,7 +6,7 @@ module ActionBuilder
     action = Action.create({
       member: member,
       page: page,
-      form_data: @params,
+      form_data: form_data,
 
       # indicates if action subscribed the member
       subscribed_member: subscribed_member
@@ -88,5 +88,14 @@ module ActionBuilder
 
   def is_recurring_donation?
     @params[:is_subscription] ? true : false
+  end
+
+  def form_data
+    @params.tap do |params|
+      if params[:referrer_id]
+        member = Member.find_by(id: params[:referrer_id])
+        params[:referrer_email] = member.email if member.try(:email).present?
+      end
+    end
   end
 end

--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -94,7 +94,7 @@ module ActionBuilder
     @params.tap do |params|
       if params[:referrer_id]
         member = Member.find_by(id: params[:referrer_id])
-        params[:referrer_email] = member.email if member.try(:email).present?
+        params[:action_referrer_email] = member.email if member.try(:email).present?
       end
     end
   end

--- a/app/services/page_follower.rb
+++ b/app/services/page_follower.rb
@@ -2,16 +2,18 @@
 class PageFollower
   include Rails.application.routes.url_helpers
 
-  def self.new_from_page(page, member_id=nil)
-    new(page.follow_up_plan, page.slug, page.follow_up_liquid_layout_id, page.follow_up_page.try(:slug), member_id)
+  PARAMS_TO_PASS = [:member_id, :bucket]
+
+  def self.new_from_page(page, extra_params=nil)
+    new(page.follow_up_plan, page.slug, page.follow_up_liquid_layout_id, page.follow_up_page.try(:slug), extra_params)
   end
 
-  def initialize(plan, page_slug, follow_up_liquid_layout_id, follow_up_page_slug, member_id=nil)
+  def initialize(plan, page_slug, follow_up_liquid_layout_id, follow_up_page_slug, extra_params=nil)
     @plan = plan
     @page_slug = page_slug
     @follow_up_page_slug = follow_up_page_slug
     @follow_up_liquid_layout_id = follow_up_liquid_layout_id
-    @member_id = member_id
+    @extra_params = extra_params.try(:symbolize_keys)
   end
 
   def follow_up_path
@@ -29,13 +31,21 @@ class PageFollower
 
   def path_to_follow_up_page
     return nil if @follow_up_page_slug.blank?
-    return member_facing_page_path(@follow_up_page_slug) if @member_id.blank?
-    member_facing_page_path(@follow_up_page_slug, member_id: @member_id)
+    member_facing_page_path(@follow_up_page_slug, **url_params)
   end
 
   def path_to_follow_up_layout
     return nil if @page_slug.blank? || @follow_up_liquid_layout_id.blank?
-    return follow_up_member_facing_page_path(@page_slug) if @member_id.blank?
-    follow_up_member_facing_page_path(@page_slug, member_id: @member_id)
+    follow_up_member_facing_page_path(@page_slug, **url_params)
+  end
+
+  def url_params
+    return {} if @extra_params.blank?
+    return @url_params if @url_params.present?
+    @url_params = {}.tap do |ps|
+      PARAMS_TO_PASS.each do |key|
+        ps[key] = @extra_params[key] if @extra_params.has_key?(key)
+      end
+    end
   end
 end

--- a/app/services/page_follower.rb
+++ b/app/services/page_follower.rb
@@ -2,15 +2,16 @@
 class PageFollower
   include Rails.application.routes.url_helpers
 
-  def self.new_from_page(page)
-    new(page.follow_up_plan, page.slug, page.follow_up_liquid_layout_id, page.follow_up_page.try(:slug))
+  def self.new_from_page(page, member_id=nil)
+    new(page.follow_up_plan, page.slug, page.follow_up_liquid_layout_id, page.follow_up_page.try(:slug), member_id)
   end
 
-  def initialize(plan, page_slug, follow_up_liquid_layout_id, follow_up_page_slug)
+  def initialize(plan, page_slug, follow_up_liquid_layout_id, follow_up_page_slug, member_id=nil)
     @plan = plan
     @page_slug = page_slug
     @follow_up_page_slug = follow_up_page_slug
     @follow_up_liquid_layout_id = follow_up_liquid_layout_id
+    @member_id = member_id
   end
 
   def follow_up_path
@@ -27,10 +28,14 @@ class PageFollower
   private
 
   def path_to_follow_up_page
-    member_facing_page_path(@follow_up_page_slug) unless @follow_up_page_slug.blank?
+    return nil if @follow_up_page_slug.blank?
+    return member_facing_page_path(@follow_up_page_slug) if @member_id.blank?
+    member_facing_page_path(@follow_up_page_slug, member_id: @member_id)
   end
 
   def path_to_follow_up_layout
-    follow_up_member_facing_page_path(@page_slug) unless @page_slug.blank? || @follow_up_liquid_layout_id.blank?
+    return nil if @page_slug.blank? || @follow_up_liquid_layout_id.blank?
+    return follow_up_member_facing_page_path(@page_slug) if @member_id.blank?
+    follow_up_member_facing_page_path(@page_slug, member_id: @member_id)
   end
 end

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -124,7 +124,8 @@
           akid:              chmp.personalization.urlParams.akid,
           source:            chmp.personalization.urlParams.source,
           referrer_id:       chmp.personalization.urlParams.referrer_id,
-          prefill:          true
+          bucket:            chmp.personalization.urlParams.bucket,
+          prefill:           true
         });
         chmp.myFundraiser = new chmp.Fundraiser({
           pageId:           "{{ id }}",

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -123,6 +123,7 @@
           location:          chmp.personalization.location,
           akid:              chmp.personalization.urlParams.akid,
           source:            chmp.personalization.urlParams.source,
+          referrer_id:       chmp.personalization.urlParams.referrer_id,
           prefill:          true
         });
         chmp.myFundraiser = new chmp.Fundraiser({

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -30,6 +30,7 @@
           location:         chmp.personalization.location,
           akid:             chmp.personalization.urlParams.akid,
           source:           chmp.personalization.urlParams.source,
+          referrer_id:      chmp.personalization.urlParams.referrer_id,
           prefill:          true
         });
 

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -31,6 +31,7 @@
           akid:             chmp.personalization.urlParams.akid,
           source:           chmp.personalization.urlParams.source,
           referrer_id:      chmp.personalization.urlParams.referrer_id,
+          bucket:           chmp.personalization.urlParams.bucket,
           prefill:          true
         });
 

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: sharer-id
+    branch: development
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: asset-extraction
+    branch: sharer-id
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/spec/controllers/api/go_cardless_controller_spec.rb
+++ b/spec/controllers/api/go_cardless_controller_spec.rb
@@ -2,7 +2,14 @@
 require 'rails_helper'
 
 describe Api::GoCardlessController do
-  let(:page) { double(:page, id: '1') }
+  let(:page) do
+    double(:page,
+      id: 1,
+      slug: 'trol-lol-lol',
+      follow_up_plan: :with_liquid,
+      follow_up_liquid_layout_id: 4,
+      follow_up_page: nil)
+  end
   let(:action) { instance_double('Action', member_id: 79) }
 
   before do

--- a/spec/controllers/api/payment/braintree_controller_spec.rb
+++ b/spec/controllers/api/payment/braintree_controller_spec.rb
@@ -7,7 +7,14 @@ describe Api::Payment::BraintreeController do
     allow(MobileDetector).to receive(:detect).and_return(action_mobile: 'mobile')
   end
 
-  let(:page) { instance_double('Page') }
+  let(:page) do
+    instance_double('Page',
+      follow_up_plan: :with_liquid,
+      follow_up_liquid_layout_id: 4,
+      slug: 'asd-f',
+      follow_up_page: nil
+    )
+  end
   let(:action) { instance_double('Action', member_id: 79) }
 
   describe 'GET token' do
@@ -71,7 +78,11 @@ describe Api::Payment::BraintreeController do
         end
 
         it 'responds with subscription_id in JSON' do
-          expect(response.body).to eq({ success: true, subscription_id: 's1234' }.to_json)
+          expect(response.body).to eq({
+            success: true,
+            follow_up_url: '/a/asd-f/follow-up?member_id=79',
+            subscription_id: 's1234'
+          }.to_json)
         end
 
         it 'sets the member cookie' do
@@ -96,7 +107,11 @@ describe Api::Payment::BraintreeController do
         end
 
         it 'responds with transaction_id in JSON' do
-          expect(response.body).to eq({ success: true, transaction_id: 't1234' }.to_json)
+          expect(response.body).to eq({
+            success: true,
+            follow_up_url: '/a/asd-f/follow-up?member_id=79',
+            transaction_id: 't1234'
+          }.to_json)
         end
 
         it 'sets the member cookie' do

--- a/spec/javascripts/member-ui/action_form_spec.js
+++ b/spec/javascripts/member-ui/action_form_spec.js
@@ -245,6 +245,22 @@ describe("Action form", function() {
     });
   });
 
+  describe('adding referrer_id', function(){
+    var sourceFieldSelector = 'form.action-form input[type="hidden"][name="referrer_id"]';
+
+    it('adds a hidden field for source if source passed', function(){
+      expect($(sourceFieldSelector).length).to.eq(0);
+      suite.form = new window.champaign.ActionForm({referrer_id: '1234567890'});
+      expect($(sourceFieldSelector).length).to.eq(1);
+    });
+
+    it('does not add a hidden field if source not passed', function(){
+      expect($(sourceFieldSelector).length).to.eq(0);
+      suite.form = new window.champaign.ActionForm();
+      expect($(sourceFieldSelector).length).to.eq(0);
+    });
+  });
+
   describe('clearing prefill', function(){
 
     beforeEach(function(){

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -252,9 +252,10 @@ describe("Fundraiser", function() {
 
     describe('submission success', function(){
 
-      suite.triggerSuccess = function(){
+      suite.triggerSuccess = function(data){
+        data = data || '{ "success": "true" }';
         suite.server.respondWith('POST', "/api/payment/braintree/pages/1/transaction",
-          [200, { "Content-Type": "application/json" }, '{ "success": "true" }' ]);
+          [200, { "Content-Type": "application/json" }, data ]);
         Backbone.trigger('fundraiser:nonce_received', helpers.btNonce);
         suite.server.respond();
       }
@@ -274,6 +275,14 @@ describe("Fundraiser", function() {
         sinon.stub(suite.fundraiser, 'redirectTo');
         suite.triggerSuccess();
         expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.followUpUrl);
+        suite.fundraiser.redirectTo.restore();
+      });
+
+      it('redirects to the follow_up_url in the response if one is present', function(){
+        suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: '/not-used', pageId: '1'});
+        sinon.stub(suite.fundraiser, 'redirectTo');
+        suite.triggerSuccess('{ "success": "true", "follow_up_url": "/this-one?a=b" }');
+        expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/this-one?a=b');
         suite.fundraiser.redirectTo.restore();
       });
 

--- a/spec/javascripts/member-ui/petition_spec.js
+++ b/spec/javascripts/member-ui/petition_spec.js
@@ -28,6 +28,14 @@ describe("Petition", function() {
       suite.petition.redirectTo.restore();
     });
 
+    it('redirects to the follow_up_url in the response if one is present', function(){
+      suite.petition = new window.champaign.Petition({followUpUrl: '/not-used'});
+      sinon.stub(suite.petition, 'redirectTo');
+      Backbone.trigger('form:submitted', {}, {follow_up_url: suite.followUpUrl});
+      expect(suite.petition.redirectTo).to.have.been.calledWith(suite.followUpUrl);
+      suite.petition.redirectTo.restore();
+    });
+
     it('calls the callback function if it is supplied', function(){
       var callback = sinon.spy();
       suite.petition = new window.champaign.Petition({submissionCallback: callback});

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -3,7 +3,14 @@
 require 'rails_helper'
 
 describe 'Braintree API' do
-  let(:page) { create(:page, title: 'Cash rules everything around me') }
+  let(:page) do
+    create(:page,
+            title: 'Cash rules everything around me',
+            follow_up_plan: :with_liquid,
+            follow_up_liquid_layout: follow_up_liquid_layout)
+  end
+  let(:follow_up_liquid_layout) { create :liquid_layout }
+  let(:follow_up_url) { "/a/cash-rules-everything-around-me/follow-up?member_id=#{Member.last.id}" }
   let(:form) { create(:form) }
   let(:four_digits) { /[0-9]{4}/ }
   let(:token_format) { /[a-z0-9]{1,36}/i }
@@ -213,11 +220,12 @@ describe 'Braintree API' do
               expect(member.donor_status).to eq 'donor'
             end
 
-            it 'responds successfully with transaction_id' do
+            it 'responds successfully with follow_up_url and transaction_id' do
               subject
               transaction_id = Payment::Braintree::Transaction.last.transaction_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, transaction_id: transaction_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
 
@@ -277,11 +285,12 @@ describe 'Braintree API' do
               ))
             end
 
-            it 'responds successfully with transaction_id' do
+            it 'responds successfully with follow_up_url and transaction_id' do
               subject
               transaction_id = Payment::Braintree::Transaction.last.transaction_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, transaction_id: transaction_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
         end
@@ -395,11 +404,12 @@ describe 'Braintree API' do
               expect(member.postal).to eq '11225'
             end
 
-            it 'responds successfully with transaction_id' do
+            it 'responds successfully with follow_up_url and transaction_id' do
               subject
               transaction_id = Payment::Braintree::Transaction.last.transaction_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, transaction_id: transaction_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
 
@@ -457,11 +467,12 @@ describe 'Braintree API' do
               ))
             end
 
-            it 'responds successfully with transaction_id' do
+            it 'responds successfully with follow_up_url and transaction_id' do
               subject
               transaction_id = Payment::Braintree::Transaction.last.transaction_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, transaction_id: transaction_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
         end
@@ -511,11 +522,12 @@ describe 'Braintree API' do
               expect(member.donor_status).to eq 'donor'
             end
 
-            it 'responds successfully with transaction_id' do
+            it 'responds successfully with follow_up_url and transaction_id' do
               subject
               transaction_id = Payment::Braintree::Transaction.last.transaction_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, transaction_id: transaction_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
         end
@@ -713,11 +725,12 @@ describe 'Braintree API' do
               expect(member.donor_status).to eq 'recurring_donor'
             end
 
-            it 'responds successfully with subscription_id' do
+            it 'responds successfully with follow_up_url and subscription_id' do
               subject
               subscription_id = Payment::Braintree::Subscription.last.subscription_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, subscription_id: subscription_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, subscription_id: subscription_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
 
@@ -769,11 +782,12 @@ describe 'Braintree API' do
               ))
             end
 
-            it 'responds successfully with subscription_id' do
+            it 'responds successfully with follow_up_url and subscription_id' do
               subject
               subscription_id = Payment::Braintree::Subscription.last.subscription_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, subscription_id: subscription_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, subscription_id: subscription_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
         end
@@ -901,11 +915,12 @@ describe 'Braintree API' do
               expect(member.postal).to eq '11225'
             end
 
-            it 'responds successfully with subscription_id' do
+            it 'responds successfully with follow_up_url and subscription_id' do
               subject
               subscription_id = Payment::Braintree::Subscription.last.subscription_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, subscription_id: subscription_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, subscription_id: subscription_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
 
@@ -954,11 +969,12 @@ describe 'Braintree API' do
               ))
             end
 
-            it 'responds successfully with subscription_id' do
+            it 'responds successfully with follow_up_url and subscription_id' do
               subject
               subscription_id = Payment::Braintree::Subscription.last.subscription_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, subscription_id: subscription_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, subscription_id: subscription_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
         end
@@ -1008,11 +1024,12 @@ describe 'Braintree API' do
               expect(member.donor_status).to eq 'recurring_donor'
             end
 
-            it 'responds successfully with subscription_id' do
+            it 'responds successfully with follow_up_url and subscription_id' do
               subject
               subscription_id = Payment::Braintree::Subscription.last.subscription_id
               expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, subscription_id: subscription_id }.to_json)
+              data = { success: true, follow_up_url: follow_up_url, subscription_id: subscription_id }
+              expect(response.body).to eq(data.to_json)
             end
           end
         end

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -214,6 +214,39 @@ describe ActionBuilder do
     end
   end
 
+  describe 'referrer_email' do
+    let(:base_params) { { page_id: page.id, email: member.email } }
+    describe 'is not added if referrer_id' do
+
+      it 'is not included' do
+        action = MockActionBuilder.new(base_params).build_action
+        expect(action.form_data.keys).not_to include('referrer_email')
+      end
+
+      it 'is blank' do
+        action = MockActionBuilder.new(base_params.merge(referrer_id: '')).build_action
+        expect(action.form_data.keys).not_to include('referrer_email')
+      end
+
+      it "is an id of a member that doesn't exist" do
+        action = MockActionBuilder.new(base_params.merge(referrer_id: 1234567890)).build_action
+        expect(action.form_data.keys).not_to include('referrer_email')
+      end
+
+      it 'is an id of a member with no email' do
+        m2 = create :member, email: ''
+        action = MockActionBuilder.new(base_params.merge(referrer_id: m2.id)).build_action
+        expect(action.form_data.keys).not_to include('referrer_email')
+      end
+    end
+
+    it 'is added to form_data if it is the id of a member' do
+      m2 = create :member, email: 'asdf@hjkl.com'
+      action = MockActionBuilder.new(base_params.merge(referrer_id: m2.id)).build_action
+      expect(action.form_data['referrer_email']).to eq 'asdf@hjkl.com'
+    end
+  end
+
   describe 'filtered_params' do
     let(:params) do
       {

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -214,36 +214,36 @@ describe ActionBuilder do
     end
   end
 
-  describe 'referrer_email' do
+  describe 'action_referrer_email' do
     let(:base_params) { { page_id: page.id, email: member.email } }
     describe 'is not added if referrer_id' do
 
       it 'is not included' do
         action = MockActionBuilder.new(base_params).build_action
-        expect(action.form_data.keys).not_to include('referrer_email')
+        expect(action.form_data.keys).not_to include('action_referrer_email')
       end
 
       it 'is blank' do
         action = MockActionBuilder.new(base_params.merge(referrer_id: '')).build_action
-        expect(action.form_data.keys).not_to include('referrer_email')
+        expect(action.form_data.keys).not_to include('action_referrer_email')
       end
 
       it "is an id of a member that doesn't exist" do
         action = MockActionBuilder.new(base_params.merge(referrer_id: 1234567890)).build_action
-        expect(action.form_data.keys).not_to include('referrer_email')
+        expect(action.form_data.keys).not_to include('action_referrer_email')
       end
 
       it 'is an id of a member with no email' do
         m2 = create :member, email: ''
         action = MockActionBuilder.new(base_params.merge(referrer_id: m2.id)).build_action
-        expect(action.form_data.keys).not_to include('referrer_email')
+        expect(action.form_data.keys).not_to include('action_referrer_email')
       end
     end
 
     it 'is added to form_data if it is the id of a member' do
       m2 = create :member, email: 'asdf@hjkl.com'
       action = MockActionBuilder.new(base_params.merge(referrer_id: m2.id)).build_action
-      expect(action.form_data['referrer_email']).to eq 'asdf@hjkl.com'
+      expect(action.form_data['action_referrer_email']).to eq 'asdf@hjkl.com'
     end
   end
 

--- a/spec/services/page_follower_spec.rb
+++ b/spec/services/page_follower_spec.rb
@@ -70,10 +70,10 @@ describe PageFollower do
       end
     end
 
-    describe 'member_id' do
+    describe 'extra params' do
       let(:plan) { :with_page }
 
-      describe 'is not in URL if the member_id parameter' do
+      describe 'are not in URL if the extra_params parameter' do
         it 'is not passed' do
           result = PageFollower.new(plan, page_id, nil, follow_up_page_id).follow_up_path
           expect(result).to eq member_facing_page_path(follow_up_page_id)
@@ -90,15 +90,35 @@ describe PageFollower do
         end
       end
 
-      describe 'is in the URL if the member_id parameter' do
-        it 'is a number' do
-          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, 34).follow_up_path
+      describe 'when passed' do
+        it 'ignores unknown parameters' do
+          params = { herp: 'derp' }
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, params).follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id)
+        end
+
+        it 'passes bucket through' do
+          params = { bucket: 'kick-it' }
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, params).follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id, bucket: 'kick-it')
+        end
+
+        it 'passes member_id through' do
+          params = { member_id: 34 }
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, params).follow_up_path
           expect(result).to eq member_facing_page_path(follow_up_page_id, member_id: 34)
         end
 
-        it 'is a string' do
-          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, '45').follow_up_path
-          expect(result).to eq member_facing_page_path(follow_up_page_id, member_id: '45')
+        it 'passes member_id through and ignores unknown parameters' do
+          params = {member_id: 34, foo: 'bar'}
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, params).follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id, member_id: 34)
+        end
+
+        it 'passes bucket and member_id through' do
+          params = { bucket: 'kick-it', member_id: 45 }
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, params).follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id, member_id: 45, bucket: 'kick-it')
         end
       end
     end

--- a/spec/services/page_follower_spec.rb
+++ b/spec/services/page_follower_spec.rb
@@ -70,6 +70,39 @@ describe PageFollower do
       end
     end
 
+    describe 'member_id' do
+      let(:plan) { :with_page }
+
+      describe 'is not in URL if the member_id parameter' do
+        it 'is not passed' do
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id).follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id)
+        end
+
+        it 'is nil' do
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, nil).follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id)
+        end
+
+        it 'is blank' do
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, ' ').follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id)
+        end
+      end
+
+      describe 'is in the URL if the member_id parameter' do
+        it 'is a number' do
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, 34).follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id, member_id: 34)
+        end
+
+        it 'is a string' do
+          result = PageFollower.new(plan, page_id, nil, follow_up_page_id, '45').follow_up_path
+          expect(result).to eq member_facing_page_path(follow_up_page_id, member_id: '45')
+        end
+      end
+    end
+
     describe 'plan is anything else' do
       it 'raises error if plan is :with_link' do
         expect do
@@ -100,7 +133,7 @@ describe PageFollower do
     it 'calls with page attributes' do
       allow(PageFollower).to receive(:new)
       PageFollower.new_from_page(page)
-      expect(PageFollower).to have_received(:new).with('with_liquid', 'astro-droid', 3, 'bleep-bloop')
+      expect(PageFollower).to have_received(:new).with('with_liquid', 'astro-droid', 3, 'bleep-bloop', nil)
     end
 
     it 'returns the instance for call chaining' do


### PR DESCRIPTION
This pull request enables us to start tracking *who* the sharer was when a member comes in on a share. This was a solution that Tara and I came up with together to meet her needs. The process is -

- a recognized member loads a follow-up page and we add the url parameter `member_id=12345` to the url
- that person shares, and when they do, ShareProgress notices the `member_id`
- a person clicks on that share and ShareProgress loads them onto the shared page with the url param `referrer_id=12345`.
- our javascript adds a hidden field with the referrer_id if one is present
- the new member submits the form and our server is passed the referrer_id. it translates this into `action_referrer_email` by performing a lookup, and includes that in the action data passed to ActionKit

I'm not super crazy about the redirect on the follow-up url, but I couldn't figure out another way to add a url parameter to the page, and that's the only way to get SP to pass the ID through the share.