### PR TITLE
Fix bug where sticky sidebar flickered

### DIFF
--- a/app/assets/javascripts/member-facing/backbone/sidebar.js
+++ b/app/assets/javascripts/member-facing/backbone/sidebar.js
@@ -17,6 +17,7 @@ const Sidebar = Backbone.View.extend({
     }
     GlobalEvents.bindEvents(this);
     this.policeHeights();
+    window.setTimeout(this.policeHeights.bind(this), 200); // give sticky time to init
   },
 
   isSticky: function() {


### PR DESCRIPTION
The sticky js seems to have started to initialize after the sidebar positioning js, so I added a check 200 ms later just to be safe. Seems to clear it up just fine.