### PR TITLE
Fix JS tests for one-click release

### DIFF
--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -57,13 +57,13 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     this.pageId = options.pageId;
     this.directDebitOpened = false;
     this.displayDirectDebit(options.showDirectDebit);
-    this.updateButton();
 
     this.paymentMethods = new Backbone.Collection(options.paymentMethods || []);
     this.paymentMethodsView = new PaymentMethodsView({ collection: this.paymentMethods });
 
     this.setOneClickVisibility();
     this.initializeRecurring(options.recurringDefault);
+    this.updateButton();
 
     GlobalEvents.bindEvents(this);
 

--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -37,6 +37,7 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
   //    followUpUrl: the url to redirect to after success
   //    submissionCallback: a function to call after success, receives the
   //      arguments received by the ajax call posting the donation
+  //    member: an object for an existing member. registered and email fields are used
   //    currency: the three letter capitalized currency code to use
   //    amount: a preselected donation amount, if > 0 the first step will be skipped
   //    showDirectDebit: boolean, whether to show the direct debit option
@@ -51,6 +52,11 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     this.followUpUrl = options.followUpUrl;
     if (typeof options.submissionCallback === 'function') {
       this.submissionCallback = options.submissionCallback;
+    }
+    if (typeof options.member === 'object') {
+      this.member = options.member;
+    } else {
+      this.member = {};
     }
 
     this.initializeSkipping(options);
@@ -299,6 +305,7 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     if (this.submissionCallback) {
       this.submissionCallback(data, status);
     }
+    return data;
   },
 
   submitOneClick(event) {
@@ -310,19 +317,19 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
       .then(this.onOneClickSuccess.bind(this), this.onOneClickFailed.bind(this));
   },
 
-  onOneClickSuccess(e, data) {
+  onOneClickSuccess(data) {
     if ( this.memberShouldRegister() ) {
-      this.followRedirect(this.registrationPath(window.champaign.personalization.member.email));
+      this.followRedirect(this.registrationPath(this.member.email));
     } else {
       this.followRedirect((data && data.follow_up_url) || this.followUpUrl);
     }
   },
 
-  transactionSuccess(e, data) {
-    const user = this.serializeUserForm();
+  transactionSuccess(data) {
     let url = (data && data.follow_up_url) || this.followUpUrl;
 
     if ( this.memberShouldRegister() ) {
+      const user = this.serializeUserForm();
       url = this.registrationPath(user.email);
     }
 
@@ -420,7 +427,7 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     // If we have no redirect URL or submission callback,
     // we display a thank you message
     if (!url && !this.submissionCallback) {
-      alert(I18n.t('fundraiser.thank_you'));
+      window.alert(I18n.t('fundraiser.thank_you'));
       return;
     }
 
@@ -457,7 +464,7 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
   },
 
   memberRegistered() {
-    return window.champaign.personalization.member.registered;
+    return this.member.registered;
   },
 
   memberShouldRegister() {

--- a/app/controllers/member_authentications_controller.rb
+++ b/app/controllers/member_authentications_controller.rb
@@ -39,7 +39,7 @@ class MemberAuthenticationsController < ApplicationController
   end
 
   def page
-    @page ||= Page.find(params[:id])
+    @page ||= Page.find(params[:page_id])
   end
 
   def redirect_signed_up_members

--- a/app/controllers/member_authentications_controller.rb
+++ b/app/controllers/member_authentications_controller.rb
@@ -25,7 +25,8 @@ class MemberAuthenticationsController < ApplicationController
 
     if auth.valid?
       flash[:notice] = I18n.t('member_registration.check_email')
-      render js: "window.location = '#{follow_up_page_path(params[:page_id])}'"
+      path = follow_up_member_facing_page_path(page.slug, member_id: auth.member_id)
+      render js: "window.location = '#{path}'"
     else
       render json: { errors: auth.errors }, status: 422
     end
@@ -35,6 +36,10 @@ class MemberAuthenticationsController < ApplicationController
 
   def member
     @member ||= Member.find_by(id: cookies.signed[:member_id], email: params[:email])
+  end
+
+  def page
+    @page ||= Page.find(params[:id])
   end
 
   def redirect_signed_up_members

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,7 +46,7 @@ class PagesController < ApplicationController
     # usually already included because of the logic to pass member_id to the follow_up_url
     # returned when an action is taken.
     if !params[:member_id].present? && recognized_member.try(:id).present?
-      return redirect_to follow_up_member_facing_page_path(@page.id, member_id: recognized_member.id)
+      return redirect_to follow_up_member_facing_page_path(@page, member_id: recognized_member.id)
     end
     liquid_layout = @page.follow_up_liquid_layout || @page.liquid_layout
     render_liquid(liquid_layout, :follow_up)

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -138,6 +138,7 @@
         chmp.myFundraiser = new chmp.Fundraiser({
           pageId:           "{{ id }}",
           followUpUrl:      "{{ follow_up_url }}",
+          member:           chmp.personalization.member,
           showDirectDebit:  chmp.personalization.showDirectDebit,
           currency:         chmp.personalization.urlParams.currency || chmp.personalization.location.currency,
           donationBands:    chmp.personalization.donationBands,

--- a/spec/controllers/member_authentications_controller_spec.rb
+++ b/spec/controllers/member_authentications_controller_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 
 describe MemberAuthenticationsController do
   describe 'POST create' do
-    let(:auth) { double('auth', valid?: true) }
-    let(:page) { double('page', page_id: '1', language: double('language', code: 'EN')) }
+    let(:auth) { double('auth', valid?: true, member_id: 34) }
+    let(:page) { double('page', slug: 'heyo', page_id: '1', language: double('language', code: 'EN')) }
 
     before do
       allow(MemberAuthenticationBuilder).to receive(:build) { auth }
@@ -19,8 +19,8 @@ describe MemberAuthenticationsController do
     end
 
     context 'successfully creates authentication' do
-      it 'returns with js snippet to redirect' do
-        expect(response.body).to match("window.location = '/pages/1/follow-up'")
+      it 'returns with js snippet to redirect that includes member id' do
+        expect(response.body).to match("window.location = '/a/heyo/follow-up?member_id=34'")
       end
 
       it 'sets flash notice' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -5,7 +5,7 @@ describe PagesController do
   let(:user) { instance_double('User', id: '1') }
   let(:default_language) { instance_double(Language, code: :en) }
   let(:language) { instance_double(Language, code: :fr) }
-  let(:page) { instance_double('Page', published?: true, featured?: true, id: '1', liquid_layout: '3', follow_up_liquid_layout: '4', language: default_language) }
+  let(:page) { instance_double('Page', published?: true, featured?: true, to_param: 'foo', id: '1', liquid_layout: '3', follow_up_liquid_layout: '4', language: default_language) }
   let(:renderer) { instance_double('LiquidRenderer', render: 'my rendered html', personalization_data: { some: 'data' }) }
 
   include_examples 'session authentication'
@@ -284,7 +284,7 @@ describe PagesController do
 
         it 'redirects to the same route with member id set' do
           subject
-          expect(response).to redirect_to follow_up_member_facing_page_path(1, member_id: member.id)
+          expect(response).to redirect_to follow_up_member_facing_page_path(page, member_id: member.id)
         end
       end
     end

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -205,7 +205,7 @@ describe("Fundraiser", function() {
         });
 
         it('hides the recurring box', function(){
-          expect($('input.fundraiser-bar__recurring').parents('.form__group')).to.have.class('hidden-irrelevant');
+          expect($('input.fundraiser-bar__recurring').parents('.form__group .checkbox-label')).to.have.class('hidden-irrelevant');
         });
 
         it('adds "/ month" the button text', function(){

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -205,7 +205,7 @@ describe("Fundraiser", function() {
         });
 
         it('hides the recurring box', function(){
-          expect($('input.fundraiser-bar__recurring').parents('.form__group .checkbox-label')).to.have.class('hidden-irrelevant');
+          expect($('input.fundraiser-bar__recurring').parents('label')).to.have.class('hidden-irrelevant');
         });
 
         it('adds "/ month" the button text', function(){
@@ -261,7 +261,7 @@ describe("Fundraiser", function() {
       }
 
       beforeEach(function(){
-        suite.followUpUrl = '/api/member_authentication/new?page_id=1&email=';
+        suite.memberAuthUrl = '/member_authentication/new?page_id=1&email=';
         suite.callback = sinon.spy();
       });
 
@@ -270,44 +270,84 @@ describe("Fundraiser", function() {
         Backbone.off();
       });
 
-      it('redirects to the followUpUrl if it is supplied', function(){
-        suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: suite.followUpUrl, pageId: '1'});
-        sinon.stub(suite.fundraiser, 'redirectTo');
-        suite.triggerSuccess();
-        expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.followUpUrl);
-        suite.fundraiser.redirectTo.restore();
+      describe('when store_in_vault is checked', function(){
+
+        beforeEach(function(){
+          $('input.fundraiser-bar__store-in-vault').prop('checked', true);
+        });
+
+        it('redirects to the member signup url if no url supplied in constructor or response', function(){
+          suite.fundraiser = new window.champaign.Fundraiser({pageId: '1'});
+          sinon.stub(suite.fundraiser, 'redirectTo');
+          suite.triggerSuccess();
+          expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.memberAuthUrl);
+          suite.fundraiser.redirectTo.restore();
+        });
+
+        it('overrides all follow up paths with member_authentication', function(){
+          suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: '/not-used', pageId: '1'});
+          sinon.stub(suite.fundraiser, 'redirectTo');
+          suite.triggerSuccess('{ "success": "true", "follow_up_url": "/this-one?a=b" }');
+          expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.memberAuthUrl);
+          suite.fundraiser.redirectTo.restore();
+        });
+
+        it('calls the callback function if it is supplied', function(){
+          var callback = sinon.spy();
+          suite.fundraiser = new window.champaign.Fundraiser({submissionCallback: callback, pageId: '1'});
+          sinon.stub(suite.fundraiser, 'redirectTo');
+          suite.triggerSuccess();
+          expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.memberAuthUrl);
+          expect(callback.called).to.eq(true);
+          suite.fundraiser.redirectTo.restore();
+        });
       });
 
-      it('redirects to the follow_up_url in the response if one is present', function(){
-        suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: '/not-used', pageId: '1'});
-        sinon.stub(suite.fundraiser, 'redirectTo');
-        suite.triggerSuccess('{ "success": "true", "follow_up_url": "/this-one?a=b" }');
-        expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/this-one?a=b');
-        suite.fundraiser.redirectTo.restore();
-      });
+      describe('when store_in_vault is not checked', function() {
 
-      it('calls the callback function if it is supplied', function(){
-        var callback = sinon.spy();
-        suite.fundraiser = new window.champaign.Fundraiser({submissionCallback: callback, pageId: '1'});
-        suite.triggerSuccess();
-        expect(callback.called).to.eq(true);
-      });
+        beforeEach(function(){
+          $('input.fundraiser-bar__store-in-vault').prop('checked', false);
+        });
 
-      it('calls the callback function and redirects to the followUpUrl if both supplied', function(){
-        var callback = sinon.spy();
-        suite.fundraiser = new window.champaign.Fundraiser({submissionCallback: callback, followUpUrl: suite.followUpUrl, pageId: '1'});
-        sinon.stub(suite.fundraiser, 'redirectTo');
-        suite.triggerSuccess();
-        expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.followUpUrl);
-        expect(callback.called).to.eq(true);
-        suite.fundraiser.redirectTo.restore();
-      });
+        it('redirects to the followUpUrl if it is supplied', function(){
+          suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: '/other-url', pageId: '1'});
+          sinon.stub(suite.fundraiser, 'redirectTo');
+          suite.triggerSuccess();
+          expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/other-url');
+          suite.fundraiser.redirectTo.restore();
+        });
 
-      it('sends an alert if neither callback nor followUpUrl passed', function(){
-        window.alert = sinon.spy();
-        suite.fundraiser = new window.champaign.Fundraiser({pageId: '1'});
-        suite.triggerSuccess();
-        expect(window.alert.called).to.eq(true);
+        it('redirects to the follow_up_url in the response if one is present', function(){
+          suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: '/not-used', pageId: '1'});
+          sinon.stub(suite.fundraiser, 'redirectTo');
+          suite.triggerSuccess('{ "success": "true", "follow_up_url": "/this-one?a=b" }');
+          expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/this-one?a=b');
+          suite.fundraiser.redirectTo.restore();
+        });
+
+        it('sends an alert if neither callback nor followUpUrl passed', function(){
+          window.alert = sinon.spy();
+          suite.fundraiser = new window.champaign.Fundraiser({pageId: '1'});
+          suite.triggerSuccess();
+          expect(window.alert.called).to.eq(true);
+        });
+
+        it('calls the callback function if it is supplied', function(){
+          var callback = sinon.spy();
+          suite.fundraiser = new window.champaign.Fundraiser({submissionCallback: callback, pageId: '1'});
+          suite.triggerSuccess();
+          expect(callback.called).to.eq(true);
+        });
+
+        it('calls the callback function and redirects to the followUpUrl if both supplied', function(){
+          var callback = sinon.spy();
+          suite.fundraiser = new window.champaign.Fundraiser({submissionCallback: callback, followUpUrl: '/other-url', pageId: '1'});
+          sinon.stub(suite.fundraiser, 'redirectTo');
+          suite.triggerSuccess();
+          expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/other-url');
+          expect(callback.called).to.eq(true);
+          suite.fundraiser.redirectTo.restore();
+        });
       });
     });
   });

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -301,6 +301,18 @@ describe("Fundraiser", function() {
           expect(callback.called).to.eq(true);
           suite.fundraiser.redirectTo.restore();
         });
+
+        it('redirects to passed followUpUrl if member is already registered', function(){
+          suite.fundraiser = new window.champaign.Fundraiser({
+            followUpUrl: '/not-used',
+            pageId: '1',
+            member: { registered: true, email: 'adsf@asdf.com' }
+          });
+          sinon.stub(suite.fundraiser, 'redirectTo');
+          suite.triggerSuccess('{ "success": "true", "follow_up_url": "/this-one?a=b" }');
+          expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/this-one?a=b');
+          suite.fundraiser.redirectTo.restore();
+        });
       });
 
       describe('when store_in_vault is not checked', function() {


### PR DESCRIPTION
This pull request manages to get all the existing javascript tests working with the new front-end logic, making some changes to reflect the new logic. All tests are passing for both ruby and javascript, but rubocop is failing some specs from my stuff that's already in development.

However, I don't think this PR should be merged and we should release without adding a few test cases to the fundraiser_spec.js that test the logic in `submitOneClick` and `onOneClickSuccess`. It's pretty straightforward to add them like the ones I've added in this PR. I'll do it when I get in if nobody else feels like doing it.