### PR TITLE
Survey ak sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/SumOfUs/actionkit_connector.git
-  revision: dd773c527ee1e411332c04bfb155ac7730837d83
+  revision: 4f822b6de92807f3e654b5c4b6724577c99fe1c3
   branch: master
   specs:
-    actionkit_connector (0.4.3)
+    actionkit_connector (0.4.4)
       httparty (~> 0.13)
 
 GIT

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -30,14 +30,16 @@ class Member < ActiveRecord::Base
   enum donor_status: [:nondonor, :donor, :recurring_donor]
 
   def self.find_from_request(akid: nil, id: nil)
-    actionkit_user_id = AkidParser.parse(akid, Settings.action_kit.akid_secret)[:actionkit_user_id]
-
-    if actionkit_user_id
-      member = where(actionkit_user_id: actionkit_user_id).order('created_at ASC').first
-      return member if member.present?
-    end
-
+    member = find_by_akid(akid)
+    return member if member.present?
     id.present? ? find_by(id: id) : nil
+  end
+
+  def self.find_by_akid(akid)
+    actionkit_user_id = AkidParser.parse(akid, Settings.action_kit.akid_secret)[:actionkit_user_id]
+    if actionkit_user_id.present?
+      where(actionkit_user_id: actionkit_user_id).order('created_at ASC').first
+    end
   end
 
   def name

--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -12,7 +12,7 @@ module ActionBuilder
       subscribed_member: subscribed_member
     }.merge(extra_attrs))
 
-    ActionQueue::Pusher.push(action)
+    ActionQueue::Pusher.push(:new_action, action)
     Analytics::Page.increment(page.id, new_member: subscribed_member)
 
     action

--- a/app/services/action_queue.rb
+++ b/app/services/action_queue.rb
@@ -31,10 +31,10 @@ module ActionQueue
           title:      page.title,
           uri:        "/a/#{page.slug}",
           slug:       page.slug,
-          first_name: member.first_name,
-          last_name:  member.last_name,
+          first_name: member.try(:first_name),
+          last_name:  member.try(:last_name),
           created_at: @action.created_at,
-          country:    country(member.country),
+          country:    country(member.try(:country)),
           action_id:  @action.id,
           subscribed_member: @action.subscribed_member
         }
@@ -76,20 +76,25 @@ module ActionQueue
   end
 
   class Pusher
-    def self.push(action)
-      if action.donation
-        if action.form_data.fetch('payment_provider', '').inquiry.go_cardless?
-          DirectDebitAction.push(action)
+    def self.push(event, action)
+      case event
+      when :new_action
+        if action.donation
+          if action.form_data.fetch('payment_provider', '').inquiry.go_cardless?
+            NewDirectDebitAction.push(action)
+          else
+            NewDonationAction.push(action)
+          end
         else
-          DonationAction.push(action)
+          NewPetitionAction.push(action)
         end
-      else
-        PetitionAction.push(action)
+      when :new_survey_response
+        NewSurveyResponse.push(action)
       end
     end
   end
 
-  class PetitionAction
+  class NewPetitionAction
     include Donatable
     include Enqueable
 
@@ -109,12 +114,21 @@ module ActionQueue
         }
           .merge(@action.form_data)
           .merge(UserLanguageISO.for(page.language))
-          .tap { |params| params[:country] = country(member.country) if member.country.present? }
+          .tap { |params| params[:country] = country(member.country) if member.try(:country).present? }
       }.deep_symbolize_keys
     end
   end
 
-  class DirectDebitAction
+  #TODO Refactor
+  class NewSurveyResponse < NewPetitionAction
+    def payload
+      super.tap do |p|
+        p[:type] = 'new_survey_response'
+      end
+    end
+  end
+
+  class NewDirectDebitAction
     include Enqueable
     include Donatable
 
@@ -190,7 +204,7 @@ module ActionQueue
     end
   end
 
-  class DonationAction
+  class NewDonationAction
     include Enqueable
     include Donatable
 

--- a/app/services/member_updater.rb
+++ b/app/services/member_updater.rb
@@ -1,0 +1,31 @@
+class MemberUpdater
+  def self.run(member, params)
+    new(member, params).run
+  end
+
+  def initialize(member, params)
+    @member, @params = member, params
+  end
+
+  def run
+    @member.name = @params[:name] if @params.key? :name
+    @member.actionkit_user_id = action_kit_user_id if action_kit_user_id.present?
+    @member.assign_attributes(filtered_params)
+    @member.save!
+  end
+
+  private
+
+  def action_kit_user_id
+    AkidParser.parse(@params[:akid], Settings.action_kit.akid_secret)[:actionkit_user_id]
+  end
+
+  def filtered_params
+    hash = @params.try(:to_unsafe_hash) || @params.to_h # for ActionController::Params
+    hash.symbolize_keys.compact.keep_if { |k| permitted_keys.include? k }
+  end
+
+  def permitted_keys
+    Member.new.attributes.keys.map(&:to_sym).reject! { |k| k == :id }
+  end
+end

--- a/lib/champaign_queue.rb
+++ b/lib/champaign_queue.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require_relative 'champaign_queue/clients/sqs'
-require_relative 'champaign_queue/clients/direct'
+require_relative 'champaign_queue/clients/http'
 
 module ChampaignQueue
   extend self
 
   def push(opts)
-    if Rails.env.production?
+    if Rails.env.production? || Settings.publish_champaign_events
       client.push(opts)
     else
       false
@@ -14,6 +14,10 @@ module ChampaignQueue
   end
 
   def client
-    Clients::Sqs
+    if Settings.champaign_queue_client == 'http'
+      Clients::HTTP
+    else
+      Clients::Sqs
+    end
   end
 end

--- a/lib/champaign_queue/clients/http.rb
+++ b/lib/champaign_queue/clients/http.rb
@@ -8,7 +8,7 @@ require 'net/http'
 
 module ChampaignQueue
   module Clients
-    class Direct
+    class HTTP
       class << self
         def push(params)
           new(params).push
@@ -20,7 +20,7 @@ module ChampaignQueue
       end
 
       def push
-        return false if ak_processor_url.blank?
+        raise "Champaign queue http URL not set" if queue_http_url.blank?
 
         Net::HTTP.start(uri.host, uri.port) do |http|
           http.post(uri.path, @params.to_query)
@@ -34,11 +34,11 @@ module ChampaignQueue
       private
 
       def uri
-        URI(ak_processor_url)
+        URI(queue_http_url)
       end
 
-      def ak_processor_url
-        Settings.ak_processor_url
+      def queue_http_url
+        Settings.champaign_queue_http_url
       end
     end
   end

--- a/spec/lib/champaign_queue/clients/http_spec.rb
+++ b/spec/lib/champaign_queue/clients/http_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe ChampaignQueue::Clients::Direct do
+describe ChampaignQueue::Clients::HTTP do
   before do
-    Settings.ak_processor_url = 'http://example.com/message'
+    Settings.champaign_queue_http_url = 'http://example.com/message'
   end
 
   before do
@@ -12,7 +12,7 @@ describe ChampaignQueue::Clients::Direct do
   end
 
   it 'posts directly to ActionKit worker' do
-    ChampaignQueue::Clients::Direct.push(foo: :bar)
+    ChampaignQueue::Clients::HTTP.push(foo: :bar)
     expect(@stub).to have_been_requested
   end
 end

--- a/spec/services/member_updater_spec.rb
+++ b/spec/services/member_updater_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe MemberUpdater do
+  describe '#filtered_params' do
+    let(:member) { build(:member) }
+
+    it "symbolizes keys" do
+      updater = MemberUpdater.new(member, 'email' => 'rod@rod.com')
+      expect(updater.send(:filtered_params)).to eq(email: 'rod@rod.com')
+    end
+
+    it "disregards unknown params" do
+      updater = MemberUpdater.new(member, email: 'rod@rod.com', blerg: false, akid:  '1234.514.lQVxcW')
+      expect(updater.send(:filtered_params)).to eq(email: 'rod@rod.com')
+    end
+  end
+
+  describe 'permitted_keys' do
+    let(:updater) { MemberUpdater.new(double("member"), {}) }
+
+    it 'returns symbols' do
+      expect(updater.send(:permitted_keys).map(&:class).uniq).to eq [Symbol]
+    end
+
+    it 'does not include the id' do
+      expect(updater.send(:permitted_keys)).not_to include(:id)
+    end
+
+    it 'includes all the other keys of member' do
+      expect(updater.send(:permitted_keys))
+        .to include(
+          :email,
+          :country,
+          :first_name,
+          :last_name,
+          :city,
+          :postal,
+          :title,
+          :address1,
+          :address2,
+          :actionkit_user_id
+        )
+    end
+  end
+end


### PR DESCRIPTION
Hey @NealJMD! here's a working version of the AK sync functionality for surveys. I still need to write a couple of tests, and define the format we're using to store and publish the survey data. 

Note: I refactored `ActionBuilder` in order to be able to reuse part of its functionality, mainly the ability to update a user from the action form params. You'll find other minor refactors and tweaks as well. 

Also, I'm not happy at all with the `ActionQueue::NewSurveyResponse` implementation, but in order to implement a good solution I would've had to rewrite the entire `ActionQueue` module, which I think we should put off for another time. 