### PR TITLE
Correctly pass and handle recurring flag for one click payments

### DIFF
--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -82,12 +82,11 @@ module ActionBuilder
   end
 
   def is_donation?
-    return false if @extra_attrs.blank?
-    @extra_attrs[:donation] ? true : false
+    @extra_attrs && @extra_attrs[:donation]
   end
 
   def is_recurring_donation?
-    @params[:is_subscription] ? true : false
+    @params && @params[:is_subscription]
   end
 
   def form_data

--- a/app/services/manage_action.rb
+++ b/app/services/manage_action.rb
@@ -12,7 +12,7 @@ class ManageAction
     @params = params
     @skip_queue = skip_queue
     @skip_counter = skip_counter
-    @extra_params = extra_params
+    @extra_attrs = extra_params
   end
 
   def create
@@ -20,7 +20,7 @@ class ManageAction
       return previous_action
     end
 
-    build_action(@extra_params)
+    build_action(@extra_attrs)
   end
 
   private

--- a/circle.yml
+++ b/circle.yml
@@ -32,13 +32,13 @@ database:
 
 deployment:
   production:
-    branch: "feature/one-click-donations"
+    branch: "master"
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: "feature/one-click-donations"
+    branch: "development"
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/lib/payment_processor/braintree/one_click.rb
+++ b/lib/payment_processor/braintree/one_click.rb
@@ -53,6 +53,7 @@ module PaymentProcessor::Braintree
           .merge(page_id: params[:page_id])
           .merge(action_express_donation: 1,
                  store_in_vault: true,
+                 is_recurring: payment_options.recurring?,
                  express_account: payment_options.express_account?,
                  card_num: payment_options.payment_method.last_4,
                  card_expiration_date: payment_options.payment_method.expiration_date),

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -68,6 +68,10 @@ describe 'Express Donation' do
       end
     end
 
+    it 'sets donor status to "recurring_donor"' do
+      expect(member.reload.donor_status).to eq('recurring_donor')
+    end
+
     describe 'local record' do
       it 'creates action' do
         action = page.actions.first
@@ -143,6 +147,10 @@ describe 'Express Donation' do
 
         transaction = payment_method.transactions.first.attributes.symbolize_keys
         expect(transaction).to include(expected_attributes)
+      end
+
+      it 'sets donor status to "donor"' do
+        expect(member.reload.donor_status).to eq('donor')
       end
     end
 


### PR DESCRIPTION
`braintree/oneclick` wasn't passing ` is_recurring` to the `ManageAction`, nor were `extra_attrs` being properly defined. This block the class from correctly setting the `donor_status` field on `Member`.

Delivers [PT#132154343](https://www.pivotaltracker.com/story/show/132154343)