### PR TITLE
Pushes a cancellation message to the AK queue when a subscription gets cancelled

### DIFF
--- a/app/controllers/api/stateless/braintree/subscriptions_controller.rb
+++ b/app/controllers/api/stateless/braintree/subscriptions_controller.rb
@@ -14,14 +14,21 @@ module Api
           result = ::Braintree::Subscription.cancel(@subscription.subscription_id)
 
           if result.success?
-            @subscription.destroy
+            cancel_subscription
             render json: @subscription.slice(:id, :subscription_id)
           else
             render json: { success: false, errors: result.errors }, status: 422
           end
         rescue ::Braintree::NotFoundError
-          @subscription.destroy
+          cancel_subscription
           render json: { success: true }
+        end
+
+        private
+
+        def cancel_subscription
+          @subscription.destroy
+          @subscription.cancel_on_ak('user')
         end
       end
     end

--- a/app/controllers/api/stateless/braintree/subscriptions_controller.rb
+++ b/app/controllers/api/stateless/braintree/subscriptions_controller.rb
@@ -27,8 +27,8 @@ module Api
         private
 
         def cancel_subscription
-          @subscription.destroy
-          @subscription.cancel_on_ak('user')
+          @subscription.update(cancelled_at: Time.now)
+          @subscription.publish_cancellation('user')
         end
       end
     end

--- a/app/models/payment/braintree/subscription.rb
+++ b/app/models/payment/braintree/subscription.rb
@@ -26,7 +26,8 @@ class Payment::Braintree::Subscription < ActiveRecord::Base
                               foreign_key: :subscription_id
 
   scope :active, -> { where(cancelled_at: nil) }
-  def cancel_on_ak(reason)
+
+  def publish_cancellation(reason)
     # reason can be "user", "admin", "processor", "failure", "expired"
     ChampaignQueue.push(type: 'cancel_subscription',
                         params: {

--- a/app/models/payment/braintree/subscription.rb
+++ b/app/models/payment/braintree/subscription.rb
@@ -26,4 +26,12 @@ class Payment::Braintree::Subscription < ActiveRecord::Base
                               foreign_key: :subscription_id
 
   scope :active, -> { where(cancelled_at: nil) }
+  def cancel_on_ak(reason)
+    # reason can be "user", "admin", "processor", "failure", "expired"
+    ChampaignQueue.push(type: 'cancel_subscription',
+                        params: {
+                          recurring_id: subscription_id,
+                          canceled_by: reason
+                        })
+  end
 end

--- a/app/models/payment/go_cardless/subscription.rb
+++ b/app/models/payment/go_cardless/subscription.rb
@@ -105,4 +105,13 @@ class Payment::GoCardless::Subscription < ActiveRecord::Base
       transitions to: :active, after: Payment::GoCardless::Subscription::Charge
     end
   end
+
+  def cancel_on_ak(reason)
+    # reason can be "user", "admin", "processor", "failure", "expired"
+    ChampaignQueue.push(type: 'cancel_subscription',
+                        params: {
+                          recurring_id: go_cardless_id,
+                          canceled_by: reason
+                        })
+  end
 end

--- a/app/models/payment/go_cardless/subscription.rb
+++ b/app/models/payment/go_cardless/subscription.rb
@@ -106,7 +106,7 @@ class Payment::GoCardless::Subscription < ActiveRecord::Base
     end
   end
 
-  def cancel_on_ak(reason)
+  def publish_cancellation(reason)
     # reason can be "user", "admin", "processor", "failure", "expired"
     ChampaignQueue.push(type: 'cancel_subscription',
                         params: {

--- a/app/services/go_cardless_cancellation_service.rb
+++ b/app/services/go_cardless_cancellation_service.rb
@@ -26,6 +26,7 @@ class GoCardlessCancellationService
     )
     PaymentProcessor::GoCardless::Subscription.cancel(@subscription.go_cardless_id)
     @subscription.update(cancelled_at: Time.now)
+    @subscription.cancel_on_ak('user')
     return nil
   rescue *GO_CARDLESS_ERRORS => e
     Rails.logger.error("#{e} occurred when cancelling subscription #{@subscription.go_cardless_id}: #{e.message}")

--- a/app/services/go_cardless_cancellation_service.rb
+++ b/app/services/go_cardless_cancellation_service.rb
@@ -26,7 +26,7 @@ class GoCardlessCancellationService
     )
     PaymentProcessor::GoCardless::Subscription.cancel(@subscription.go_cardless_id)
     @subscription.update(cancelled_at: Time.now)
-    @subscription.cancel_on_ak('user')
+    @subscription.publish_cancellation('user')
     return nil
   rescue *GO_CARDLESS_ERRORS => e
     Rails.logger.error("#{e} occurred when cancelling subscription #{@subscription.go_cardless_id}: #{e.message}")

--- a/spec/models/payment/braintree/subscription_spec.rb
+++ b/spec/models/payment/braintree/subscription_spec.rb
@@ -42,13 +42,25 @@ describe Payment::Braintree::Subscription do
     expect(Payment::Braintree::Subscription.last.amount.class).to eq BigDecimal
   end
 
-  context 'scopes' do
+  describe 'scopes' do
     context 'active' do
       let!(:subscription) { create :payment_braintree_subscription, cancelled_at: nil }
       let!(:cancelled_subscription) { create :payment_braintree_subscription, cancelled_at: 1.month.ago }
       it 'only returns subscriptions that have not been cancelled' do
         expect(Payment::GoCardless::Subscription.active).to match([])
       end
+    end
+  end
+
+  describe 'cancel on ak' do
+    let(:subscription) { create(:payment_braintree_subscription, subscription_id: 'asd123') }
+    it 'pushes to the AK queue with correct parameters' do
+      expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
+                                                    params: {
+                                                      recurring_id: 'asd123',
+                                                      canceled_by: 'user'
+                                                    })
+      subscription.cancel_on_ak('user')
     end
   end
 end

--- a/spec/models/payment/braintree/subscription_spec.rb
+++ b/spec/models/payment/braintree/subscription_spec.rb
@@ -52,15 +52,15 @@ describe Payment::Braintree::Subscription do
     end
   end
 
-  describe 'cancel on ak' do
+  describe 'publish cancellation event' do
     let(:subscription) { create(:payment_braintree_subscription, subscription_id: 'asd123') }
-    it 'pushes to the AK queue with correct parameters' do
+    it 'pushes to the event queue with correct parameters' do
       expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
                                                     params: {
                                                       recurring_id: 'asd123',
                                                       canceled_by: 'user'
                                                     })
-      subscription.cancel_on_ak('user')
+      subscription.publish_cancellation('user')
     end
   end
 end

--- a/spec/models/payment/go_cardless/subscription_spec.rb
+++ b/spec/models/payment/go_cardless/subscription_spec.rb
@@ -149,13 +149,25 @@ describe Payment::GoCardless::Subscription do
     end
   end
 
-  context 'scopes' do
+  describe 'scopes' do
     context 'active' do
       let!(:subscription) { create :payment_go_cardless_subscription, cancelled_at: nil }
       let!(:cancelled_subscription) { create :payment_go_cardless_subscription, cancelled_at: 1.month.ago }
       it 'only returns subscriptions that have not been cancelled' do
         expect(Payment::GoCardless::Subscription.active).to match([subscription])
       end
+    end
+  end
+
+  describe 'cancel on ak' do
+    let(:subscription) { create(:payment_go_cardless_subscription, go_cardless_id: 'adklwe') }
+    it 'pushes to the AK queue with correct parameters' do
+      expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
+                                                    params: {
+                                                      recurring_id: 'adklwe',
+                                                      canceled_by: 'user'
+                                                    })
+      subscription.cancel_on_ak('user')
     end
   end
 end

--- a/spec/models/payment/go_cardless/subscription_spec.rb
+++ b/spec/models/payment/go_cardless/subscription_spec.rb
@@ -159,15 +159,15 @@ describe Payment::GoCardless::Subscription do
     end
   end
 
-  describe 'cancel on ak' do
+  describe 'publish cancellation event' do
     let(:subscription) { create(:payment_go_cardless_subscription, go_cardless_id: 'adklwe') }
-    it 'pushes to the AK queue with correct parameters' do
+    it 'pushes to the event queue with correct parameters' do
       expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
                                                     params: {
                                                       recurring_id: 'adklwe',
                                                       canceled_by: 'user'
                                                     })
-      subscription.cancel_on_ak('user')
+      subscription.publish_cancellation('user')
     end
   end
 end

--- a/spec/requests/api/stateless/braintree/subscriptions_spec.rb
+++ b/spec/requests/api/stateless/braintree/subscriptions_spec.rb
@@ -100,27 +100,29 @@ describe 'API::Stateless Braintree Subscriptions' do
       create(:payment_braintree_subscription, subscription_id: 'nosuchthing', customer: customer)
     end
 
-    it 'deletes the subscription locally and on Braintree' do
+    it 'marks the local subscription cancelled and deletes it on Braintree' do
       VCR.use_cassette('stateless api cancel subscription') do
-        delete "/api/stateless/braintree/subscriptions/#{cancel_this_subscription.id}", nil, auth_headers
-        expect(response.status).to eq(200)
-        expect do
-          ::Payment::Braintree::Subscription.find(cancel_this_subscription.id)
-        end.to raise_exception(ActiveRecord::RecordNotFound)
+        Timecop.freeze do
+          delete "/api/stateless/braintree/subscriptions/#{cancel_this_subscription.id}", nil, auth_headers
+          expect(response.status).to eq(200)
+          expect(::Payment::Braintree::Subscription.find(cancel_this_subscription.id).cancelled_at)
+            .to be_within(0.1.second).of(Time.now)
+        end
       end
     end
 
-    it 'returns success and deletes the subscription locally even if does not exist on Braintree' do
+    it 'returns success and marks the local subscription cancelled even if does not exist on Braintree' do
       VCR.use_cassette('stateless api cancel subscription failure') do
-        delete "/api/stateless/braintree/subscriptions/#{no_such_subscription.id}", nil, auth_headers
-        expect(response.status).to eq(200)
-        expect do
-          ::Payment::Braintree::Subscription.find(no_such_subscription.id)
-        end.to raise_exception(ActiveRecord::RecordNotFound)
+        Timecop.freeze do
+          delete "/api/stateless/braintree/subscriptions/#{no_such_subscription.id}", nil, auth_headers
+          expect(response.status).to eq(200)
+          expect(::Payment::Braintree::Subscription.find(no_such_subscription.id).cancelled_at)
+            .to be_within(0.1.second).of(Time.now)
+        end
       end
     end
 
-    it 'pushes a cancelled subscription event to the AK queue' do
+    it 'pushes a cancelled subscription event to the event queue' do
       VCR.use_cassette('stateless api cancel subscription') do
         expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
                                                       params: {

--- a/spec/requests/api/stateless/braintree/subscriptions_spec.rb
+++ b/spec/requests/api/stateless/braintree/subscriptions_spec.rb
@@ -119,5 +119,17 @@ describe 'API::Stateless Braintree Subscriptions' do
         end.to raise_exception(ActiveRecord::RecordNotFound)
       end
     end
+
+    it 'pushes a cancelled subscription event to the AK queue' do
+      VCR.use_cassette('stateless api cancel subscription') do
+        expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
+                                                      params: {
+                                                        recurring_id: '4ts4r2',
+                                                        canceled_by: 'user'
+                                                      })
+
+        delete "/api/stateless/braintree/subscriptions/#{cancel_this_subscription.id}", nil, auth_headers
+      end
+    end
   end
 end

--- a/spec/requests/api/stateless/go_cardless/subscriptions_spec.rb
+++ b/spec/requests/api/stateless/go_cardless/subscriptions_spec.rb
@@ -140,7 +140,7 @@ describe 'API::Stateless GoCardless Subscriptions' do
       end
     end
 
-    it 'pushes a cancelled subscription event to the AK queue' do
+    it 'pushes a cancelled subscription event to the event queue' do
       VCR.use_cassette('stateless api cancel go_cardless subscription') do
         expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
                                                       params: {

--- a/spec/requests/api/stateless/go_cardless/subscriptions_spec.rb
+++ b/spec/requests/api/stateless/go_cardless/subscriptions_spec.rb
@@ -139,5 +139,17 @@ describe 'API::Stateless GoCardless Subscriptions' do
         expect(Payment::GoCardless::Subscription.find(nonexistent_subscription.id).cancelled_at).to be nil
       end
     end
+
+    it 'pushes a cancelled subscription event to the AK queue' do
+      VCR.use_cassette('stateless api cancel go_cardless subscription') do
+        expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
+                                                      params: {
+                                                        recurring_id: 'SB00003GHBQ3YF',
+                                                        canceled_by: 'user'
+                                                      })
+
+        delete "/api/stateless/go_cardless/subscriptions/#{delete_subscription.id}", nil, auth_headers
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR is ready to review but depends on https://github.com/SumOfUs/champaign-ak-processor/pull/78, which depends on https://github.com/SumOfUs/actionkit_connector/pull/11.