### PR TITLE
Make country optional for MemberWithAuthentication

### DIFF
--- a/app/services/member_with_authentication.rb
+++ b/app/services/member_with_authentication.rb
@@ -5,7 +5,7 @@ class MemberWithAuthentication
   include ActiveModel::Model
 
   validates :password, length: { minimum: 6 }, allow_nil: true
-  validates :email, :country, presence: true
+  validates :email, presence: true
   validate  :cannot_be_already_authenticated, :cannot_have_non_matching_passwords
 
   attr_accessor(:first_name,

--- a/spec/services/member_with_authentication_spec.rb
+++ b/spec/services/member_with_authentication_spec.rb
@@ -43,16 +43,6 @@ describe MemberWithAuthentication do
       expect(builder.errors[:email].first).to eq("can't be blank")
     end
 
-    it 'on blank country' do
-      builder = MemberWithAuthentication.create(valid_params.except(:country))
-      expect(builder.errors[:country].first).to eq("can't be blank")
-    end
-
-    it 'on blank country' do
-      builder = MemberWithAuthentication.create(valid_params.except(:country))
-      expect(builder.errors[:country].first).to eq("can't be blank")
-    end
-
     it 'on non-matching passwords' do
       params = valid_params.merge(password: 'somethingelse')
       builder = MemberWithAuthentication.create(params)


### PR DESCRIPTION
The member's dashboard now only requires an email and a password (+ password confirmation) in order to register, so this PR removes the validation on `country`.