### PR TITLE
Correctly pass params to ActionKit for one click donations

### DIFF
--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -37,7 +37,9 @@ class PaymentController < ApplicationController
 
   def render_errors
     @errors = client::ErrorProcessing.new(builder.error_container, locale: locale).process
+
     @page = page
+
     respond_to do |format|
       format.html { render 'payment/donation_errors', layout: 'member_facing' }
       format.json { render json: { success: false, errors: @errors }, status: 422 }

--- a/app/services/action_queue.rb
+++ b/app/services/action_queue.rb
@@ -58,7 +58,9 @@ module ActionQueue
         akid:       data[:akid],
         postal:     data[:postal],
         address1:   data[:address1],
-        source:     data[:source]
+        source:     data[:source],
+        user_express_cookie: data[:store_in_vault] ? 1 : 0,
+        user_express_account: data[:express_account] ? 1 : 0
       }.merge(UserLanguageISO.for(page.language))
     end
 
@@ -172,7 +174,8 @@ module ActionQueue
         fields: action_fields.merge(
           action_account_number_ending:  data[:account_number_ending],
           action_mandate_reference:      data[:mandate_reference],
-          action_bank_name:              data[:bank_name]
+          action_bank_name:              data[:bank_name],
+          action_express_donation:       data[:express_donation] ? 1 : 0
         ),
         source: data[:source]
       }

--- a/app/services/action_queue.rb
+++ b/app/services/action_queue.rb
@@ -193,6 +193,10 @@ module ActionQueue
     def get_payment_account
       "GoCardless #{data[:currency]}"
     end
+
+    def user_data
+      super.except(:user_express_cookie, :user_express_account)
+    end
   end
 
   class DonationAction

--- a/app/services/braintree_services/one_click_service.rb
+++ b/app/services/braintree_services/one_click_service.rb
@@ -14,21 +14,27 @@ module BraintreeServices
 
       if payment_options.recurring?
         sale = make_subscription
+
         store_subscription_locally(sale) if sale.success?
       else
         sale = make_sale
+
         store_sale_locally(sale) if sale.success?
       end
     end
 
     private
 
-    def create_action
+    def create_action(_extra = {})
       ManageAction.create(
         params_for_action.merge(params[:user])
           .merge(params[:payment])
           .merge(page_id: params[:page_id])
-          .merge(action_express_donation: 1),
+          .merge(action_express_donation: 1,
+                 store_in_vault: true,
+                 express_account: payment_options.express_account?,
+                 card_num: payment_options.payment_method.last_4,
+                 card_expiration_date: payment_options.payment_method.expiration_date),
         extra_params: { donation: true },
         skip_counter: true,
         skip_queue: false

--- a/app/services/braintree_services/payment_options.rb
+++ b/app/services/braintree_services/payment_options.rb
@@ -30,6 +30,10 @@ module BraintreeServices
         .for_currency(params[:payment][:currency])
     end
 
+    def express_account?
+      authentication.present?
+    end
+
     def currency
       params[:payment][:currency]
     end
@@ -39,7 +43,11 @@ module BraintreeServices
     end
 
     def member
-      Member.find_by(email: params[:user][:email])
+      @member ||= Member.find_by(email: params[:user][:email])
+    end
+
+    def authentication
+      member.authentication
     end
 
     def page

--- a/app/services/email_verifier_service.rb
+++ b/app/services/email_verifier_service.rb
@@ -15,7 +15,6 @@ class EmailVerifierService
   def verify
     if verifier.success?
       bake_cookies
-      update_on_ak
       []
     else
       verifier.errors
@@ -23,18 +22,6 @@ class EmailVerifierService
   end
 
   private
-
-  def update_on_ak
-    ChampaignQueue.push(
-      type: 'update_member',
-      params: {
-        akid: @member.actionkit_user_id,
-        fields: {
-          express_account: 1
-        }
-      }
-    )
-  end
 
   def verifier
     @verifier ||= AuthTokenVerifier.new(@token, @member).verify

--- a/app/services/manage_braintree_donation.rb
+++ b/app/services/manage_braintree_donation.rb
@@ -3,18 +3,20 @@ class ManageBraintreeDonation
   include ActionBuilder
   PAYPAL_IDENTIFIER = 'PYPL'
 
-  def self.create(params:, braintree_result:, is_subscription: false)
+  def self.create(params:, braintree_result:, is_subscription: false, store_in_vault: false)
     new(
       params:           params,
       braintree_result: braintree_result,
-      is_subscription:  is_subscription
+      is_subscription:  is_subscription,
+      store_in_vault:   store_in_vault
     ).create
   end
 
-  def initialize(params:, braintree_result:, is_subscription: false)
+  def initialize(params:, braintree_result:, is_subscription: false, store_in_vault: false)
     @params = params
     @braintree_result = braintree_result
     @is_subscription = is_subscription
+    @store_in_vault = store_in_vault
   end
 
   def create
@@ -30,7 +32,8 @@ class ManageBraintreeDonation
         is_subscription:      @is_subscription,
         card_expiration_date: transaction.credit_card_details.expiration_date,
         payment_provider: 'braintree',
-        action_express_donation: 0
+        action_express_donation: 0,
+        store_in_vault:       @store_in_vault
       }.tap do |params|
         params[:recurrence_number] = 0 if @is_subscription
       end

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: "feature/one-click-donations"
+    branch: "feature.oneclick.actionkit"
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/lib/champaign_queue.rb
+++ b/lib/champaign_queue.rb
@@ -10,6 +10,7 @@ module ChampaignQueue
       client.push(opts)
     else
       false
+      # Clients::Direct.push(opts)
     end
   end
 

--- a/lib/payment_processor/braintree/subscription.rb
+++ b/lib/payment_processor/braintree/subscription.rb
@@ -75,7 +75,7 @@ module PaymentProcessor
       end
 
       def record_in_local_database(payment_method, customer_result, subscription_result)
-        @action = ManageBraintreeDonation.create(params: @user.merge(page_id: @page_id), braintree_result: subscription_result, is_subscription: true)
+        @action = ManageBraintreeDonation.create(params: @user.merge(page_id: @page_id), braintree_result: subscription_result, is_subscription: true, store_in_vault: @store_in_vault)
         customer = Payment::Braintree::BraintreeCustomerBuilder.build(customer_result.customer, payment_method, @action.member_id, existing_customer, store_in_vault: @store_in_vault)
 
         payment_method_id = customer.payment_methods.find_by(token: payment_method.token).id

--- a/lib/payment_processor/braintree/transaction.rb
+++ b/lib/payment_processor/braintree/transaction.rb
@@ -40,7 +40,7 @@ module PaymentProcessor
       def transact
         @result = ::Braintree::Transaction.sale(options)
         if @result.success?
-          @action = ManageBraintreeDonation.create(params: @user.merge(page_id: @page_id), braintree_result: @result, is_subscription: false)
+          @action = ManageBraintreeDonation.create(params: @user.merge(page_id: @page_id), braintree_result: @result, is_subscription: false, store_in_vault: @store_in_vault)
           Payment::Braintree.write_transaction(@result, @page_id, @action.member_id, existing_customer, store_in_vault: @store_in_vault)
         else
           Payment::Braintree.write_transaction(@result, @page_id, nil, existing_customer, store_in_vault: @store_in_vault)

--- a/spec/factories/payment_braintree_payment_method.rb
+++ b/spec/factories/payment_braintree_payment_method.rb
@@ -3,6 +3,8 @@ FactoryGirl.define do
   factory :payment_braintree_payment_method, class: 'Payment::Braintree::PaymentMethod' do
     customer_id { Faker::Number.number(6) }
     token 'MyString'
+    last_4 '1234'
+    expiration_date '12/2050'
     trait :stored do
       store_in_vault true
     end

--- a/spec/mailers/confirmation_mailer_spec.rb
+++ b/spec/mailers/confirmation_mailer_spec.rb
@@ -15,7 +15,7 @@ describe ConfirmationMailer do
       subject { mail.html_part.body.to_s }
 
       it 'has a thank you message' do
-        expected = /Thank you for your donation/
+        expected = /Thank you for registering/
 
         expect(subject).to match(expected)
       end
@@ -31,7 +31,7 @@ describe ConfirmationMailer do
       subject { mail.text_part.body.to_s }
 
       it 'has a thank you message' do
-        expected = /Thank you for your donation/
+        expected = /Thank you for registering/
 
         expect(subject).to match(expected)
       end

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -119,30 +119,29 @@ describe 'Express Donation' do
       expect(payment_method.customer).to eq(customer)
     end
 
-    # What's the status on this regarding the comment below? Why do we want to push outside of ActionBuilder?
-    it 'posts a donation to the queue with action_express_donation custom field - FIXME' do
-      # We want to post to queue, but outside of the action builder
+    it 'posts a donation to the queue with action_express_donation custom field' do
       expect(ChampaignQueue).to have_received(:push)
-        .with(hash_including(type: 'donation',
-                             payment_provider: 'braintree',
-                             params: {
-                               donationpage: {
-                                 name: 'hello-world-donation',
-                                 payment_account: 'Braintree GBP'
-                               },
-                               order: hash_including(amount: '2.0'),
-                               action: {
-                                 source: nil,
-                                 fields: {
-                                   action_express_donation: 1
-                                 }
-                               },
-                               user: hash_including(
-                                 first_name: 'John',
+        .with(
+          type: 'donation',
+          payment_provider: 'braintree',
+          params: {
+            donationpage: {
+              name: 'hello-world-donation',
+              payment_account: 'Braintree GBP'
+            },
+            order: hash_including(amount: '2.0',
+                                  card_num: '1234',
+                                  exp_date_month: '12',
+                                  exp_date_year: '2050'),
+            action: hash_including(fields: hash_including(action_express_donation: 1)),
+            user: hash_including(first_name: 'John',
                                  last_name: 'Doe',
-                                 email: 'test@example.com'
-                               )
-                             }))
+                                 email: 'test@example.com',
+                                 user_express_cookie: 1,
+                                 user_express_account: 0)
+          },
+          meta: hash_including({})
+        )
     end
   end
 end
@@ -176,6 +175,9 @@ describe 'Braintree API' do
                    action_id: instance_of(Fixnum))
   end
 
+  let(:action_express_donation) { 0 }
+  let(:user_express_cookie) { 0 }
+
   let(:donation_push_params) do
     {
       type: 'donation',
@@ -203,14 +205,15 @@ describe 'Braintree API' do
           last_name: 'Sanders',
           akid: '1234.5678.9910',
           source: 'fb',
-          user_en: 1
+          user_en: 1,
+          user_express_cookie: user_express_cookie
         ),
         action: {
           source: 'fb',
           fields: hash_including(
             action_registered_voter: '1',
             action_mobile: 'desktop',
-            action_express_donation: 0
+            action_express_donation: action_express_donation
           )
         }
       }
@@ -281,13 +284,14 @@ describe 'Braintree API' do
                                    user: hash_including(
                                      first_name: 'Bernie',
                                      last_name: 'Sanders',
-                                     email: 'itsme@feelthebern.org'
+                                     email: 'itsme@feelthebern.org',
+                                     user_express_cookie: 0
                                    )
                                  }))
         end
       end
 
-      describe " with storing in Braintree's vault" do
+      describe "with storing in Braintree's vault" do
         let(:basic_params) do
           {
             currency: 'EUR',
@@ -297,6 +301,8 @@ describe 'Braintree API' do
             store_in_vault: true
           }
         end
+
+        let(:user_express_cookie) { 1 }
 
         context 'when Member exists' do
           let!(:member) { create :member, email: user_params[:email], postal: nil, actionkit_user_id: 'woo_actionkit' }
@@ -372,7 +378,7 @@ describe 'Braintree API' do
                 previous_token = customer.default_payment_method
                 previous_last_4 = customer.card_last_4
                 expect { subject }.to change { Payment::Braintree::Customer.count }.by 0
-                new_token = Payment::Braintree::PaymentMethod.last
+                Payment::Braintree::PaymentMethod.last
                 customer.reload
                 expect(customer.default_payment_method).to_not eq previous_token
                 expect(customer.default_payment_method).to eq Payment::Braintree::PaymentMethod.last
@@ -810,7 +816,9 @@ describe 'Braintree API' do
               last_name: 'Sanders',
               akid: '1234.5678.9910',
               source: 'fb',
-              user_en: 1
+              user_en: 1,
+              user_express_cookie: user_express_cookie,
+              user_express_account: 0
             },
             action: {
               source: 'fb',

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -246,9 +246,7 @@ describe 'GoCardless API' do
                 last_name: 'Sanders',
                 akid: '123.456.789',
                 source: 'fb',
-                user_en: 1,
-                user_express_cookie: 0,
-                user_express_account: 0
+                user_en: 1
               ),
               action: {
                 source: 'fb',
@@ -413,9 +411,7 @@ describe 'GoCardless API' do
                 last_name: 'Sanders',
                 akid: '123.456.789',
                 source: 'fb',
-                user_en: 1,
-                user_express_cookie: 0,
-                user_express_account: 0
+                user_en: 1
               },
               action: {
                 source: 'fb',

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -246,7 +246,9 @@ describe 'GoCardless API' do
                 last_name: 'Sanders',
                 akid: '123.456.789',
                 source: 'fb',
-                user_en: 1
+                user_en: 1,
+                user_express_cookie: 0,
+                user_express_account: 0
               ),
               action: {
                 source: 'fb',
@@ -411,7 +413,9 @@ describe 'GoCardless API' do
                 last_name: 'Sanders',
                 akid: '123.456.789',
                 source: 'fb',
-                user_en: 1
+                user_en: 1,
+                user_express_cookie: 0,
+                user_express_account: 0
               },
               action: {
                 source: 'fb',

--- a/spec/requests/api/stateless/braintree/subscriptions_spec.rb
+++ b/spec/requests/api/stateless/braintree/subscriptions_spec.rb
@@ -60,7 +60,7 @@ describe 'API::Stateless Braintree Subscriptions' do
                                                        instrument_type: 'credit card',
                                                        token: '2ewruo4i5o3',
                                                        last_4: '2454',
-                                                       expiration_date: nil,
+                                                       expiration_date: '12/2050',
                                                        bin: nil,
                                                        email: customer.email,
                                                        card_type: 'Mastercard')

--- a/spec/requests/api/stateless/braintree/transactions_spec.rb
+++ b/spec/requests/api/stateless/braintree/transactions_spec.rb
@@ -59,7 +59,7 @@ describe 'API::Stateless Braintree Transactions' do
           instrument_type: 'credit card',
           token: '2ewruo4i5o3',
           last_4: '2454',
-          expiration_date: nil,
+          expiration_date: '12/2050',
           bin: nil,
           email: customer.email,
           card_type: 'Mastercard'

--- a/spec/requests/email_confirmation_spec.rb
+++ b/spec/requests/email_confirmation_spec.rb
@@ -19,17 +19,6 @@ describe 'Email Confirmation when signing up to express donations' do
       expect(response.body).to include('successfully confirmed your account')
       expect(auth.reload.confirmed_at).to_not be_nil
     end
-
-    it 'pushes a member update to the ActionKit queue' do
-      expect(ChampaignQueue).to receive(:push).with(type: 'update_member',
-                                                    params: {
-                                                      akid: 'actionkit_wohoo',
-                                                      fields: {
-                                                        express_account: 1
-                                                      }
-                                                    })
-      subject
-    end
   end
 
   context 'failure' do


### PR DESCRIPTION
A user's `express_cookie` and `express_account` fields are kept in synch whenever that user donates.  `express_cookie` is set when a member first opts-in to one-click, and `express_account` is set when a member donates with an authentication account created.