### PR TITLE
Only return stored payment methods

### DIFF
--- a/lib/api/stateless/payment_helper.rb
+++ b/lib/api/stateless/payment_helper.rb
@@ -10,11 +10,11 @@ module Api
         end
 
         def payment_methods_for_member(member)
-          customer(member).payment_methods.order('created_at desc')
+          customer(member).payment_methods.stored.order('created_at desc')
         end
 
         def payment_method_for_member(member:, id:)
-          customer(member).payment_methods.find(id)
+          payment_methods_for_member(member).find(id)
         end
 
         def subscriptions_for_member(member)

--- a/spec/requests/api/stateless/braintree/payment_methods_spec.rb
+++ b/spec/requests/api/stateless/braintree/payment_methods_spec.rb
@@ -6,7 +6,7 @@ describe 'API::Stateless Braintree PaymentMethods' do
   include AuthToken
   let!(:member) { create(:member, email: 'test@example.com') }
   let!(:customer) { create(:payment_braintree_customer, member: member) }
-  let!(:method_a) { create(:payment_braintree_payment_method, customer: customer) }
+  let!(:method_a) { create(:payment_braintree_payment_method, :stored, customer: customer) }
   let!(:method_b) { create(:payment_braintree_payment_method, customer: customer) }
 
   before :each do
@@ -19,6 +19,12 @@ describe 'API::Stateless Braintree PaymentMethods' do
   end
 
   describe 'GET index' do
+    it 'returns stored payment methods for member' do
+      get '/api/stateless/braintree/payment_methods', nil, auth_headers
+
+      expect(json_hash.length).to eq(1)
+    end
+
     it 'returns payment methods for member' do
       get '/api/stateless/braintree/payment_methods', nil, auth_headers
 


### PR DESCRIPTION
Some stored payment methods are stored because they're linked to subscriptions. When fetching member payment methods, we only want to return those payment methods that were stored as a result of the member's decision (payment methods with the `store_in_vault` flag set to `true`).