### PR TITLE
add facebook app id meta tag if available

### DIFF
--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -4,6 +4,8 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     title  = @page.title
     meta name="viewport" content="width=device-width, initial-scale=1.0"
     meta name="description" content=t('branding.description')
+    - if Settings.facebook_app_id.present?
+      meta property='fb:app_id' content="#{Settings.facebook_app_id}"
     = stylesheet_link_tag "member-facing"
     = javascript_include_tag "member-facing"
 


### PR DESCRIPTION
good catch by Paul that this was only happening in `liquid.slim`