### PR TITLE
Separately install legacy aws sdk for Paperclip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,8 +66,10 @@ gem 'rmagick' # rmagick for image processing
 gem 'paperclip'
 gem 'action_parameter'
 
-# AWS SDK for Rails
+# AWS SDK for Rails - makes SES integration easy
 gem 'aws-sdk-rails'
+# Paperclip has a hard requirement for aws-sdk version < 2.0 because hey why not?   ...
+gem 'aws-sdk-v1'
 
 # Logging and log management
 gem 'logger'

--- a/spec/requests/api/stateless/braintree/subscriptions_spec.rb
+++ b/spec/requests/api/stateless/braintree/subscriptions_spec.rb
@@ -54,8 +54,7 @@ describe 'API::Stateless Braintree Subscriptions' do
                                       created_at: /^\d{4}-\d{2}-\d{2}/,
                                       billing_day_of_month: 22,
                                       amount: '4.0',
-                                      currency: 'GBP'
-                                     )
+                                      currency: 'GBP')
 
       expect(subscription[:payment_method]).to include(id: payment_method.id,
                                                        instrument_type: 'credit card',


### PR DESCRIPTION
We use Paperclip for image uploads to S3, and while it's very convenient, it's lagging behind on its dependencies and has a hard requirement for an old version of the AWS SDK. My solution to fix this has been to use the up-to-date version for our own requirements, and install the old SDK for Paperclip. Obviously having two versions of the same gem is a little sub-optimal, but I don't want us to stick to the old sdk just because of Paperclip.