### PR TITLE
Check authentication has been confirmed.

### DIFF
--- a/app/models/member_authentication.rb
+++ b/app/models/member_authentication.rb
@@ -32,6 +32,10 @@ class MemberAuthentication < ActiveRecord::Base
     }
   end
 
+  def authenticate(password)
+    confirmed_at.present? && super(password).present?
+  end
+
   private
 
   def set_token

--- a/spec/models/member_authentication_spec.rb
+++ b/spec/models/member_authentication_spec.rb
@@ -36,10 +36,10 @@ describe MemberAuthentication do
   end
 
   context 'password authentication' do
-    subject { create(:member_authentication) }
+    subject { create(:member_authentication, confirmed_at: Time.now) }
 
     it 'is able to authenticate a password (via `has_secure_password`)' do
-      expect(subject.authenticate('password')).to eq(subject)
+      expect(subject.authenticate('password')).to be(true)
       expect(subject.authenticate('invalid_password')).to be(false)
     end
   end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -181,16 +181,24 @@ describe Member do
       end
     end
 
-    context 'when a member has a password authentication' do
-      before do
+    context 'when a member has an unconfirmed authentication' do
+      it 'returns `false`' do
         member.create_authentication(password: 'password')
+
+        expect(member.authenticate('password')).to be(false)
+      end
+    end
+
+    context 'when a member has a  confirmed authentication' do
+      before do
+        member.create_authentication(password: 'password', confirmed_at: Time.now)
       end
 
-      it 'returns the `:authentication` record when the password matches' do
-        expect(member.authenticate('password')).to be_a(MemberAuthentication)
+      it 'returns `true` when the password matches' do
+        expect(member.authenticate('password')).to be(true)
       end
 
-      it 'returns the `false` record when the password does not match' do
+      it 'returns `false` when the password does not match' do
         expect(member.authenticate('invalid_password')).to be(false)
       end
 

--- a/spec/requests/api/stateless/auth_spec.rb
+++ b/spec/requests/api/stateless/auth_spec.rb
@@ -8,7 +8,7 @@ describe 'API::Stateless Authentication' do
   let(:member) { create :member }
 
   before :each do
-    member.create_authentication(password: 'password')
+    member.create_authentication(password: 'password', confirmed_at: Time.now)
   end
 
   context 'Password Authentication' do

--- a/spec/requests/api/stateless/members_spec.rb
+++ b/spec/requests/api/stateless/members_spec.rb
@@ -172,7 +172,7 @@ describe 'API::Stateless Members' do
         post api_stateless_members_path, member: member_params, format: :json
 
         expect(response.body).to eq(member.to_json)
-        expect(member.authenticate('password')).to be_kind_of(MemberAuthentication)
+        expect(member.authentication).to be_a(MemberAuthentication)
       end
     end
 


### PR DESCRIPTION
We've been authorizing unconfirmed authentication records. `authenticate` now checks that `confirmed-at` isn't `nil`.