### PR TITLE
cancelled_at field for payment methods, returning only active payment methods through the stateless api, and marking subscriptions cancelled when a GC mandate is cancelled

### DIFF
--- a/app/controllers/api/stateless/braintree/payment_methods_controller.rb
+++ b/app/controllers/api/stateless/braintree/payment_methods_controller.rb
@@ -6,7 +6,7 @@ module Api
         before_filter :authenticate_request!
 
         def index
-          @payment_methods = PaymentHelper::Braintree.payment_methods_for_member(@current_member)
+          @payment_methods = PaymentHelper::Braintree.payment_methods_for_member(@current_member).active
         end
 
         def destroy
@@ -18,7 +18,7 @@ module Api
             Rails.logger.error("Payment Method #{@payment_method.token} not found on Braintree")
           end
 
-          @payment_method.destroy
+          @payment_method.update(cancelled_at: Time.now)
           PaymentHelper::Braintree.active_subscriptions_for_payment_method(@payment_method)
             .update_all(cancelled_at: Time.now)
           render json: { success: true }

--- a/app/controllers/api/stateless/go_cardless/payment_methods_controller.rb
+++ b/app/controllers/api/stateless/go_cardless/payment_methods_controller.rb
@@ -6,7 +6,7 @@ module Api
         before_filter :authenticate_request!
 
         def index
-          @payment_methods = PaymentHelper::GoCardless.payment_methods_for_member(@current_member)
+          @payment_methods = PaymentHelper::GoCardless.payment_methods_for_member(@current_member).active
         end
 
         def destroy

--- a/app/models/payment/braintree/payment_method.rb
+++ b/app/models/payment/braintree/payment_method.rb
@@ -20,4 +20,5 @@ class Payment::Braintree::PaymentMethod < ActiveRecord::Base
                             foreign_key: 'payment_method_id'
 
   scope :stored, -> { where(store_in_vault: true) }
+  scope :active, -> { where(cancelled_at: nil) }
 end

--- a/app/models/payment/go_cardless/payment_method.rb
+++ b/app/models/payment/go_cardless/payment_method.rb
@@ -57,4 +57,5 @@ class Payment::GoCardless::PaymentMethod < ActiveRecord::Base
   belongs_to :customer, class_name: 'Payment::GoCardless::Customer'
 
   validates :go_cardless_id, presence: true, allow_blank: false
+  scope :active, -> { where(cancelled_at: nil) }
 end

--- a/app/services/go_cardless_cancellation_service.rb
+++ b/app/services/go_cardless_cancellation_service.rb
@@ -13,6 +13,7 @@ class GoCardlessCancellationService
     )
     ::PaymentProcessor::GoCardless::Populator.client.mandates.cancel(@payment_method.go_cardless_id)
     @payment_method.update(cancelled_at: Time.now)
+    cancel_active_subscriptions(@payment_method)
     return nil
   rescue *GO_CARDLESS_ERRORS => e
     Rails.logger.error("#{e} occurred when cancelling mandate #{@payment_method.go_cardless_id}: #{e.message}")
@@ -31,5 +32,12 @@ class GoCardlessCancellationService
   rescue *GO_CARDLESS_ERRORS => e
     Rails.logger.error("#{e} occurred when cancelling subscription #{@subscription.go_cardless_id}: #{e.message}")
     return e
+  end
+
+  private
+
+  def self.cancel_active_subscriptions(mandate)
+    Api::Stateless::PaymentHelper::GoCardless.active_subscriptions_for_payment_method(mandate).
+      update_all(cancelled_at: Time.now)
   end
 end

--- a/app/services/go_cardless_cancellation_service.rb
+++ b/app/services/go_cardless_cancellation_service.rb
@@ -2,42 +2,42 @@
 # require './lib/api/stateless/payment_helper.rb'
 
 class GoCardlessCancellationService
-  GO_CARDLESS_ERRORS = [GoCardlessPro::InvalidApiUsageError,
-                        GoCardlessPro::InvalidStateError,
-                        GoCardlessPro::ValidationError,
-                        GoCardlessPro::GoCardlessError].freeze
+  class << self
+    GO_CARDLESS_ERRORS = [GoCardlessPro::InvalidApiUsageError,
+                          GoCardlessPro::InvalidStateError,
+                          GoCardlessPro::ValidationError,
+                          GoCardlessPro::GoCardlessError].freeze
 
-  def self.cancel_mandate(current_member, params)
-    @payment_method = Api::Stateless::PaymentHelper::GoCardless.payment_method_for_member(
-      member: current_member, id: params[:id]
-    )
-    ::PaymentProcessor::GoCardless::Populator.client.mandates.cancel(@payment_method.go_cardless_id)
-    @payment_method.update(cancelled_at: Time.now)
-    cancel_active_subscriptions(@payment_method)
-    return nil
-  rescue *GO_CARDLESS_ERRORS => e
-    Rails.logger.error("#{e} occurred when cancelling mandate #{@payment_method.go_cardless_id}: #{e.message}")
-    return e
-  end
+    def cancel_mandate(current_member, params)
+      @payment_method = Api::Stateless::PaymentHelper::GoCardless.payment_method_for_member(
+        member: current_member, id: params[:id]
+      )
+      ::PaymentProcessor::GoCardless::Populator.client.mandates.cancel(@payment_method.go_cardless_id)
+      @payment_method.update(cancelled_at: Time.now)
+      cancel_active_subscriptions(@payment_method)
+      return nil
+    rescue *GO_CARDLESS_ERRORS => e
+      Rails.logger.error("#{e} occurred when cancelling mandate #{@payment_method.go_cardless_id}: #{e.message}")
+      return e
+    end
 
-  def self.cancel_subscription(current_member, params)
-    @subscription = Api::Stateless::PaymentHelper::GoCardless.subscription_for_member(
-      member: current_member,
-      id: params[:id]
-    )
-    PaymentProcessor::GoCardless::Subscription.cancel(@subscription.go_cardless_id)
-    @subscription.update(cancelled_at: Time.now)
-    @subscription.publish_cancellation('user')
-    return nil
-  rescue *GO_CARDLESS_ERRORS => e
-    Rails.logger.error("#{e} occurred when cancelling subscription #{@subscription.go_cardless_id}: #{e.message}")
-    return e
-  end
+    def cancel_subscription(current_member, params)
+      @subscription = Api::Stateless::PaymentHelper::GoCardless.subscription_for_member(
+        member: current_member,
+        id: params[:id]
+      )
+      PaymentProcessor::GoCardless::Subscription.cancel(@subscription.go_cardless_id)
+      @subscription.update(cancelled_at: Time.now)
+      @subscription.publish_cancellation('user')
+      return nil
+    rescue *GO_CARDLESS_ERRORS => e
+      Rails.logger.error("#{e} occurred when cancelling subscription #{@subscription.go_cardless_id}: #{e.message}")
+      return e
+    end
 
-  private
-
-  def self.cancel_active_subscriptions(mandate)
-    Api::Stateless::PaymentHelper::GoCardless.active_subscriptions_for_payment_method(mandate).
-      update_all(cancelled_at: Time.now)
+    def cancel_active_subscriptions(mandate)
+      Api::Stateless::PaymentHelper::GoCardless.active_subscriptions_for_payment_method(mandate)
+        .update_all(cancelled_at: Time.now)
+    end
   end
 end

--- a/db/migrate/20161018221759_add_cancelled_at_to_braintree_payment_methods.rb
+++ b/db/migrate/20161018221759_add_cancelled_at_to_braintree_payment_methods.rb
@@ -4,4 +4,3 @@ class AddCancelledAtToBraintreePaymentMethods < ActiveRecord::Migration
     add_column :payment_braintree_payment_methods, :cancelled_at, :timestamp
   end
 end
-

--- a/db/migrate/20161018221759_add_cancelled_at_to_braintree_payment_methods.rb
+++ b/db/migrate/20161018221759_add_cancelled_at_to_braintree_payment_methods.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+class AddCancelledAtToBraintreePaymentMethods < ActiveRecord::Migration
+  def change
+    add_column :payment_braintree_payment_methods, :cancelled_at, :timestamp
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160916170801) do
+ActiveRecord::Schema.define(version: 20161018221759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -269,6 +269,7 @@ ActiveRecord::Schema.define(version: 20160916170801) do
     t.string   "instrument_type"
     t.string   "email"
     t.boolean  "store_in_vault",  default: false
+    t.datetime "cancelled_at"
   end
 
   add_index "payment_braintree_payment_methods", ["customer_id"], name: "braintree_customer_index", using: :btree

--- a/lib/api/stateless/payment_helper.rb
+++ b/lib/api/stateless/payment_helper.rb
@@ -10,7 +10,7 @@ module Api
         end
 
         def payment_methods_for_member(member)
-          customer(member).payment_methods.stored.order('created_at desc')
+          customer(member).payment_methods.stored.active.order('created_at desc')
         end
 
         def payment_method_for_member(member:, id:)
@@ -54,11 +54,15 @@ module Api
         end
 
         def payment_methods_for_member(member)
-          customer(member).payment_methods.order('created_at desc')
+          customer(member).payment_methods.active.order('created_at desc')
         end
 
         def payment_method_for_member(member:, id:)
           customer(member).payment_methods.find(id)
+        end
+
+        def active_subscriptions_for_payment_method(payment_method)
+          ::Payment::GoCardless::Subscription.active.where(payment_method_id: payment_method.id)
         end
       end
     end

--- a/spec/fixtures/vcr_cassettes/stateless_api_cancel_braintree_payment_method.yml
+++ b/spec/fixtures/vcr_cassettes/stateless_api_cancel_braintree_payment_method.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.sandbox.braintreegateway.com/merchants/<merchant_id>/payment_methods/any/2xyvw2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.54.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic djlmcGMyZ3pxZnh4NDVucTo0MWFlNWIxOGJlNTRjNTdjN2NiZmQyMTYxNDcxN2M2ZA==
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Tue, 18 Oct 2016 23:05:07 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - f3480a4e-d0ac-4648-bc16-d70633f6e2ca
+      X-Runtime:
+      - '0.065898'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAKOqBlgAAwAAAP//AwAAAAAAAAAAAA==
+    http_version: 
+  recorded_at: Tue, 18 Oct 2016 23:05:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/models/payment/go_cardless/payment_method_spec.rb
+++ b/spec/models/payment/go_cardless/payment_method_spec.rb
@@ -108,4 +108,16 @@ describe Payment::GoCardless::PaymentMethod do
       end.to change { subject.reload.cancelled? }.from(false).to(true)
     end
   end
+
+  describe 'scope' do
+    context 'active' do
+      let!(:active_method) { create(:payment_go_cardless_payment_method, cancelled_at: nil) }
+      let!(:cancelled_method) { create(:payment_go_cardless_payment_method, cancelled_at: Time.now) }
+
+      it 'returns payment methods that have not been cancelled' do
+        expect(Payment::GoCardless::PaymentMethod.active).to match([active_method])
+      end
+
+    end
+  end
 end

--- a/spec/models/payment/go_cardless/payment_method_spec.rb
+++ b/spec/models/payment/go_cardless/payment_method_spec.rb
@@ -117,7 +117,6 @@ describe Payment::GoCardless::PaymentMethod do
       it 'returns payment methods that have not been cancelled' do
         expect(Payment::GoCardless::PaymentMethod.active).to match([active_method])
       end
-
     end
   end
 end

--- a/spec/requests/api/stateless/braintree/payment_methods_spec.rb
+++ b/spec/requests/api/stateless/braintree/payment_methods_spec.rb
@@ -57,8 +57,8 @@ describe 'API::Stateless Braintree PaymentMethods' do
     it 'marks local record as cancelled' do
       Timecop.freeze do
         expect(response.status).to eq(200)
-        expect(Payment::Braintree::PaymentMethod.find(method_a.id).cancelled_at).
-          to be_within(0.1.seconds).of(Time.now)
+        expect(Payment::Braintree::PaymentMethod.find(method_a.id).cancelled_at)
+          .to be_within(0.1.seconds).of(Time.now)
       end
     end
 

--- a/spec/requests/api/stateless/braintree/payment_methods_spec.rb
+++ b/spec/requests/api/stateless/braintree/payment_methods_spec.rb
@@ -7,8 +7,9 @@ describe 'API::Stateless Braintree PaymentMethods' do
   let!(:member) { create(:member, email: 'test@example.com') }
   let!(:customer) { create(:payment_braintree_customer, member: member) }
   let(:month_ago) { 1.month.ago }
-  let!(:method_a) { create(:payment_braintree_payment_method, :stored, customer: customer, token: 'store_me') }
+  let!(:method_a) { create(:payment_braintree_payment_method, :stored, customer: customer, token: '2xyvw2') }
   let!(:method_b) { create(:payment_braintree_payment_method, customer: customer, token: 'dont_store_me') }
+  let!(:method_c) { create(:payment_braintree_payment_method, customer: customer, cancelled_at: month_ago) }
   let!(:subscription_a) { create(:payment_braintree_subscription, payment_method_id: method_a.id, cancelled_at: nil) }
   let!(:subscription_b) { create(:payment_braintree_subscription, payment_method_id: method_a.id, cancelled_at: nil) }
   let!(:subscription_c) { create(:payment_braintree_subscription, payment_method_id: method_b.id, cancelled_at: nil) }
@@ -36,10 +37,11 @@ describe 'API::Stateless Braintree PaymentMethods' do
       expect(json_hash.to_s).to include(method_a.token)
     end
 
-    it 'does not list payment methods that have not been stored in vault' do
+    it 'does not list inactive methods or payment methods that have not been stored in vault' do
       get '/api/stateless/braintree/payment_methods', nil, auth_headers
       expect(response.status).to eq(200)
       expect(json_hash.to_s).to_not include(method_b.token)
+      expect(json_hash.to_s).to_not include(method_c.token)
     end
   end
 
@@ -47,15 +49,17 @@ describe 'API::Stateless Braintree PaymentMethods' do
     let(:success_object) { double(success?: true) }
     before do
       allow(::Braintree::PaymentMethod).to receive(:delete) { success_object }
-      delete "/api/stateless/braintree/payment_methods/#{method_a.id}", nil, auth_headers
+      VCR.use_cassette('stateless api cancel braintree payment method') do
+        delete "/api/stateless/braintree/payment_methods/#{method_a.id}", nil, auth_headers
+      end
     end
 
-    it 'destroys record locally' do
-      expect(response.status).to eq(200)
-
-      expect(
-        Payment::Braintree::PaymentMethod.exists?(id: method_a.id)
-      ).to be false
+    it 'marks local record as cancelled' do
+      Timecop.freeze do
+        expect(response.status).to eq(200)
+        expect(Payment::Braintree::PaymentMethod.find(method_a.id).cancelled_at).
+          to be_within(0.1.seconds).of(Time.now)
+      end
     end
 
     it 'destroys record from Braintree' do

--- a/spec/requests/api/stateless/go_cardless/payment_method_spec.rb
+++ b/spec/requests/api/stateless/go_cardless/payment_method_spec.rb
@@ -77,8 +77,7 @@ describe 'API::Stateless GoCardless PaymentMethods' do
              customer: customer,
              created_at: last_month,
              cancelled_at: nil,
-             payment_method: delete_me
-      )
+             payment_method: delete_me)
     end
 
     let!(:subscription_b) do
@@ -86,8 +85,7 @@ describe 'API::Stateless GoCardless PaymentMethods' do
              customer: customer,
              created_at: last_month,
              cancelled_at: last_month,
-             payment_method: delete_me
-      )
+             payment_method: delete_me)
     end
 
     let!(:subscription_c) do
@@ -95,8 +93,7 @@ describe 'API::Stateless GoCardless PaymentMethods' do
              customer: customer,
              created_at: last_month,
              cancelled_at: nil,
-             payment_method: create(:payment_go_cardless_payment_method)
-      )
+             payment_method: create(:payment_go_cardless_payment_method))
     end
 
     it 'cancels the mandate on GoCardless and sets the cancelled_at field in the local record' do
@@ -120,7 +117,6 @@ describe 'API::Stateless GoCardless PaymentMethods' do
         end
       end
     end
-
 
     it 'returns errors and does not update the local record if GoCardless returns an error' do
       VCR.use_cassette('stateless api cancel go_cardless payment method failure') do

--- a/spec/requests/api/stateless/go_cardless/payment_method_spec.rb
+++ b/spec/requests/api/stateless/go_cardless/payment_method_spec.rb
@@ -26,7 +26,14 @@ describe 'API::Stateless GoCardless PaymentMethods' do
              next_possible_charge_date: Date.tomorrow,
              created_at: Time.now)
     end
-    it 'returns payment methods for member' do
+    let!(:cancelled_method) do
+      create(:payment_go_cardless_payment_method,
+             customer: customer,
+             go_cardless_id: 'asdfgf',
+             cancelled_at: 1.month.ago)
+    end
+
+    it 'returns list of active payment methods for member' do
       get '/api/stateless/go_cardless/payment_methods', nil, auth_headers
       expect(response.status).to eq(200)
       expect(json_hash.first.deep_symbolize_keys!).to include(id: 1432,
@@ -34,6 +41,11 @@ describe 'API::Stateless GoCardless PaymentMethods' do
                                                               scheme: 'bacs',
                                                               next_possible_charge_date: /^\d{4}-\d{2}-\d{2}/,
                                                               created_at: /^\d{4}-\d{2}-\d{2}/)
+    end
+
+    it 'does not return payment methods that have been cancelled' do
+      get '/api/stateless/go_cardless/payment_methods', nil, auth_headers
+      expect(json_hash.to_s).to_not include(cancelled_method.go_cardless_id)
     end
   end
 
@@ -58,6 +70,35 @@ describe 'API::Stateless GoCardless PaymentMethods' do
              created_at: Time.now)
     end
 
+    let(:last_month) { 1.month.ago }
+
+    let!(:subscription_a) do
+      create(:payment_go_cardless_subscription,
+             customer: customer,
+             created_at: last_month,
+             cancelled_at: nil,
+             payment_method: delete_me
+      )
+    end
+
+    let!(:subscription_b) do
+      create(:payment_go_cardless_subscription,
+             customer: customer,
+             created_at: last_month,
+             cancelled_at: last_month,
+             payment_method: delete_me
+      )
+    end
+
+    let!(:subscription_c) do
+      create(:payment_go_cardless_subscription,
+             customer: customer,
+             created_at: last_month,
+             cancelled_at: nil,
+             payment_method: create(:payment_go_cardless_payment_method)
+      )
+    end
+
     it 'cancels the mandate on GoCardless and sets the cancelled_at field in the local record' do
       Timecop.freeze do
         VCR.use_cassette('stateless api cancel go_cardless mandate') do
@@ -68,6 +109,18 @@ describe 'API::Stateless GoCardless PaymentMethods' do
         end
       end
     end
+
+    it 'marks active subcriptions with that method cancelled, but does not update cancelled subscriptions' do
+      Timecop.freeze do
+        VCR.use_cassette('stateless api cancel go_cardless mandate') do
+          delete "/api/stateless/go_cardless/payment_methods/#{delete_me.id}", nil, auth_headers
+          expect(subscription_a.reload.cancelled_at).to be_within(0.1.second).of(Time.now)
+          expect(subscription_b.reload.cancelled_at).to be_within(0.1.second).of(last_month)
+          expect(subscription_c.reload.cancelled_at).to eq(nil)
+        end
+      end
+    end
+
 
     it 'returns errors and does not update the local record if GoCardless returns an error' do
       VCR.use_cassette('stateless api cancel go_cardless payment method failure') do


### PR DESCRIPTION
For https://www.pivotaltracker.com/n/projects/1364614/stories/132682301 and https://www.pivotaltracker.com/n/projects/1364614/stories/132682369