### PR TITLE
Fix Active Admin

### DIFF
--- a/app/admin/action.rb
+++ b/app/admin/action.rb
@@ -4,6 +4,12 @@ ActiveAdmin.register Action do
 
   index pagination_total: false
   config.per_page = 20
+  scope :active, show_count: false
+
+  filter :page_title_cont, label: 'Page'
+  filter :subscribed_member
+  filter :donation
+  filter :created_at
 
   sidebar 'Previous Versions', only: :show do
     attributes_table_for action do

--- a/app/admin/action.rb
+++ b/app/admin/action.rb
@@ -2,6 +2,9 @@
 ActiveAdmin.register Action do
   actions :all, except: [:new, :edit]
 
+  index pagination_total: false
+  config.per_page = 20
+
   sidebar 'Previous Versions', only: :show do
     attributes_table_for action do
       row :versions do

--- a/app/admin/donation_band.rb
+++ b/app/admin/donation_band.rb
@@ -2,6 +2,11 @@
 ActiveAdmin.register DonationBand do
   actions :all, except: [:new, :edit]
 
+  index pagination_total: false
+  config.per_page = 20
+  scope :active, show_count: false
+  config.filters = false
+
   sidebar 'Previous Versions', only: :show do
     attributes_table_for donation_band do
       row :versions do

--- a/app/admin/image.rb
+++ b/app/admin/image.rb
@@ -4,6 +4,12 @@ ActiveAdmin.register Image do
 
   index pagination_total: false
   config.per_page = 20
+  scope :active, show_count: false
+
+  filter :page_title_cont, label: 'Page'
+  filter :content_file_name
+  filter :content_content_type
+  filter :content_file_size
 
   sidebar 'Previous Versions', only: :show do
     attributes_table_for image do

--- a/app/admin/image.rb
+++ b/app/admin/image.rb
@@ -2,6 +2,9 @@
 ActiveAdmin.register Image do
   actions :all, except: [:new, :edit, :destroy]
 
+  index pagination_total: false
+  config.per_page = 20
+
   sidebar 'Previous Versions', only: :show do
     attributes_table_for image do
       row :versions do

--- a/app/admin/language.rb
+++ b/app/admin/language.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 ActiveAdmin.register Language do
   permit_params :code, :name
+  config.filters = false
 
   sidebar 'Previous Versions', only: :show do
     attributes_table_for language do

--- a/app/admin/link.rb
+++ b/app/admin/link.rb
@@ -2,6 +2,15 @@
 ActiveAdmin.register Link do
   permit_params :url, :title, :date, :source, :link_id
 
+  index pagination_total: false
+  config.per_page = 20
+  scope :active, show_count: false
+
+  filter :page_title_cont, label: 'Page'
+  filter :url
+  filter :title
+  filter :source
+
   sidebar 'Previous Versions', only: :show do
     attributes_table_for link do
       row :versions do

--- a/app/admin/liquid_layout.rb
+++ b/app/admin/liquid_layout.rb
@@ -2,6 +2,16 @@
 ActiveAdmin.register LiquidLayout do
   actions :all, except: [:new, :edit]
 
+  index pagination_total: false
+  config.per_page = 20
+  scope :active, show_count: false
+
+  filter :title
+  filter :content
+  filter :experimental
+  filter :primary_layout
+  filter :post_action_layout
+
   index do
     selectable_column
     id_column

--- a/app/admin/liquid_partial.rb
+++ b/app/admin/liquid_partial.rb
@@ -2,6 +2,11 @@
 ActiveAdmin.register LiquidPartial do
   actions :all, except: [:new, :edit, :destroy]
 
+  filter :title
+  filter :content
+  filter :created_at
+  filter :updated_at
+
   index do
     selectable_column
     id_column

--- a/app/admin/member.rb
+++ b/app/admin/member.rb
@@ -13,6 +13,17 @@ ActiveAdmin.register Member do
 
   index pagination_total: false
   config.per_page = 20
+  scope :active, show_count: false
+
+  filter :email
+  filter :country
+  filter :first_name
+  filter :last_name
+  filter :city
+  filter :postal
+  filter :donor_status
+  filter :created_at
+  filter :updated_at
 
   actions :all, except: [:destroy]
 

--- a/app/admin/member.rb
+++ b/app/admin/member.rb
@@ -11,6 +11,9 @@ ActiveAdmin.register Member do
                 :address2,
                 :actionkit_member_id
 
+  index pagination_total: false
+  config.per_page = 20
+
   actions :all, except: [:destroy]
 
   sidebar 'Previous Versions', only: :show do

--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -3,7 +3,9 @@ ActiveAdmin.register Page do
   actions :all, except: [:new, :destroy]
   permit_params :active, :featured
 
-  index do
+  config.per_page = 20
+
+  index pagination_total: false do
     selectable_column
     id_column
     column :title

--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -4,6 +4,16 @@ ActiveAdmin.register Page do
   permit_params :active, :featured
 
   config.per_page = 20
+  scope :active, show_count: false
+
+  filter :liquid_layout, label: 'Layout'
+  filter :language
+  filter :follow_up_page_title_cont, label: 'Follow up page title'
+  filter :follow_up_liquid_layout, label: 'Follow up layout'
+  filter :title
+  filter :slug
+  filter :publish_status
+  filter :featured
 
   index pagination_total: false do
     selectable_column

--- a/app/admin/pages_tag.rb
+++ b/app/admin/pages_tag.rb
@@ -2,6 +2,9 @@
 ActiveAdmin.register PagesTag do
   permit_params :page_id, :tag_id
 
+  config.per_page = 20
+  index pagination_total: false
+
   index do
     selectable_column
     id_column

--- a/app/admin/pages_tag.rb
+++ b/app/admin/pages_tag.rb
@@ -4,6 +4,9 @@ ActiveAdmin.register PagesTag do
 
   config.per_page = 20
   index pagination_total: false
+  scope :active, show_count: false
+
+  filter :page_title_cont
 
   index do
     selectable_column


### PR DESCRIPTION
Our Active Admin interface used some out-of-the-box interfaces that made sense before launch, but once our database grew, were completely untenable. This included things like dropdown selectors with every single member listed in them. This remedies those things, and should have our ActiveAdmin not-timing-out again as soon as its deployed.