### PR TITLE
Express donors to ak

### DIFF
--- a/app/controllers/email_confirmation_controller.rb
+++ b/app/controllers/email_confirmation_controller.rb
@@ -12,8 +12,6 @@ class EmailConfirmationController < ApplicationController
       'errors' => verifier.errors,
       'members_dashboard_url' => Settings.members.dashboard_url
     ).html_safe
-    ## FIXME seed and fetch from DB
-    #
     render 'email_confirmation/follow_up', layout: 'generic'
   end
 
@@ -46,7 +44,9 @@ class EmailConfirmationController < ApplicationController
   end
 
   def template
-    @template ||= Liquid::Template.parse(File.read("#{Rails.root}/app/liquid/views/layouts/email-confirmation-follow-up.liquid"))
+    ## FIXME seed and fetch from DB
+    #
+    view = File.read("#{Rails.root}/app/liquid/views/layouts/email-confirmation-follow-up.liquid")
+    @template ||= Liquid::Template.parse(view)
   end
-
 end

--- a/app/controllers/email_confirmation_controller.rb
+++ b/app/controllers/email_confirmation_controller.rb
@@ -1,47 +1,16 @@
 # frozen_string_literal: true
 class EmailConfirmationController < ApplicationController
-  include AuthToken
-
   def verify
     @member = Member.find_by(email: params[:email])
-    if verifier.success?
-      bake_cookies
-      update_on_ak
-    end
+    errors = EmailVerifierService.verify(params[:token], params[:email], cookies)
     @rendered = template.render(
-      'errors' => verifier.errors,
+      'errors' => errors,
       'members_dashboard_url' => Settings.members.dashboard_url
     ).html_safe
     render 'email_confirmation/follow_up', layout: 'generic'
   end
 
   private
-
-  def update_on_ak
-    ChampaignQueue.push(
-      type: 'update_member',
-      params: {
-        akid: @member.actionkit_user_id,
-        fields: {
-          express_account: 1
-        }
-      }
-    )
-  end
-
-  def verifier
-    @verifier ||= AuthTokenVerifier.new(params[:token], @member).verify
-  end
-
-  def bake_cookies
-    minutes_in_a_year = 1.year.abs / 60
-    encoded_jwt = encode_jwt(verifier.authentication.member.token_payload, minutes_in_a_year)
-
-    cookies.signed['authentication_id'] = {
-      value: encoded_jwt,
-      expires: 1.year.from_now
-    }
-  end
 
   def template
     ## FIXME seed and fetch from DB

--- a/app/controllers/email_confirmation_controller.rb
+++ b/app/controllers/email_confirmation_controller.rb
@@ -3,28 +3,39 @@ class EmailConfirmationController < ApplicationController
   include AuthToken
 
   def verify
-    verifier = AuthTokenVerifier.new(params[:token]).verify
-
-    ## FIXME seed and fetch from DB
-    #
-    view = File.read("#{Rails.root}/app/liquid/views/layouts/email-confirmation-follow-up.liquid")
-    template = Liquid::Template.parse(view)
 
     if verifier.success?
-      minutes_in_a_year = 1.year.abs / 60
-      encoded_jwt = encode_jwt(verifier.authentication.member.token_payload, minutes_in_a_year)
-
-      cookies.signed['authentication_id'] = {
-        value: encoded_jwt,
-        expires: 1.year.from_now
-      }
+      bake_cookies
     end
 
     @rendered = template.render(
       'errors' => verifier.errors,
       'members_dashboard_url' => Settings.members.dashboard_url
     ).html_safe
-
+    ## FIXME seed and fetch from DB
+    #
     render 'email_confirmation/follow_up', layout: 'generic'
+
   end
+
+  private
+
+  def verifier
+    @verifier ||= AuthTokenVerifier.new(params[:token]).verify
+  end
+
+  def bake_cookies
+    minutes_in_a_year = 1.year.abs / 60
+    encoded_jwt = encode_jwt(verifier.authentication.member.token_payload, minutes_in_a_year)
+
+    cookies.signed['authentication_id'] = {
+      value: encoded_jwt,
+      expires: 1.year.from_now
+    }
+  end
+
+  def template
+    @template ||= Liquid::Template.parse(File.read("#{Rails.root}/app/liquid/views/layouts/email-confirmation-follow-up.liquid"))
+  end
+
 end

--- a/app/controllers/email_confirmation_controller.rb
+++ b/app/controllers/email_confirmation_controller.rb
@@ -6,6 +6,7 @@ class EmailConfirmationController < ApplicationController
     @member = Member.find_by(email: params[:email])
     if verifier.success?
       bake_cookies
+      update_on_ak
     end
     @rendered = template.render(
       'errors' => verifier.errors,

--- a/app/controllers/email_confirmation_controller.rb
+++ b/app/controllers/email_confirmation_controller.rb
@@ -3,11 +3,10 @@ class EmailConfirmationController < ApplicationController
   include AuthToken
 
   def verify
-
+    @member = Member.find_by(email: params[:email])
     if verifier.success?
       bake_cookies
     end
-
     @rendered = template.render(
       'errors' => verifier.errors,
       'members_dashboard_url' => Settings.members.dashboard_url
@@ -15,13 +14,24 @@ class EmailConfirmationController < ApplicationController
     ## FIXME seed and fetch from DB
     #
     render 'email_confirmation/follow_up', layout: 'generic'
-
   end
 
   private
 
+  def update_on_ak
+    ChampaignQueue.push(
+      type: 'update_member',
+      params: {
+        akid: @member.actionkit_user_id,
+        fields: {
+          express_account: 1
+        }
+      }
+    )
+  end
+
   def verifier
-    @verifier ||= AuthTokenVerifier.new(params[:token]).verify
+    @verifier ||= AuthTokenVerifier.new(params[:token], @member).verify
   end
 
   def bake_cookies

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -74,7 +74,7 @@ class PaymentController < ApplicationController
     ChampaignQueue.push(
       type: 'update_member',
       params: {
-        akid: ( Member.find(member_id) ).actionkit_user_id,
+        akid: Member.find(member_id).actionkit_user_id,
         fields: {
           express_cookie: 1
         }

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -25,6 +25,8 @@ class PaymentController < ApplicationController
         value: existing_payment_methods.join(','),
         expires: 1.year.from_now
       }
+
+      update_on_ak(builder.action.member_id)
     end
 
     respond_to do |format|
@@ -66,5 +68,17 @@ class PaymentController < ApplicationController
 
   def locale
     page.try(:language).try(:code)
+  end
+
+  def update_on_ak(member_id)
+    ChampaignQueue.push(
+      type: 'update_member',
+      params: {
+        akid: ( Member.find(member_id) ).actionkit_user_id,
+        fields: {
+          express_cookie: 1
+        }
+      }
+    )
   end
 end

--- a/app/services/auth_token_verifier.rb
+++ b/app/services/auth_token_verifier.rb
@@ -3,9 +3,10 @@
 class AuthTokenVerifier
   attr_reader :errors
 
-  def initialize(token)
+  def initialize(token, member)
     @token = token
     @errors = []
+    @member = member
   end
 
   def verify
@@ -19,7 +20,7 @@ class AuthTokenVerifier
   end
 
   def authentication
-    @authentication ||= MemberAuthentication.find_by(token: @token)
+    @authentication ||= @member.authentication
   end
 
   def success?

--- a/app/services/email_verifier_service.rb
+++ b/app/services/email_verifier_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+class EmailVerifierService
+  include AuthToken
+
+  def self.verify(token, email, cookies)
+    new(token, email, cookies).verify
+  end
+
+  def initialize(token, email, cookies)
+    @token = token
+    @member = Member.find_by(email: email)
+    @cookies = cookies
+  end
+
+  def verify
+    if verifier.success?
+      bake_cookies
+      update_on_ak
+      []
+    else
+      verifier.errors
+    end
+  end
+
+  private
+
+  def update_on_ak
+    ChampaignQueue.push(
+      type: 'update_member',
+      params: {
+        akid: @member.actionkit_user_id,
+        fields: {
+          express_account: 1
+        }
+      }
+    )
+  end
+
+  def verifier
+    @verifier ||= AuthTokenVerifier.new(@token, @member).verify
+  end
+
+  def bake_cookies
+    minutes_in_a_year = 1.year.abs / 60
+    encoded_jwt = encode_jwt(verifier.authentication.member.token_payload, minutes_in_a_year)
+
+    @cookies.signed['authentication_id'] = {
+      value: encoded_jwt,
+      expires: 1.year.from_now
+    }
+  end
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ web:
   build: .
   volumes:
     - .:/myapp
+    - ../sou-assets:/sou-assets
   ports:
     - "3000:3000"
   links:

--- a/spec/factories/members.rb
+++ b/spec/factories/members.rb
@@ -22,5 +22,6 @@
 FactoryGirl.define do
   factory :member do
     email { Faker::Internet.email }
+    actionkit_user_id { Faker::Number.number(10) }
   end
 end

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -280,13 +280,11 @@ describe 'Braintree API' do
             end
 
             it 'updates the member as a cookie-based express donor on ActionKit' do
-              expect(ChampaignQueue).to receive(:push).with({
-                                                              type: 'update_member',
-                                                              params: {
-                                                                akid: 'woo_actionkit',
-                                                                fields: {
-                                                                  express_cookie: 1
-                                                                }
+              expect(ChampaignQueue).to receive(:push).with(type: 'update_member',
+                                                            params: {
+                                                              akid: 'woo_actionkit',
+                                                              fields: {
+                                                                express_cookie: 1
                                                               }
                                                             })
               subject

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -243,7 +243,7 @@ describe 'Braintree API' do
       end
     end
 
-    describe 'successfully' do
+    describe "successfully with storing in Braintree's vault" do
       let(:basic_params) do
         {
           currency: 'EUR',
@@ -255,7 +255,7 @@ describe 'Braintree API' do
       end
 
       context 'when Member exists' do
-        let!(:member) { create :member, email: user_params[:email], postal: nil }
+        let!(:member) { create :member, email: user_params[:email], postal: nil, actionkit_user_id: 'woo_actionkit' }
 
         context 'when BraintreeCustomer exists' do
           let!(:customer) { create :payment_braintree_customer, member: member, customer_id: 'test', card_last_4: '4843' }
@@ -276,8 +276,20 @@ describe 'Braintree API' do
 
             it 'stores token to cookie' do
               subject
-
               expect(response.cookies['payment_methods']).to match(/\W+/)
+            end
+
+            it 'updates the member as a cookie-based express donor on ActionKit' do
+              expect(ChampaignQueue).to receive(:push).with({
+                                                              type: 'update_member',
+                                                              params: {
+                                                                akid: 'woo_actionkit',
+                                                                fields: {
+                                                                  express_cookie: 1
+                                                                }
+                                                              }
+                                                            })
+              subject
             end
 
             it 'creates an Action associated with the Page and Member' do

--- a/spec/requests/email_confirmation_spec.rb
+++ b/spec/requests/email_confirmation_spec.rb
@@ -6,9 +6,9 @@ describe 'Email Confirmation when signing up to express donations' do
   let!(:auth) { create(:member_authentication, token: '1234', member: member) }
 
   context 'success' do
-    params = {token: '1234',
-    email: 'test@example.com',
-    language:'EN'}
+    params = { token: '1234',
+               email: 'test@example.com',
+               language: 'EN' }
 
     subject { get "/email_confirmation?#{params.to_query}" }
 
@@ -19,13 +19,11 @@ describe 'Email Confirmation when signing up to express donations' do
     end
 
     it 'pushes a member update to the ActionKit queue' do
-      expect(ChampaignQueue).to receive(:push).with({
-                                                      type: 'update_member',
-                                                      params: {
-                                                        akid: 'actionkit_wohoo',
-                                                        fields: {
-                                                          express_account: 1
-                                                        }
+      expect(ChampaignQueue).to receive(:push).with(type: 'update_member',
+                                                    params: {
+                                                      akid: 'actionkit_wohoo',
+                                                      fields: {
+                                                        express_account: 1
                                                       }
                                                     })
       subject
@@ -33,9 +31,9 @@ describe 'Email Confirmation when signing up to express donations' do
   end
 
   context 'failure' do
-    params = {token: 'nosuchtoken',
-              email: 'test@example.com',
-              language:'EN'}
+    params = { token: 'nosuchtoken',
+               email: 'test@example.com',
+               language: 'EN' }
     it 'renders error' do
       get "/email_confirmation?#{params.to_query}"
       expect(response.body).to match(/there was an issue confirming your account/)

--- a/spec/requests/email_confirmation_spec.rb
+++ b/spec/requests/email_confirmation_spec.rb
@@ -2,21 +2,44 @@
 require 'rails_helper'
 
 describe 'Email Confirmation when signing up to express donations' do
-  let!(:auth) do
-    create(:member_authentication, token: '1234')
+  let!(:member) { create(:member, email: 'test@example.com', actionkit_user_id: 'actionkit_wohoo') }
+  let!(:auth) { create(:member_authentication, token: '1234', member: member) }
+
+  context 'success' do
+    params = {token: '1234',
+    email: 'test@example.com',
+    language:'EN'}
+
+    subject { get "/email_confirmation?#{params.to_query}" }
+
+    it 'confirms user authentication' do
+      subject
+      expect(response.body).to include('successfully confirmed your account')
+      expect(auth.reload.confirmed_at).to_not be_nil
+    end
+
+    it 'pushes a member update to the ActionKit queue' do
+      expect(ChampaignQueue).to receive(:push).with({
+                                                      type: 'update_member',
+                                                      params: {
+                                                        akid: 'actionkit_wohoo',
+                                                        fields: {
+                                                          express_account: 1
+                                                        }
+                                                      }
+                                                    })
+      subject
+    end
   end
 
-  it 'confirms user authentication if the token matches' do
-    get '/email_confirmation?token=1234'
-
-    expect(response.body).to include('successfully confirmed your account')
-    expect(auth.reload.confirmed_at).to_not be_nil
-  end
-
-  it 'renders error if the token does not match' do
-    get '/email_confirmation?token=abcd'
-
-    expect(response.body).to match(/there was an issue confirming your account/)
-    expect(auth.reload.confirmed_at).to be nil
+  context 'failure' do
+    params = {token: 'nosuchtoken',
+              email: 'test@example.com',
+              language:'EN'}
+    it 'renders error' do
+      get "/email_confirmation?#{params.to_query}"
+      expect(response.body).to match(/there was an issue confirming your account/)
+      expect(auth.reload.confirmed_at).to be nil
+    end
   end
 end

--- a/spec/services/auth_token_verifier_spec.rb
+++ b/spec/services/auth_token_verifier_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe AuthTokenVerifier do
 
   describe '#verify' do
-    let!(:member) { create(:member, email: 'foo@example.com' ) }
+    let!(:member) { create(:member, email: 'foo@example.com', actionkit_user_id: 'actionkit_wohoo') }
 
     context 'with matching unconfirmed record' do
       let!(:member_authentication) { create(:member_authentication, token: 'a_token', member: member) }
@@ -45,6 +45,10 @@ describe AuthTokenVerifier do
       it 'returns error' do
         subject.verify
         expect(subject.errors.first).to match(/already been confirmed/)
+      end
+
+      it 'does not push to the ActionKit queue' do
+        expect(ChampaignQueue).to_not receive(:push)
       end
     end
 

--- a/spec/services/auth_token_verifier_spec.rb
+++ b/spec/services/auth_token_verifier_spec.rb
@@ -2,7 +2,6 @@
 require 'rails_helper'
 
 describe AuthTokenVerifier do
-
   describe '#verify' do
     let!(:member) { create(:member, email: 'foo@example.com', actionkit_user_id: 'actionkit_wohoo') }
 
@@ -53,7 +52,6 @@ describe AuthTokenVerifier do
     end
 
     context 'with no matching record' do
-
       subject { AuthTokenVerifier.new('nosuchtoken', member) }
 
       it 'is unsuccessful' do
@@ -82,8 +80,6 @@ describe AuthTokenVerifier do
         subject.verify
         expect(subject.errors.first).to match(/No account was found/)
       end
-
     end
-
   end
 end

--- a/spec/services/auth_token_verifier_spec.rb
+++ b/spec/services/auth_token_verifier_spec.rb
@@ -78,7 +78,7 @@ describe AuthTokenVerifier do
 
       it 'returns error' do
         subject.verify
-        expect(subject.errors.first).to match(/No account was found/)
+        expect(subject.errors.first).to match(/[Nn]o account was found/)
       end
     end
   end


### PR DESCRIPTION
Pushes messages about becoming an express donor (either account or cookie based express donor) to the AK worker queue. Also some cleanup. The custom action field needs to be added later after I get input from the analysts. 