### PR TITLE
Passes a custom action field to AK when making one click donation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -610,5 +610,8 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.13.1
+   1.13.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,9 @@ GEM
       railties (>= 3)
     aws-sdk-resources (2.6.1)
       aws-sdk-core (= 2.6.1)
+    aws-sdk-v1 (1.66.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -524,6 +527,7 @@ DEPENDENCIES
   activeadmin!
   annotate
   aws-sdk-rails
+  aws-sdk-v1
   bcrypt (~> 3.1.7)
   bootstrap-sass (~> 3.3.5)
   braintree (~> 2.54.0)
@@ -605,9 +609,6 @@ DEPENDENCIES
   vcr
   web-console (~> 2.0)
   webmock
-
-RUBY VERSION
-   ruby 2.3.0p0
 
 BUNDLED WITH
    1.13.1

--- a/app/services/action_queue.rb
+++ b/app/services/action_queue.rb
@@ -119,6 +119,8 @@ module ActionQueue
     include Donatable
 
     def payload
+      # TODO: This really needs to be handled in a less hackish solution once we refactor.
+      @action.form_data[:action_express_donation] = 0
       if data[:is_subscription]
         subscription_payload
       else

--- a/app/services/braintree_services/one_click_service.rb
+++ b/app/services/braintree_services/one_click_service.rb
@@ -28,7 +28,7 @@ module BraintreeServices
         params_for_action.merge(params[:user])
           .merge(params[:payment])
           .merge(page_id: params[:page_id])
-          .merge(action_express_donation: true),
+          .merge(action_express_donation: 1),
         extra_params: { donation: true },
         skip_counter: true,
         skip_queue: false

--- a/app/services/braintree_services/one_click_service.rb
+++ b/app/services/braintree_services/one_click_service.rb
@@ -25,7 +25,10 @@ module BraintreeServices
 
     def create_action
       ManageAction.create(
-        params_for_action.merge(params[:user]).merge(params[:payment]).merge(page_id: params[:page_id]),
+        params_for_action.merge(params[:user])
+          .merge(params[:payment])
+          .merge(page_id: params[:page_id])
+          .merge(action_express_donation: true),
         extra_params: { donation: true },
         skip_counter: true,
         skip_queue: false

--- a/app/services/manage_braintree_donation.rb
+++ b/app/services/manage_braintree_donation.rb
@@ -29,7 +29,8 @@ class ManageBraintreeDonation
         subscription_id:      subscription_id,
         is_subscription:      @is_subscription,
         card_expiration_date: transaction.credit_card_details.expiration_date,
-        payment_provider: 'braintree'
+        payment_provider: 'braintree',
+        action_express_donation: 0
       }.tap do |params|
         params[:recurrence_number] = 0 if @is_subscription
       end

--- a/app/services/manage_braintree_donation.rb
+++ b/app/services/manage_braintree_donation.rb
@@ -34,7 +34,6 @@ class ManageBraintreeDonation
         params[:recurrence_number] = 0 if @is_subscription
       end
     )
-
     build_action(donation: true)
   end
 

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -134,7 +134,7 @@ describe 'Express Donation' do
                                action: {
                                  source: nil,
                                  fields: {
-                                   action_express_donation: true
+                                   action_express_donation: 1
                                  }
                                },
                                user: hash_including(
@@ -186,15 +186,15 @@ describe 'Braintree API' do
           name: 'cash-rules-everything-around-me-donation',
           payment_account: 'Braintree EUR'
         },
-        order: {
+        order: hash_including(
           amount: amount.to_s,
           card_num: '1881',
           card_code: '007',
           exp_date_month: '12',
           exp_date_year: '2020',
           currency: 'EUR'
-        },
-        user: {
+        ),
+        user: hash_including(
           email: 'itsme@feelthebern.org',
           country: 'United States',
           postal: '11225',
@@ -204,13 +204,14 @@ describe 'Braintree API' do
           akid: '1234.5678.9910',
           source: 'fb',
           user_en: 1
-        },
+        ),
         action: {
           source: 'fb',
-          fields: {
+          fields: hash_including(
             action_registered_voter: '1',
-            action_mobile: 'desktop'
-          }
+            action_mobile: 'desktop',
+            action_express_donation: 0
+          )
         }
       }
     }
@@ -273,7 +274,8 @@ describe 'Braintree API' do
                                      source: 'fb',
                                      fields: {
                                        action_registered_voter: '1',
-                                       action_mobile: 'desktop'
+                                       action_mobile: 'desktop',
+                                       action_express_donation: 0
                                      }
                                    },
                                    user: hash_including(
@@ -814,7 +816,8 @@ describe 'Braintree API' do
               source: 'fb',
               fields: {
                 action_registered_voter: '1',
-                action_mobile: 'desktop'
+                action_mobile: 'desktop',
+                action_express_donation: 0
               }
             }
           }

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -119,14 +119,30 @@ describe 'Express Donation' do
       expect(payment_method.customer).to eq(customer)
     end
 
-    it 'posts to queue - FIXME' do
+    # What's the status on this regarding the comment below? Why do we want to push outside of ActionBuilder?
+    it 'posts a donation to the queue with action_express_donation custom field - FIXME' do
       # We want to post to queue, but outside of the action builder
-
-      expect(
-        ChampaignQueue
-      ).to have_received(:push)
+      expect(ChampaignQueue).to have_received(:push)
         .with(hash_including(type: 'donation',
-                             params: hash_including(order: hash_including(amount: '2.0'))))
+                             payment_provider: 'braintree',
+                             params: {
+                               donationpage: {
+                                 name: 'hello-world-donation',
+                                 payment_account: 'Braintree GBP'
+                               },
+                               order: hash_including(amount: '2.0'),
+                               action: {
+                                 source: nil,
+                                 fields: {
+                                   action_express_donation: true
+                                 }
+                               },
+                               user: hash_including(
+                                 first_name: 'John',
+                                 last_name: 'Doe',
+                                 email: 'test@example.com'
+                               )
+                             }))
     end
   end
 end
@@ -207,519 +223,546 @@ describe 'Braintree API' do
   end
 
   describe 'making a transaction' do
-    describe "without storing in Braintree's vault" do
-      let(:params) do
-        {
-          currency: 'EUR',
-          payment_method_nonce: 'fake-valid-nonce',
-          recurring: false,
-          amount: 2.00,
-          store_in_vault: false,
-          user: user_params
-        }
-      end
-
-      before do
-        VCR.use_cassette('braintree_transaction no_vault') do
-          post api_payment_braintree_transaction_path(page.id), params
+    context 'successfully' do
+      describe "without storing in Braintree's vault" do
+        let(:params) do
+          {
+            currency: 'EUR',
+            payment_method_nonce: 'fake-valid-nonce',
+            recurring: false,
+            amount: 2.00,
+            store_in_vault: false,
+            user: user_params
+          }
         end
-      end
 
-      it 'no customer is created' do
-        expect(Payment::Braintree::Customer.all).to be_empty
-      end
-
-      it 'no payment method is created' do
-        expect(Payment::Braintree::PaymentMethod.all).to be_empty
-      end
-
-      it 'transaction is created' do
-        transaction = Payment::Braintree::Transaction.first
-
-        expect(transaction.attributes).to include({
-          currency: 'EUR',
-          customer_id: nil
-        }.stringify_keys)
-      end
-    end
-
-    describe "successfully with storing in Braintree's vault" do
-      let(:basic_params) do
-        {
-          currency: 'EUR',
-          payment_method_nonce: 'fake-valid-nonce',
-          amount: '2.00',
-          recurring: false,
-          store_in_vault: true
-        }
-      end
-
-      context 'when Member exists' do
-        let!(:member) { create :member, email: user_params[:email], postal: nil, actionkit_user_id: 'woo_actionkit' }
-
-        context 'when BraintreeCustomer exists' do
-          let!(:customer) { create :payment_braintree_customer, member: member, customer_id: 'test', card_last_4: '4843' }
-
-          context 'with basic params' do
-            let(:amount) { 23.20 } # to avoid duplicate donations recording specs
-            let(:params) { basic_params.merge(user: user_params, amount: amount) }
-            subject do
-              VCR.use_cassette('transaction success basic existing customer') do
-                post api_payment_braintree_transaction_path(page.id), params
-              end
-            end
-
-            it 'increments redis counters' do
-              expect(Analytics::Page).to receive(:increment).with(page.id, new_member: false)
-              subject
-            end
-
-            it 'stores token to cookie' do
-              subject
-              expect(response.cookies['payment_methods']).to match(/\W+/)
-            end
-
-            it 'updates the member as a cookie-based express donor on ActionKit' do
-              expect(ChampaignQueue).to receive(:push).with(type: 'update_member',
-                                                            params: {
-                                                              akid: 'woo_actionkit',
-                                                              fields: {
-                                                                express_cookie: 1
-                                                              }
-                                                            })
-              subject
-            end
-
-            it 'creates an Action associated with the Page and Member' do
-              expect { subject }.to change { Action.count }.by 1
-              expect(Action.last.page).to eq page
-              expect(Action.last.member).to eq member
-            end
-
-            it 'stores amount, currency, card_num, is_subscription, and transaction_id in form_data on the Action' do
-              expect { subject }.to change { Action.count }.by 1
-              form_data = Action.last.form_data
-              expect(form_data['card_num']).to eq '1881'
-              expect(form_data['is_subscription']).to eq false
-              expect(form_data['amount']).to eq amount.to_s
-              expect(form_data['currency']).to eq 'EUR'
-              expect(form_data['transaction_id']).to eq Payment::Braintree::Transaction.last.transaction_id
-            end
-
-            it 'creates a Transaction associated with the page storing relevant info' do
-              expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
-              transaction = Payment::Braintree::Transaction.last
-              expect(transaction.page).to eq page
-              expect(transaction.amount).to eq amount
-              expect(transaction.currency).to eq 'EUR'
-              expect(transaction.merchant_account_id).to eq 'EUR'
-              expect(transaction.payment_instrument_type).to eq 'credit_card'
-              expect(transaction.transaction_type).to eq 'sale'
-              expect(transaction.customer_id).to eq customer.customer_id
-              expect(transaction.customer).to eq customer
-              expect(transaction.status).to eq 'success'
-
-              expect(Payment::Braintree::PaymentMethod.find(transaction.payment_method_id)
-                     .token).to match a_string_matching(token_format)
-              expect(transaction.transaction_id).to match a_string_matching(token_format)
-            end
-
-            it 'updates Payment::Braintree::Customer with new token and last_4' do
-              previous_token = customer.default_payment_method
-              previous_last_4 = customer.card_last_4
-              expect { subject }.to change { Payment::Braintree::Customer.count }.by 0
-              new_token = Payment::Braintree::PaymentMethod.last
-              customer.reload
-              expect(customer.default_payment_method).to_not eq previous_token
-              expect(customer.default_payment_method).to eq Payment::Braintree::PaymentMethod.last
-              expect(customer.card_last_4).to match a_string_matching(four_digits)
-              expect(customer.card_last_4).not_to eq previous_last_4
-            end
-
-            it 'posts donation action to queue with key data' do
-              subject
-              expect(ChampaignQueue).to have_received(:push).with(donation_push_params)
-            end
-
-            it 'increments action count on page' do
-              expect { subject }.to change { page.reload.action_count }.by 1
-            end
-
-            it 'passes the params to braintree' do
-              allow(Braintree::Transaction).to receive(:sale).and_call_original
-              subject
-              expect(Braintree::Transaction).to have_received(:sale).with(amount: amount,
-                                                                          payment_method_nonce: 'fake-valid-nonce',
-                                                                          merchant_account_id: 'EUR',
-                                                                          options: {
-                                                                            submit_for_settlement: true,
-                                                                            store_in_vault_on_success: true
-                                                                          },
-                                                                          customer: {
-                                                                            first_name: 'Bernie',
-                                                                            last_name: 'Sanders',
-                                                                            email: 'itsme@feelthebern.org'
-                                                                          },
-                                                                          billing: {
-                                                                            first_name: 'Bernie',
-                                                                            last_name: 'Sanders',
-                                                                            street_address: '25 Elm Drive',
-                                                                            postal_code: '11225',
-                                                                            country_code_alpha2: 'US'
-                                                                          },
-                                                                          customer_id: customer.customer_id)
-            end
-
-            it 'leaves a cookie with the member_id' do
-              expect(cookies['member_id']).to eq nil
-              subject
-
-              # we can't access signed cookies in request specs, so check for hashed value
-              expect(cookies['member_id']).not_to eq nil
-              expect(cookies['member_id'].length).to be > 20
-            end
-
-            it 'updates the Member’s fields with any new data' do
-              expect(member.first_name).not_to eq 'Bernie'
-              expect(member.last_name).not_to eq 'Sanders'
-              expect(member.postal).to eq nil
-              expect(member.donor_status).to eq 'nondonor'
-              expect { subject }.to change { Member.count }.by 0
-              member.reload
-              expect(member.first_name).to eq 'Bernie'
-              expect(member.last_name).to eq 'Sanders'
-              expect(member.postal).to eq '11225'
-              expect(member.donor_status).to eq 'donor'
-            end
-
-            it 'responds successfully with transaction_id' do
-              subject
-              transaction_id = Payment::Braintree::Transaction.last.transaction_id
-              expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
-            end
-          end
-
-          context 'with Paypal' do
-            let(:amount) { 29.20 } # to avoid duplicate donations recording specs
-            let(:params) { basic_params.merge(user: user_params, payment_method_nonce: 'fake-paypal-future-nonce', amount: amount, store_in_vault: true) }
-
-            subject do
-              VCR.use_cassette('transaction success paypal existing customer') do
-                post api_payment_braintree_transaction_path(page.id), params
-              end
-            end
-
-            it 'creates a Transaction associated with the page storing relevant info' do
-              expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
-              transaction = Payment::Braintree::Transaction.last
-
-              expect(transaction.page).to eq page
-              expect(transaction.amount).to eq amount
-              expect(transaction.currency).to eq 'EUR'
-              expect(transaction.merchant_account_id).to eq 'EUR'
-              expect(transaction.payment_instrument_type).to eq 'paypal_account'
-              expect(transaction.transaction_type).to eq 'sale'
-              expect(transaction.customer_id).to eq customer.customer_id
-              expect(transaction.customer).to eq customer
-              expect(transaction.status).to eq 'success'
-
-              expect(transaction.payment_method.token).to match a_string_matching(token_format)
-              expect(transaction.transaction_id).to match a_string_matching(token_format)
-            end
-
-            it 'updates Payment::Braintree::Customer with new token and PYPL for last_4' do
-              previous_token = customer.default_payment_method
-              previous_last_4 = customer.card_last_4
-              expect { subject }.to change { Payment::Braintree::Customer.count }.by 0
-              customer.reload
-              expect(customer.default_payment_method.token).to match a_string_matching(token_format)
-              expect(customer.default_payment_method).to eq Payment::Braintree::PaymentMethod.last
-              expect(customer.default_payment_method).not_to eq previous_token
-              expect(customer.card_last_4).to eq 'PYPL'
-            end
-
-            it 'stores PYPL as card_num on the Action' do
-              expect { subject }.to change { Action.count }.by 1
-              form_data = Action.last.form_data
-              expect(form_data['card_num']).to eq 'PYPL'
-              expect(form_data['is_subscription']).to eq false
-              expect(form_data['amount']).to eq amount.to_s
-              expect(form_data['currency']).to eq 'EUR'
-              expect(form_data['transaction_id']).to eq Payment::Braintree::Transaction.last.transaction_id
-            end
-
-            it 'passes PYPL as card_num to queue' do
-              subject
-              expect(ChampaignQueue).to have_received(:push).with(a_hash_including(
-                params: a_hash_including(order: a_hash_including(card_num: 'PYPL'))
-              ))
-            end
-
-            it 'responds successfully with transaction_id' do
-              subject
-              transaction_id = Payment::Braintree::Transaction.last.transaction_id
-              expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
-            end
-
-            it 'persists payment_method' do
-              subject
-
-              payment_method = Payment::Braintree::PaymentMethod.first
-
-              expect(payment_method.attributes).to include({
-                token: token_format,
-                instrument_type: 'paypal_account',
-                email: 'payer@example.com'
-              }.stringify_keys)
-            end
+        before do
+          VCR.use_cassette('braintree_transaction no_vault') do
+            post api_payment_braintree_transaction_path(page.id), params
           end
         end
 
-        context 'when BraintreeCustomer is new' do
-          context 'with basic params' do
-            let(:amount) { 13.20 } # to avoid duplicate donations recording specs
-            let(:params) { basic_params.merge(user: user_params, amount: amount) }
-            subject do
-              VCR.use_cassette('transaction success basic new customer') do
-                post api_payment_braintree_transaction_path(page.id), params
-              end
-            end
+        it 'no customer is created' do
+          expect(Payment::Braintree::Customer.all).to be_empty
+        end
 
-            it 'persists payment method for customer' do
-              subject
+        it 'no payment method is created' do
+          expect(Payment::Braintree::PaymentMethod.all).to be_empty
+        end
 
-              payment_method = Payment::Braintree::PaymentMethod.first
+        it 'transaction is created' do
+          transaction = Payment::Braintree::Transaction.first
 
-              expect(payment_method.attributes).to include({
-                last_4: '1881',
-                token: token_format,
-                card_type: 'Visa',
-                bin: /\d{6}/,
-                expiration_date: %r{\d{2}/\d{4}},
-                instrument_type: 'credit_card'
-              }.stringify_keys)
-            end
+          expect(transaction.attributes).to include({
+            currency: 'EUR',
+            customer_id: nil
+          }.stringify_keys)
+        end
 
-            it 'creates an Action associated with the Page and Member' do
-              expect { subject }.to change { Action.count }.by 1
-              expect(Action.last.page).to eq page
-              expect(Action.last.member).to eq member
-            end
-
-            it 'stores amount, currency, card_num, is_subscription, and transaction_id in form_data on the Action' do
-              expect { subject }.to change { Action.count }.by 1
-              form_data = Action.last.form_data
-              expect(form_data['card_num']).to eq '1881'
-              expect(form_data['is_subscription']).to eq false
-              expect(form_data['amount']).to eq amount.to_s
-              expect(form_data['currency']).to eq 'EUR'
-              expect(form_data['transaction_id']).to eq Payment::Braintree::Transaction.last.transaction_id
-              expect(form_data).to_not include('recurrence_number')
-            end
-
-            it 'creates a Transaction associated with the page storing relevant info' do
-              expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
-              transaction = Payment::Braintree::Transaction.last
-
-              expect(transaction.page).to eq page
-              expect(transaction.amount).to eq amount
-              expect(transaction.currency).to eq 'EUR'
-              expect(transaction.merchant_account_id).to eq 'EUR'
-              expect(transaction.payment_instrument_type).to eq 'credit_card'
-              expect(transaction.transaction_type).to eq 'sale'
-              expect(transaction.customer_id).to eq Payment::Braintree::Customer.last.customer_id
-              expect(transaction.status).to eq 'success'
-
-              expect(Payment::Braintree::PaymentMethod.find(transaction.payment_method_id)
-                     .token).to match a_string_matching(token_format)
-              expect(transaction.transaction_id).to match a_string_matching(token_format)
-            end
-
-            it 'creates new Payment::Braintree::Customer including token, customer_id, and last four for credit card' do
-              expect { subject }.to change { Payment::Braintree::Customer.count }.by 1
-              customer = Payment::Braintree::Customer.last
-              expect(customer.customer_id).not_to be_blank
-              expect(customer.card_last_4).to eq '1881'
-              expect(customer.default_payment_method).not_to be_blank
-              expect(customer.email).to eq user_params[:email]
-            end
-
-            it 'posts donation action to queue with key data' do
-              subject
-              expect(ChampaignQueue).to have_received(:push).with(donation_push_params)
-            end
-
-            it 'increments action count on page' do
-              expect { subject }.to change { page.reload.action_count }.by 1
-            end
-
-            it 'passes the params to braintree' do
-              allow(Braintree::Transaction).to receive(:sale).and_call_original
-              subject
-              expect(Braintree::Transaction).to have_received(:sale).with(amount: amount,
-                                                                          payment_method_nonce: 'fake-valid-nonce',
-                                                                          merchant_account_id: 'EUR',
-                                                                          options: {
-                                                                            submit_for_settlement: true,
-                                                                            store_in_vault_on_success: true
-                                                                          },
-                                                                          customer: {
-                                                                            first_name: 'Bernie',
-                                                                            last_name: 'Sanders',
-                                                                            email: 'itsme@feelthebern.org'
-                                                                          },
-                                                                          billing: {
-                                                                            first_name: 'Bernie',
-                                                                            last_name: 'Sanders',
-                                                                            street_address: '25 Elm Drive',
-                                                                            postal_code: '11225',
-                                                                            country_code_alpha2: 'US'
-                                                                          })
-            end
-
-            it 'leaves a cookie with the member_id' do
-              expect(cookies['member_id']).to eq nil
-              subject
-
-              # we can't access signed cookies in request specs, so check for hashed value
-              expect(cookies['member_id']).not_to eq nil
-              expect(cookies['member_id'].length).to be > 20
-            end
-
-            it 'updates the Member’s fields with any new data' do
-              expect(member.first_name).not_to eq 'Bernie'
-              expect(member.last_name).not_to eq 'Sanders'
-              expect(member.postal).to eq nil
-              expect { subject }.to change { Member.count }.by 0
-              member.reload
-              expect(member.first_name).to eq 'Bernie'
-              expect(member.last_name).to eq 'Sanders'
-              expect(member.postal).to eq '11225'
-            end
-
-            it 'responds successfully with transaction_id' do
-              subject
-              transaction_id = Payment::Braintree::Transaction.last.transaction_id
-              expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
-            end
-          end
-
-          context 'with Paypal' do
-            let(:amount) { 19.20 } # to avoid duplicate donations recording specs
-            let(:params) { basic_params.merge(user: user_params, payment_method_nonce: 'fake-paypal-future-nonce', amount: amount) }
-
-            subject do
-              VCR.use_cassette('transaction success paypal new customer') do
-                post api_payment_braintree_transaction_path(page.id), params
-              end
-            end
-
-            it 'creates a Transaction associated with the page storing relevant info' do
-              expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
-              transaction = Payment::Braintree::Transaction.last
-
-              expect(transaction.page).to eq page
-              expect(transaction.amount).to eq amount
-              expect(transaction.currency).to eq 'EUR'
-              expect(transaction.merchant_account_id).to eq 'EUR'
-              expect(transaction.payment_instrument_type).to eq 'paypal_account'
-              expect(transaction.transaction_type).to eq 'sale'
-              expect(transaction.customer_id).to eq Payment::Braintree::Customer.last.customer_id
-              expect(transaction.status).to eq 'success'
-
-              expect(Payment::Braintree::PaymentMethod.find(transaction.payment_method_id)
-                     .token).to match a_string_matching(token_format)
-              expect(transaction.transaction_id).to match a_string_matching(token_format)
-            end
-
-            it 'creates a Payment::Braintree::Customer with customer_id and PYPL for last 4' do
-              expect { subject }.to change { Payment::Braintree::Customer.count }.by 1
-              customer = Payment::Braintree::Customer.last
-              expect(customer.customer_id).not_to be_blank
-              expect(customer.card_last_4).to eq 'PYPL'
-              expect(customer.default_payment_method).not_to be_blank
-              expect(customer.email).to eq user_params[:email]
-            end
-
-            it 'stores PYPL as card_num on the Action' do
-              expect { subject }.to change { Action.count }.by 1
-              form_data = Action.last.form_data
-              expect(form_data['card_num']).to eq 'PYPL'
-              expect(form_data['is_subscription']).to eq false
-              expect(form_data['amount']).to eq amount.to_s
-              expect(form_data['currency']).to eq 'EUR'
-              expect(form_data['transaction_id']).to eq Payment::Braintree::Transaction.last.transaction_id
-            end
-
-            it 'passes PYPL as card_num to queue' do
-              subject
-              expect(ChampaignQueue).to have_received(:push).with(a_hash_including(
-                params: a_hash_including(order: a_hash_including(card_num: 'PYPL'))
-              ))
-            end
-
-            it 'responds successfully with transaction_id' do
-              subject
-              transaction_id = Payment::Braintree::Transaction.last.transaction_id
-              expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
-            end
-          end
+        it 'pushes a new donation action to the ActionKit queue' do
+          expect(ChampaignQueue).to have_received(:push)
+            .with(hash_including(type: 'donation',
+                                 payment_provider: 'braintree',
+                                 params: {
+                                   donationpage: {
+                                     name: 'cash-rules-everything-around-me-donation',
+                                     payment_account: 'Braintree EUR'
+                                   },
+                                   order: hash_including(amount: '2.0'),
+                                   action: {
+                                     source: 'fb',
+                                     fields: {
+                                       action_registered_voter: '1',
+                                       action_mobile: 'desktop'
+                                     }
+                                   },
+                                   user: hash_including(
+                                     first_name: 'Bernie',
+                                     last_name: 'Sanders',
+                                     email: 'itsme@feelthebern.org'
+                                   )
+                                 }))
         end
       end
 
-      context 'when Member is new' do
-        context 'when BraintreeCustomer is new' do
-          context 'with basic params' do
-            # we're using the same casette as above anyway, so we're only running specs
-            # relevant to the new member
+      describe " with storing in Braintree's vault" do
+        let(:basic_params) do
+          {
+            currency: 'EUR',
+            payment_method_nonce: 'fake-valid-nonce',
+            amount: '2.00',
+            recurring: false,
+            store_in_vault: true
+          }
+        end
 
-            let(:amount) { 13.20 } # to avoid duplicate donations recording specs
-            let(:params) { basic_params.merge(user: user_params, amount: amount) }
+        context 'when Member exists' do
+          let!(:member) { create :member, email: user_params[:email], postal: nil, actionkit_user_id: 'woo_actionkit' }
 
-            subject do
-              VCR.use_cassette('transaction success basic new customer') do
-                post api_payment_braintree_transaction_path(page.id), params
+          context 'when BraintreeCustomer exists' do
+            let!(:customer) { create :payment_braintree_customer, member: member, customer_id: 'test', card_last_4: '4843' }
+
+            context 'with basic params' do
+              let(:amount) { 23.20 } # to avoid duplicate donations recording specs
+              let(:params) { basic_params.merge(user: user_params, amount: amount) }
+              subject do
+                VCR.use_cassette('transaction success basic existing customer') do
+                  post api_payment_braintree_transaction_path(page.id), params
+                end
+              end
+
+              it 'increments redis counters' do
+                expect(Analytics::Page).to receive(:increment).with(page.id, new_member: false)
+                subject
+              end
+
+              it 'stores token to cookie' do
+                subject
+                expect(response.cookies['payment_methods']).to match(/\W+/)
+              end
+
+              it 'updates the member as a cookie-based express donor on ActionKit' do
+                expect(ChampaignQueue).to receive(:push).with(type: 'update_member',
+                                                              params: {
+                                                                akid: 'woo_actionkit',
+                                                                fields: {
+                                                                  express_cookie: 1
+                                                                }
+                                                              })
+                subject
+              end
+
+              it 'creates an Action associated with the Page and Member' do
+                expect { subject }.to change { Action.count }.by 1
+                expect(Action.last.page).to eq page
+                expect(Action.last.member).to eq member
+              end
+
+              it 'stores amount, currency, card_num, is_subscription, and transaction_id in form_data on the Action' do
+                expect { subject }.to change { Action.count }.by 1
+                form_data = Action.last.form_data
+                expect(form_data['card_num']).to eq '1881'
+                expect(form_data['is_subscription']).to eq false
+                expect(form_data['amount']).to eq amount.to_s
+                expect(form_data['currency']).to eq 'EUR'
+                expect(form_data['transaction_id']).to eq Payment::Braintree::Transaction.last.transaction_id
+              end
+
+              it 'creates a Transaction associated with the page storing relevant info' do
+                expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
+                transaction = Payment::Braintree::Transaction.last
+                expect(transaction.page).to eq page
+                expect(transaction.amount).to eq amount
+                expect(transaction.currency).to eq 'EUR'
+                expect(transaction.merchant_account_id).to eq 'EUR'
+                expect(transaction.payment_instrument_type).to eq 'credit_card'
+                expect(transaction.transaction_type).to eq 'sale'
+                expect(transaction.customer_id).to eq customer.customer_id
+                expect(transaction.customer).to eq customer
+                expect(transaction.status).to eq 'success'
+
+                expect(Payment::Braintree::PaymentMethod.find(transaction.payment_method_id)
+                       .token).to match a_string_matching(token_format)
+                expect(transaction.transaction_id).to match a_string_matching(token_format)
+              end
+
+              it 'updates Payment::Braintree::Customer with new token and last_4' do
+                previous_token = customer.default_payment_method
+                previous_last_4 = customer.card_last_4
+                expect { subject }.to change { Payment::Braintree::Customer.count }.by 0
+                new_token = Payment::Braintree::PaymentMethod.last
+                customer.reload
+                expect(customer.default_payment_method).to_not eq previous_token
+                expect(customer.default_payment_method).to eq Payment::Braintree::PaymentMethod.last
+                expect(customer.card_last_4).to match a_string_matching(four_digits)
+                expect(customer.card_last_4).not_to eq previous_last_4
+              end
+
+              it 'posts donation action to queue with key data' do
+                subject
+                expect(ChampaignQueue).to have_received(:push).with(donation_push_params)
+              end
+
+              it 'increments action count on page' do
+                expect { subject }.to change { page.reload.action_count }.by 1
+              end
+
+              it 'passes the params to braintree' do
+                allow(Braintree::Transaction).to receive(:sale).and_call_original
+                subject
+                expect(Braintree::Transaction).to have_received(:sale).with(amount: amount,
+                                                                            payment_method_nonce: 'fake-valid-nonce',
+                                                                            merchant_account_id: 'EUR',
+                                                                            options: {
+                                                                              submit_for_settlement: true,
+                                                                              store_in_vault_on_success: true
+                                                                            },
+                                                                            customer: {
+                                                                              first_name: 'Bernie',
+                                                                              last_name: 'Sanders',
+                                                                              email: 'itsme@feelthebern.org'
+                                                                            },
+                                                                            billing: {
+                                                                              first_name: 'Bernie',
+                                                                              last_name: 'Sanders',
+                                                                              street_address: '25 Elm Drive',
+                                                                              postal_code: '11225',
+                                                                              country_code_alpha2: 'US'
+                                                                            },
+                                                                            customer_id: customer.customer_id)
+              end
+
+              it 'leaves a cookie with the member_id' do
+                expect(cookies['member_id']).to eq nil
+                subject
+
+                # we can't access signed cookies in request specs, so check for hashed value
+                expect(cookies['member_id']).not_to eq nil
+                expect(cookies['member_id'].length).to be > 20
+              end
+
+              it 'updates the Member’s fields with any new data' do
+                expect(member.first_name).not_to eq 'Bernie'
+                expect(member.last_name).not_to eq 'Sanders'
+                expect(member.postal).to eq nil
+                expect(member.donor_status).to eq 'nondonor'
+                expect { subject }.to change { Member.count }.by 0
+                member.reload
+                expect(member.first_name).to eq 'Bernie'
+                expect(member.last_name).to eq 'Sanders'
+                expect(member.postal).to eq '11225'
+                expect(member.donor_status).to eq 'donor'
+              end
+
+              it 'responds successfully with transaction_id' do
+                subject
+                transaction_id = Payment::Braintree::Transaction.last.transaction_id
+                expect(response.status).to eq 200
+                expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
               end
             end
 
-            it 'increments redis counters' do
-              expect(Analytics::Page).to receive(:increment).with(page.id, new_member: true)
-              subject
+            context 'with Paypal' do
+              let(:amount) { 29.20 } # to avoid duplicate donations recording specs
+              let(:params) { basic_params.merge(user: user_params, payment_method_nonce: 'fake-paypal-future-nonce', amount: amount, store_in_vault: true) }
+
+              subject do
+                VCR.use_cassette('transaction success paypal existing customer') do
+                  post api_payment_braintree_transaction_path(page.id), params
+                end
+              end
+
+              it 'creates a Transaction associated with the page storing relevant info' do
+                expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
+                transaction = Payment::Braintree::Transaction.last
+
+                expect(transaction.page).to eq page
+                expect(transaction.amount).to eq amount
+                expect(transaction.currency).to eq 'EUR'
+                expect(transaction.merchant_account_id).to eq 'EUR'
+                expect(transaction.payment_instrument_type).to eq 'paypal_account'
+                expect(transaction.transaction_type).to eq 'sale'
+                expect(transaction.customer_id).to eq customer.customer_id
+                expect(transaction.customer).to eq customer
+                expect(transaction.status).to eq 'success'
+
+                expect(transaction.payment_method.token).to match a_string_matching(token_format)
+                expect(transaction.transaction_id).to match a_string_matching(token_format)
+              end
+
+              it 'updates Payment::Braintree::Customer with new token and PYPL for last_4' do
+                previous_token = customer.default_payment_method
+                previous_last_4 = customer.card_last_4
+                expect { subject }.to change { Payment::Braintree::Customer.count }.by 0
+                customer.reload
+                expect(customer.default_payment_method.token).to match a_string_matching(token_format)
+                expect(customer.default_payment_method).to eq Payment::Braintree::PaymentMethod.last
+                expect(customer.default_payment_method).not_to eq previous_token
+                expect(customer.card_last_4).to eq 'PYPL'
+              end
+
+              it 'stores PYPL as card_num on the Action' do
+                expect { subject }.to change { Action.count }.by 1
+                form_data = Action.last.form_data
+                expect(form_data['card_num']).to eq 'PYPL'
+                expect(form_data['is_subscription']).to eq false
+                expect(form_data['amount']).to eq amount.to_s
+                expect(form_data['currency']).to eq 'EUR'
+                expect(form_data['transaction_id']).to eq Payment::Braintree::Transaction.last.transaction_id
+              end
+
+              it 'passes PYPL as card_num to queue' do
+                subject
+                expect(ChampaignQueue).to have_received(:push).with(a_hash_including(
+                  params: a_hash_including(order: a_hash_including(card_num: 'PYPL'))
+                ))
+              end
+
+              it 'responds successfully with transaction_id' do
+                subject
+                transaction_id = Payment::Braintree::Transaction.last.transaction_id
+                expect(response.status).to eq 200
+                expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              end
+
+              it 'persists payment_method' do
+                subject
+
+                payment_method = Payment::Braintree::PaymentMethod.first
+
+                expect(payment_method.attributes).to include({
+                  token: token_format,
+                  instrument_type: 'paypal_account',
+                  email: 'payer@example.com'
+                }.stringify_keys)
+              end
+            end
+          end
+
+          context 'when BraintreeCustomer is new' do
+            context 'with basic params' do
+              let(:amount) { 13.20 } # to avoid duplicate donations recording specs
+              let(:params) { basic_params.merge(user: user_params, amount: amount) }
+              subject do
+                VCR.use_cassette('transaction success basic new customer') do
+                  post api_payment_braintree_transaction_path(page.id), params
+                end
+              end
+
+              it 'persists payment method for customer' do
+                subject
+
+                payment_method = Payment::Braintree::PaymentMethod.first
+
+                expect(payment_method.attributes).to include({
+                  last_4: '1881',
+                  token: token_format,
+                  card_type: 'Visa',
+                  bin: /\d{6}/,
+                  expiration_date: %r{\d{2}/\d{4}},
+                  instrument_type: 'credit_card'
+                }.stringify_keys)
+              end
+
+              it 'creates an Action associated with the Page and Member' do
+                expect { subject }.to change { Action.count }.by 1
+                expect(Action.last.page).to eq page
+                expect(Action.last.member).to eq member
+              end
+
+              it 'stores amount, currency, card_num, is_subscription, and transaction_id in form_data on the Action' do
+                expect { subject }.to change { Action.count }.by 1
+                form_data = Action.last.form_data
+                expect(form_data['card_num']).to eq '1881'
+                expect(form_data['is_subscription']).to eq false
+                expect(form_data['amount']).to eq amount.to_s
+                expect(form_data['currency']).to eq 'EUR'
+                expect(form_data['transaction_id']).to eq Payment::Braintree::Transaction.last.transaction_id
+                expect(form_data).to_not include('recurrence_number')
+              end
+
+              it 'creates a Transaction associated with the page storing relevant info' do
+                expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
+                transaction = Payment::Braintree::Transaction.last
+
+                expect(transaction.page).to eq page
+                expect(transaction.amount).to eq amount
+                expect(transaction.currency).to eq 'EUR'
+                expect(transaction.merchant_account_id).to eq 'EUR'
+                expect(transaction.payment_instrument_type).to eq 'credit_card'
+                expect(transaction.transaction_type).to eq 'sale'
+                expect(transaction.customer_id).to eq Payment::Braintree::Customer.last.customer_id
+                expect(transaction.status).to eq 'success'
+
+                expect(Payment::Braintree::PaymentMethod.find(transaction.payment_method_id)
+                       .token).to match a_string_matching(token_format)
+                expect(transaction.transaction_id).to match a_string_matching(token_format)
+              end
+
+              it 'creates new Payment::Braintree::Customer including token, customer_id, and last four for credit card' do
+                expect { subject }.to change { Payment::Braintree::Customer.count }.by 1
+                customer = Payment::Braintree::Customer.last
+                expect(customer.customer_id).not_to be_blank
+                expect(customer.card_last_4).to eq '1881'
+                expect(customer.default_payment_method).not_to be_blank
+                expect(customer.email).to eq user_params[:email]
+              end
+
+              it 'posts donation action to queue with key data' do
+                subject
+                expect(ChampaignQueue).to have_received(:push).with(donation_push_params)
+              end
+
+              it 'increments action count on page' do
+                expect { subject }.to change { page.reload.action_count }.by 1
+              end
+
+              it 'passes the params to braintree' do
+                allow(Braintree::Transaction).to receive(:sale).and_call_original
+                subject
+                expect(Braintree::Transaction).to have_received(:sale).with(amount: amount,
+                                                                            payment_method_nonce: 'fake-valid-nonce',
+                                                                            merchant_account_id: 'EUR',
+                                                                            options: {
+                                                                              submit_for_settlement: true,
+                                                                              store_in_vault_on_success: true
+                                                                            },
+                                                                            customer: {
+                                                                              first_name: 'Bernie',
+                                                                              last_name: 'Sanders',
+                                                                              email: 'itsme@feelthebern.org'
+                                                                            },
+                                                                            billing: {
+                                                                              first_name: 'Bernie',
+                                                                              last_name: 'Sanders',
+                                                                              street_address: '25 Elm Drive',
+                                                                              postal_code: '11225',
+                                                                              country_code_alpha2: 'US'
+                                                                            })
+              end
+
+              it 'leaves a cookie with the member_id' do
+                expect(cookies['member_id']).to eq nil
+                subject
+
+                # we can't access signed cookies in request specs, so check for hashed value
+                expect(cookies['member_id']).not_to eq nil
+                expect(cookies['member_id'].length).to be > 20
+              end
+
+              it 'updates the Member’s fields with any new data' do
+                expect(member.first_name).not_to eq 'Bernie'
+                expect(member.last_name).not_to eq 'Sanders'
+                expect(member.postal).to eq nil
+                expect { subject }.to change { Member.count }.by 0
+                member.reload
+                expect(member.first_name).to eq 'Bernie'
+                expect(member.last_name).to eq 'Sanders'
+                expect(member.postal).to eq '11225'
+              end
+
+              it 'responds successfully with transaction_id' do
+                subject
+                transaction_id = Payment::Braintree::Transaction.last.transaction_id
+                expect(response.status).to eq 200
+                expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              end
             end
 
-            it 'creates an Action associated with the Page and Member' do
-              expect { subject }.to change { Action.count }.by 1
-              expect(Action.last.page).to eq page
-              expect(Action.last.member).to eq Member.last
+            context 'with Paypal' do
+              let(:amount) { 19.20 } # to avoid duplicate donations recording specs
+              let(:params) { basic_params.merge(user: user_params, payment_method_nonce: 'fake-paypal-future-nonce', amount: amount) }
+
+              subject do
+                VCR.use_cassette('transaction success paypal new customer') do
+                  post api_payment_braintree_transaction_path(page.id), params
+                end
+              end
+
+              it 'creates a Transaction associated with the page storing relevant info' do
+                expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
+                transaction = Payment::Braintree::Transaction.last
+
+                expect(transaction.page).to eq page
+                expect(transaction.amount).to eq amount
+                expect(transaction.currency).to eq 'EUR'
+                expect(transaction.merchant_account_id).to eq 'EUR'
+                expect(transaction.payment_instrument_type).to eq 'paypal_account'
+                expect(transaction.transaction_type).to eq 'sale'
+                expect(transaction.customer_id).to eq Payment::Braintree::Customer.last.customer_id
+                expect(transaction.status).to eq 'success'
+
+                expect(Payment::Braintree::PaymentMethod.find(transaction.payment_method_id)
+                       .token).to match a_string_matching(token_format)
+                expect(transaction.transaction_id).to match a_string_matching(token_format)
+              end
+
+              it 'creates a Payment::Braintree::Customer with customer_id and PYPL for last 4' do
+                expect { subject }.to change { Payment::Braintree::Customer.count }.by 1
+                customer = Payment::Braintree::Customer.last
+                expect(customer.customer_id).not_to be_blank
+                expect(customer.card_last_4).to eq 'PYPL'
+                expect(customer.default_payment_method).not_to be_blank
+                expect(customer.email).to eq user_params[:email]
+              end
+
+              it 'stores PYPL as card_num on the Action' do
+                expect { subject }.to change { Action.count }.by 1
+                form_data = Action.last.form_data
+                expect(form_data['card_num']).to eq 'PYPL'
+                expect(form_data['is_subscription']).to eq false
+                expect(form_data['amount']).to eq amount.to_s
+                expect(form_data['currency']).to eq 'EUR'
+                expect(form_data['transaction_id']).to eq Payment::Braintree::Transaction.last.transaction_id
+              end
+
+              it 'passes PYPL as card_num to queue' do
+                subject
+                expect(ChampaignQueue).to have_received(:push).with(a_hash_including(
+                  params: a_hash_including(order: a_hash_including(card_num: 'PYPL'))
+                ))
+              end
+
+              it 'responds successfully with transaction_id' do
+                subject
+                transaction_id = Payment::Braintree::Transaction.last.transaction_id
+                expect(response.status).to eq 200
+                expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              end
             end
+          end
+        end
 
-            it 'leaves a cookie with the member_id' do
-              expect(cookies['member_id']).to eq nil
-              subject
+        context 'when Member is new' do
+          context 'when BraintreeCustomer is new' do
+            context 'with basic params' do
+              # we're using the same casette as above anyway, so we're only running specs
+              # relevant to the new member
 
-              # we can't access signed cookies in request specs, so check for hashed value
-              expect(cookies['member_id']).not_to eq nil
-              expect(cookies['member_id'].length).to be > 20
-            end
+              let(:amount) { 13.20 } # to avoid duplicate donations recording specs
+              let(:params) { basic_params.merge(user: user_params, amount: amount) }
 
-            it 'populates the Member’s fields with form data' do
-              expect { subject }.to change { Member.count }.by 1
-              member = Member.last
-              expect(member.first_name).to eq 'Bernie'
-              expect(member.last_name).to eq 'Sanders'
-              expect(member.postal).to eq '11225'
-              expect(member.donor_status).to eq 'donor'
-            end
+              subject do
+                VCR.use_cassette('transaction success basic new customer') do
+                  post api_payment_braintree_transaction_path(page.id), params
+                end
+              end
 
-            it 'responds successfully with transaction_id' do
-              subject
-              transaction_id = Payment::Braintree::Transaction.last.transaction_id
-              expect(response.status).to eq 200
-              expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              it 'increments redis counters' do
+                expect(Analytics::Page).to receive(:increment).with(page.id, new_member: true)
+                subject
+              end
+
+              it 'creates an Action associated with the Page and Member' do
+                expect { subject }.to change { Action.count }.by 1
+                expect(Action.last.page).to eq page
+                expect(Action.last.member).to eq Member.last
+              end
+
+              it 'leaves a cookie with the member_id' do
+                expect(cookies['member_id']).to eq nil
+                subject
+
+                # we can't access signed cookies in request specs, so check for hashed value
+                expect(cookies['member_id']).not_to eq nil
+                expect(cookies['member_id'].length).to be > 20
+              end
+
+              it 'populates the Member’s fields with form data' do
+                expect { subject }.to change { Member.count }.by 1
+                member = Member.last
+                expect(member.first_name).to eq 'Bernie'
+                expect(member.last_name).to eq 'Sanders'
+                expect(member.postal).to eq '11225'
+                expect(member.donor_status).to eq 'donor'
+              end
+
+              it 'responds successfully with transaction_id' do
+                subject
+                transaction_id = Payment::Braintree::Transaction.last.transaction_id
+                expect(response.status).to eq 200
+                expect(response.body).to eq({ success: true, transaction_id: transaction_id }.to_json)
+              end
             end
           end
         end

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -229,15 +229,15 @@ describe 'GoCardless API' do
                 name: "#{page.slug}-donation",
                 payment_account: 'GoCardless GBP'
               },
-              order: {
+              order: hash_including(
                 amount: gbp_amount.to_s,
                 currency:       'GBP',
                 card_num:       'DDEB',
                 card_code:      '007',
                 exp_date_month: '01',
                 exp_date_year:  '99'
-              },
-              user: {
+              ),
+              user: hash_including(
                 email: email,
                 country: 'United States',
                 postal: '11225',
@@ -247,16 +247,16 @@ describe 'GoCardless API' do
                 akid: '123.456.789',
                 source: 'fb',
                 user_en: 1
-              },
+              ),
               action: {
                 source: 'fb',
-                fields: {
+                fields: hash_including(
                   action_registered_voter: '1',
                   action_mobile: 'tablet',
                   action_mandate_reference: 'OMAR-JMEKNM53MREX3',
                   action_bank_name: 'BARCLAYS BANK PLC',
                   action_account_number_ending: '11'
-                }
+                )
               }
             }
           }
@@ -415,13 +415,14 @@ describe 'GoCardless API' do
               },
               action: {
                 source: 'fb',
-                fields: {
+                fields: hash_including(
                   action_registered_voter: '1',
                   action_mobile: 'tablet',
                   action_mandate_reference: 'OMAR-JMEKNM53MREX3',
                   action_bank_name: 'BARCLAYS BANK PLC',
-                  action_account_number_ending: '11'
-                }
+                  action_account_number_ending: '11',
+                  action_express_donation: 0
+                )
               }
             }
           }


### PR DESCRIPTION
I'm still in talks with Tara and Simona on whether this implementation is sufficient. I think they have a wish to have a custom field separate cookie and account based donors, but since the user flow is identical I'm not sure whether it's possible to deliver on that. I've asked Simona if it's all right to just pass a boolean if the action is an express donation. 

I spent quite a bit of time planning something for the Braintree payment processing utilities until I realized there's a different route and controller method for one-click donations. I think we might want to do some refactoring. After adding the custom action I went to modify the specs and noticed a comment about wanting to change the implementation to not use ActionBuilder. @osahyoun could you comment on that, since it was your comment? `spec/requests/api/braintree/braintree_spec.rb:124` - I'll comment directly on the line.