### PR TITLE
Reset the member when user clears the form

### DIFF
--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -129,6 +129,7 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
   },
 
   resetUser() {
+    this.member = {};
     this.paymentMethods.reset([]);
     this.showSecondStep();
     this.hideOneClickForm();


### PR DESCRIPTION
> If I click 'Not you?' when a member is identified and make a donation as another member while having 'save my payment method' checked, it does not take me to the account creation page.

The `fundraiser.js` code did not properly reset the user when we cleared the form. Since the redirection rules take into account member state, it needed to be properly cleared in order to behave as expected.

I also tried adding a test for this, but since we don't have unit tests for javascript code (yet), testing this with E2E/integration tests is not trivial and prone to error. Therefore:

 **TODO** create unit tests for JavaScript code.

Delivers [PT#132203247](https://www.pivotaltracker.com/story/show/132203247)