### PR TITLE
Survey last features

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -52,4 +52,5 @@ require('campaigner-facing/layout_picker');
 
 window.PageEditBar =  require('campaigner-facing/page_edit_bar');
 window.Analytics   =  require('campaigner-facing/analytics');
+window.SurveyEditor       = require('campaigner-facing/survey_editor');
 window.FormElementCreator = require('campaigner-facing/form_element_creator');

--- a/app/assets/javascripts/campaigner-facing/collection_editor.js
+++ b/app/assets/javascripts/campaigner-facing/collection_editor.js
@@ -45,6 +45,7 @@ const ErrorDisplay = require('shared/show_errors');
     events: {
       'ajax:success #new_collection_element': 'newElementAdded',
       'ajax:success #change-form-template': 'templateChanged',
+      'ajax:error a[data-method=delete]': 'deleteFailed',
       'sortupdate': 'updateSort',
     },
 
@@ -54,6 +55,18 @@ const ErrorDisplay = require('shared/show_errors');
       this.$el.on('ajax:success', "a[data-method=delete]", function(){
         $(this).parents('.list-group-item').fadeOut();
       });
+    },
+
+    deleteFailed: function(e, xhr) {
+      let message = this.deleteErrorMessage(xhr);
+      alert(message);
+    },
+
+    deleteErrorMessage(xhr) {
+      let errors = xhr && xhr.responseJSON && xhr.responseJSON.errors;
+      if (!errors || Object.keys(errors).length < 1) return 'That element could not be deleted';
+      let firstKey = Object.keys(errors)[0];
+      return `That element ${errors[firstKey]}`;
     },
 
     substringMatcher: function(strs) {

--- a/app/assets/javascripts/campaigner-facing/collection_editor.js
+++ b/app/assets/javascripts/campaigner-facing/collection_editor.js
@@ -46,7 +46,7 @@ const ErrorDisplay = require('shared/show_errors');
       'ajax:success #new_collection_element': 'newElementAdded',
       'ajax:success #change-form-template': 'templateChanged',
       'ajax:error a[data-method=delete]': 'deleteFailed',
-      'sortupdate': 'updateSort',
+      'sortupdate .list-group': 'updateSort',
     },
 
     initialize: function(){

--- a/app/assets/javascripts/campaigner-facing/survey_editor.js
+++ b/app/assets/javascripts/campaigner-facing/survey_editor.js
@@ -1,0 +1,42 @@
+const GlobalEvents = require('shared/global_events');
+
+const SurveyEditor = Backbone.View.extend({
+
+  el: '.survey',
+
+  events: {
+    'sortupdate .survey__forms': 'handleSort',
+  },
+
+  globalEvents: {
+    'survey:form_added': 'makeSortable',
+  },
+
+  initialize(options={}) {
+    this.makeSortable();
+    this.id = this.$el.data('plugin-id');
+    GlobalEvents.bindEvents(this);
+  },
+
+  makeSortable() {
+    this.$('.survey__forms').sortable();
+  },
+
+  handleSort(e, ui) {
+    let ids = ui.item.parent().children().map(function(i, el){
+      return $(el).data('id');
+    }).get();
+    this.saveFormOrder(ids);
+  },
+
+  saveFormOrder(ids) {
+    $.ajax(`/plugins/surveys/${this.id}/sort`, {
+      method: 'PUT', 
+      data: { 'form_ids': ids.join(',') }
+    }).done(function(){
+      $.publish('plugin:form:preview:update');
+    });
+  },
+});
+
+module.exports = SurveyEditor;

--- a/app/assets/javascripts/member-facing/backbone/notification.js
+++ b/app/assets/javascripts/member-facing/backbone/notification.js
@@ -10,7 +10,6 @@ const Notification = Backbone.View.extend({
   },
 
   initialize() {
-    console.log(this.$el);
     window.setTimeout(this.appear.bind(this), this.OPEN_AFTER*1000);
     window.setTimeout(this.disappear.bind(this), this.CLOSE_AFTER*1000);
   },

--- a/app/assets/stylesheets/campaigner-facing/common.scss
+++ b/app/assets/stylesheets/campaigner-facing/common.scss
@@ -113,9 +113,9 @@ section {
   .sort {
     margin-right: 5px;
     .glyphicon {
-      color: #ddd;
-      &:active {
-        color: #000;
+      opacity: 0.3;
+      &:active, &:hover {
+        opacity: 1;
       }
     }
   }

--- a/app/assets/stylesheets/campaigner-facing/page-edit.scss
+++ b/app/assets/stylesheets/campaigner-facing/page-edit.scss
@@ -489,3 +489,10 @@ body.page-edit-body {
 .checkbox input[type="checkbox"].layout-type-checkbox {
   margin-left: 0px;
 }
+.form-sort-handle {
+  cursor: move;
+  opacity: 0.5;
+  &:hover, &:active {
+    opacity: 1;
+  }
+}

--- a/app/assets/stylesheets/member-facing/form.scss
+++ b/app/assets/stylesheets/member-facing/form.scss
@@ -101,8 +101,8 @@ label.checkbox-label {
   padding-left: 15px;
   text-indent: -15px;
   input[type='checkbox'] {
-    width: 13px;
-    height: 13px;
+    width: 14px;
+    height: 14px;
     padding: 0;
     margin:0;
     vertical-align: bottom;
@@ -117,6 +117,6 @@ label.checkbox-label {
     border-bottom: 2px solid red;
   }
   label {
-    margin: 12px 0 12px 10px;
+    margin: 22px 0 12px 10px;
   }
 }

--- a/app/assets/stylesheets/member-facing/survey.scss
+++ b/app/assets/stylesheets/member-facing/survey.scss
@@ -1,3 +1,4 @@
+// Member-facing survey styles
 .survey {
   @include centered-to-full(500px, 2%);
   min-height: calc(100vh - 300px);

--- a/app/assets/stylesheets/member-facing/survey.scss
+++ b/app/assets/stylesheets/member-facing/survey.scss
@@ -1,11 +1,15 @@
 // Member-facing survey styles
 .survey {
+  $font-size-breakpoint: 600px;
   @include centered-to-full(500px, 2%);
   min-height: calc(100vh - 300px);
   overflow: hidden;
   margin-top: 100px;
   &__intro {
     padding-top: 60px;
+    @media(min-width: $font-size-breakpoint) {
+      font-size: 18px;
+    }
   }
   &__skip-button {
     float: left;
@@ -13,7 +17,7 @@
   &__form {
     margin: 80px 0;
     overflow: hidden;
-    @media(min-width: 600px) {
+    @media(min-width: $font-size-breakpoint) {
       font-size: 18px;
     }
   }
@@ -26,6 +30,14 @@
       width: 48%;
       margin-right: 2%;
     }
+  }
+  &__instruction, &__question {
+    font-size: 20px;
+    @media(min-width: $font-size-breakpoint) {
+      font-size: 24px;
+    }
+    font-weight: lighter;
+    line-height: 1.4em;
   }
   .form--big input, 
   .form--big select, 
@@ -42,6 +54,12 @@
   }
   .form--big label.checkbox-label {
     font-size: inherit;
+    margin: 0 0 0 12px;
+    position: relative;
+    top: -10px;
+    input[type="checkbox"] {
+      top: -2px;
+    }
   }
   .form--big .has-error .selectize-control.single .selectize-input {
     border-color: $orange;

--- a/app/controllers/form_elements_controller.rb
+++ b/app/controllers/form_elements_controller.rb
@@ -17,13 +17,13 @@ class FormElementsController < ApplicationController
   end
 
   def destroy
-    @form_element = FormElement.find(params[:id])
-    @form_element.destroy
+    @form_element = FormElement.includes(:form).find(params[:id])
 
-    respond_to do |format|
-      format.json do
-        render json: { status: :ok }, status: :ok
-      end
+    if @form_element.can_destroy?
+      @form_element.destroy
+      render json: { status: :ok }, status: :ok
+    else
+      render json: { errors: @form_element.errors, name: :form_element }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/plugins/surveys_controller.rb
+++ b/app/controllers/plugins/surveys_controller.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 class Plugins::SurveysController < Plugins::BaseController
   def add_form
-    plugin = Plugins.find_for('survey', params[:plugin_id])
-    @form = Form.new(name: "survey_form_#{params[:plugin_id]}", master: false, formable: plugin)
+    survey = Plugins.find_for('survey', params[:plugin_id])
+    position = survey.forms.last.position + 1
+    @form = Form.new(name: "survey_form_#{params[:plugin_id]}",
+                     master: false,
+                     formable: survey,
+                     position: position)
 
     respond_to do |format|
       if @form.save
@@ -11,6 +15,15 @@ class Plugins::SurveysController < Plugins::BaseController
         format.js { render json: { errors: @form.errors }, status: :unprocessable_entity }
       end
     end
+  end
+
+  def sort_forms
+    ids = params[:form_ids].split(',')
+    ids.each_with_index do |id, index|
+      Form.where(id: id).update_all(position: index)
+    end
+
+    head :ok
   end
 
   private

--- a/app/liquid/views/partials/_survey_form.liquid
+++ b/app/liquid/views/partials/_survey_form.liquid
@@ -4,18 +4,18 @@
     <div class="form__group action-form__field-container">
       {% case field.data_type %}
       {% when 'text' or 'postal' %}
-        <label for="{{ field.name }}">{{ field.label }}</label>
+        <label for="{{ field.name }}" class="survey__question">{{ field.label }}</label>
         <input type="text" name="{{field.name}}" class="form-control form__content" maxlength="249" value="{{ field.default_value }}" />
       {% when 'hidden' %}
         <input type="hidden" name="{{field.name}}" class="form-control form__content" id="" value="{{ field.default_value }}" />
       {% when 'paragraph' %}
-        <label for="{{ field.name }}">{{ field.label }}</label>
+        <label for="{{ field.name }}" class="survey__question">{{ field.label }}</label>
         <textarea name="{{ field.name }}" class="form-control form__content" id="" maxlength="9999">{{ field.default_value }}</textarea>
       {% when 'email' %}
-        <label for="{{ field.name }}">{{ field.label }}</label>
+        <label for="{{ field.name }}" class="survey__question">{{ field.label }}</label>
         <input type="email" name="{{field.name}}" class="form-control mailcheck form__content" id="" value="{{ field.default_value }}" />
       {% when 'phone' %}
-        <label for="{{ field.name }}">{{ field.label }}</label>
+        <label for="{{ field.name }}" class="survey__question">{{ field.label }}</label>
         <input type="tel" name="{{field.name}}" class="form-control form__content" id="" value="{{ field.default_value }}" />
       {% when 'checkbox' %}
         {% if field.default_value == blank %}
@@ -28,7 +28,7 @@
           <input type="checkbox" name="{{field.name}}" class="form__content" value="1" {{ checked }}/> {{ field.label }}
         </label>
       {% when 'country' %}
-        <label for="{{ field.name }}">{{ field.label }}</label>
+        <label for="{{ field.name }}" class="survey__question">{{ field.label }}</label>
         <select name="{{field.name}}" class="action-form__country-selector form__content">
           <option></option>
           {% if field.default_value == blank %}
@@ -39,7 +39,7 @@
         </select>
       {% when 'choice' %}
         <div class="radio-container">
-          <div>{{ field.label }}</div>
+          <div class="survey__question">{{ field.label }}</div>
           {% for choice in field.choices %}
             <label for="{{ choice.id }}">
               <input id="{{ choice.id }}" name="{{ field.name }}" type="radio" value="{{ choice.value }}">
@@ -48,17 +48,17 @@
           {% endfor %}
         </div>
       {% when 'instruction' %}
-        <div class="form__instruction">
+        <div class="survey__instruction">
           {{ field.label }}
         </div>
       {% endcase %}
     </div>
   {% endfor %}
+  <button type="submit" class="button action-form__submit-button survey__button survey__next-button">{{ cta }}</button>
   {% if form.skippable %}
     {% unless last %}
       <!-- liquid doesn't support `not` or `!` -__- -->
       <a class="button button--inverted survey__button survey__skip-button">{{ skip }}</a>
     {% endunless %}
   {% endif %}
-  <button type="submit" class="button action-form__submit-button survey__button survey__next-button">{{ cta }}</button>
 </form>

--- a/app/models/form_element.rb
+++ b/app/models/form_element.rb
@@ -82,6 +82,15 @@ class FormElement < ActiveRecord::Base
     end
   end
 
+  def can_destroy?
+    if form.try(:formable).try(:required_form_elements).try(:include?, id)
+      errors.add(:base, "is required for this #{form.formable.class.name.demodulize}")
+      false
+    else
+      true
+    end
+  end
+
   private
 
   def choice_id(choice)

--- a/app/models/plugins/survey.rb
+++ b/app/models/plugins/survey.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Plugins::Survey < ActiveRecord::Base
-  has_many :forms, -> { order(created_at: :asc) }, as: :formable, dependent: :destroy
+  has_many :forms, -> { order(position: :asc, created_at: :asc) }, as: :formable, dependent: :destroy
 
   belongs_to :page, touch: true
   after_create :ensure_required_fields

--- a/app/views/plugins/surveys/_customize_form.slim
+++ b/app/views/plugins/surveys/_customize_form.slim
@@ -1,0 +1,12 @@
+.form-customization
+  .forms-edit
+    = render partial: 'forms/edit', locals: { form: form }
+
+  - if form
+    - klass = "forms-add-element-#{form.id}"
+    h4 data-toggle="collapse" data-target=".#{klass}" aria-expanded="false"
+      i.fa.fa-caret-right
+      = t('plugins.petition.add_new_field')
+      i.glyphicon.glyphicon-sort.pull-right.form-sort-handle
+    .forms-add-element.collapse class=klass
+      = render partial: 'forms/add_element', locals: { form: form, form_element: FormElement.new}

--- a/app/views/plugins/surveys/_form.slim
+++ b/app/views/plugins/surveys/_form.slim
@@ -2,10 +2,11 @@
   
     = render partial: 'plugins/shared/toggle_form', locals: { plugin: plugin, path: plugins_survey_path(plugin) }
 
-    .survey-forms.col-md-7
-      - plugin.forms.each do |form|
-        .well
-          = render partial: 'plugins/shared/customize_form', locals: { form: form }
+    .col-md-7
+      .survey__forms
+        - plugin.forms.each do |form|
+          .well.survey__container data-id=form.id
+            = render partial: 'plugins/surveys/customize_form', locals: { form: form }
       = form_for plugin, remote: true, url: plugins_add_survey_form_path(plugin), html: { method: 'post', class: 'form-element' } do |f|
         = f.hidden_field :id
         .form-group
@@ -19,3 +20,6 @@
 javascript:
   $.publish("collection:edit:loaded");
   $.publish("plugin:form:loaded");
+  $(document).ready(function(){
+    new SurveyEditor();
+  });

--- a/app/views/plugins/surveys/_survey.liquid
+++ b/app/views/plugins/surveys/_survey.liquid
@@ -2,20 +2,25 @@
   {% include 'No Script' %}
   <div class="script-dependent">
     {% for form in plugins.survey[ref].forms %}
-      {% capture cta %}{% if forloop.last == true %}Finish{% else %}Next{% endif %}{% endcapture %}
+      {% unless form.fields == empty %}
+        {% capture cta %}{% if forloop.last == true %}Finish{% else %}Next{% endif %}{% endcapture %}
 
-      {% include 'Survey Form',
-        cta: cta,
-        skip: 'Skip',
-        last: forloop.last,
-        form: form
-      %}
+        {% include 'Survey Form',
+          cta: cta,
+          skip: 'Skip',
+          last: forloop.last,
+          form: form
+        %}
+      {% endunless %}
     {% endfor %}
     
     <script type="text/javascript">
       $(document).ready(function(){
+        var wcp = window.champaign.personalization;
+        var prefill = _.extend(wcp.location, wcp.member, wcp.urlParams);
         window.champaign.mySurvey = new window.champaign.Survey({
           member:           window.champaign.personalization.member,
+          prefill:          prefill,
           location:         window.champaign.personalization.location,
           source:           window.champaign.personalization.urlParams.source,
           followUpUrl:      "{{ follow_up_url }}"

--- a/app/views/plugins/surveys/add_form.js.erb
+++ b/app/views/plugins/surveys/add_form.js.erb
@@ -1,2 +1,3 @@
-var html = "<div class='well'><%= j(render(partial: 'plugins/shared/customize_form', locals: {form: @form})) %></div>";
-$(".survey-forms").append(html);
+var html = "<div class='well'><%= j(render(partial: 'plugins/surveys/customize_form', locals: {form: @form})) %></div>";
+$(".survey__forms").append(html);
+$.publish('survey:form_added');

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: "development"
+    branch: "survey-last-features"
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
     resources :fundraisers, only: :update
     resources :surveys, only: :update
     post 'surveys/:plugin_id/form', to: 'surveys#add_form', as: 'add_survey_form'
+    put 'surveys/:plugin_id/sort', to: 'surveys#sort_forms', as: 'sort_survey_forms'
     get 'forms/:plugin_type/:plugin_id/', to: 'forms#show', as: 'form_preview'
     post 'forms/:plugin_type/:plugin_id/', to: 'forms#create', as: 'form_create'
   end

--- a/db/migrate/20161018213050_migration_add_position_to_forms.rb
+++ b/db/migrate/20161018213050_migration_add_position_to_forms.rb
@@ -1,0 +1,5 @@
+class MigrationAddPositionToForms < ActiveRecord::Migration
+  def change
+    add_column :forms, :position, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20161018213050_migration_add_position_to_forms.rb
+++ b/db/migrate/20161018213050_migration_add_position_to_forms.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class MigrationAddPositionToForms < ActiveRecord::Migration
   def change
     add_column :forms, :position, :integer, null: false, default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160916170801) do
+ActiveRecord::Schema.define(version: 20161018213050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 20160916170801) do
     t.boolean  "master",        default: false
     t.integer  "formable_id"
     t.string   "formable_type"
+    t.integer  "position",      default: 0,     null: false
   end
 
   add_index "forms", ["formable_type", "formable_id"], name: "index_forms_on_formable_type_and_formable_id", using: :btree

--- a/spec/controllers/form_elements_controller_spec.rb
+++ b/spec/controllers/form_elements_controller_spec.rb
@@ -60,22 +60,59 @@ describe FormElementsController do
 
   describe 'DELETE #destroy' do
     before do
+      allow(FormElement).to receive(:includes) { FormElement }
       allow(FormElement).to receive(:find) { element }
       allow(element).to receive(:destroy)
+      allow(element).to receive(:can_destroy?) { should_destroy }
 
       delete :destroy, form_id: '1', id: '2', format: :json
     end
 
-    it 'authenticates session' do
-      expect(request.env['warden']).to have_received(:authenticate!)
+    describe 'successfully' do
+      let(:should_destroy) { true }
+
+      it 'authenticates session' do
+        expect(request.env['warden']).to have_received(:authenticate!)
+      end
+
+      it 'finds form element' do
+        expect(FormElement).to have_received(:find).with('2')
+      end
+
+      it 'destroys element' do
+        expect(element).to have_received(:destroy)
+      end
+
+      it 'checks that the element can be destroyed' do
+        expect(element).to have_received(:can_destroy?)
+      end
+
+      it 'responds with 200' do
+        expect(response.status).to eq 200
+      end
     end
 
-    it 'finds form element' do
-      expect(FormElement).to have_received(:find).with('2')
-    end
+    describe 'unsuccessfully' do
+      let(:element) { instance_double('FormElement', valid?: true, errors: { base: ['cannot be deleted'] }) }
+      let(:should_destroy) { false }
 
-    it 'destroys element' do
-      expect(element).to have_received(:destroy)
+      before :each do
+        allow(element).to receive(:errors) { { base: ['cannot be deleted'] } }
+      end
+
+      let(:should_destroy) { false }
+
+      it 'does not destroy element' do
+        expect(element).to_not have_received(:destroy)
+      end
+
+      it 'responds with 422' do
+        expect(response.status).to eq 422
+      end
+
+      it 'includes errors' do
+        expect(response.body).to eq '{"errors":{"base":["cannot be deleted"]},"name":"form_element"}'
+      end
     end
   end
 end

--- a/spec/models/plugins/survey_spec.rb
+++ b/spec/models/plugins/survey_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Plugins::Survey do
+  let(:survey) { create :plugins_survey }
+  let(:french) { create :language, code: 'fr' }
+  let(:german) { create :language, code: 'de' }
+
+  describe 'auto-creation of email field' do
+
+    { de: 'E-MAIL', en: 'Email Address', fr: 'ADRESSE EMAIL' }.each_pair do |locale, label|
+      it "automatically adds a form with an email field labeled in #{locale}" do
+        page = create :page, language: (create :language, code: locale)
+        survey = Plugins::Survey.new(page: page)
+        expect(survey.save).to eq true
+        expect(survey.forms.size).to eq 1
+        expect(survey.forms.first.reload.form_elements.size).to eq 1
+        el = survey.forms.first.form_elements.first
+        expect(el.name).to eq 'email'
+        expect(el.data_type).to eq 'email'
+        expect(el.label).to eq label
+      end
+    end
+  end
+
+  describe 'required_form_elements' do
+
+    # this counts on the functionality spec'd above, that the survey auto-creates its own form
+    # with an email field on an after_create hook
+    let!(:form1) { create :form, formable: survey }
+
+    it 'does not require any of the email fields if there are two in the same form' do
+      email2 = create :form_element, name: 'email', data_type: 'email', form: survey.forms.first
+      expect(survey.required_form_elements).to eq []
+    end
+
+    it 'does not require any of the email fields if there are two in different forms' do
+      form2 = create :form, formable: survey
+      email2 = create :form_element, name: 'email', data_type: 'email', form: form2
+      expect(survey.reload.required_form_elements).to eq []
+    end
+
+    it 'does not require anything if the required fields are already missing' do
+      FormElement.destroy_all
+      create :form_element, name: 'action_survey_hair_color', form: form1
+      expect(survey.required_form_elements).to eq []
+    end
+
+    it 'requires the email field if there is only one' do
+      form2 = create :form, formable: survey
+      expect(survey.required_form_elements).to eq FormElement.where(form_id: survey.forms.first.id).map(&:id)
+    end
+  end
+end

--- a/spec/models/plugins/survey_spec.rb
+++ b/spec/models/plugins/survey_spec.rb
@@ -7,7 +7,6 @@ describe Plugins::Survey do
   let(:german) { create :language, code: 'de' }
 
   describe 'auto-creation of email field' do
-
     { de: 'E-MAIL', en: 'Email Address', fr: 'ADRESSE EMAIL' }.each_pair do |locale, label|
       it "automatically adds a form with an email field labeled in #{locale}" do
         page = create :page, language: (create :language, code: locale)
@@ -24,19 +23,18 @@ describe Plugins::Survey do
   end
 
   describe 'required_form_elements' do
-
     # this counts on the functionality spec'd above, that the survey auto-creates its own form
     # with an email field on an after_create hook
     let!(:form1) { create :form, formable: survey }
 
     it 'does not require any of the email fields if there are two in the same form' do
-      email2 = create :form_element, name: 'email', data_type: 'email', form: survey.forms.first
+      create :form_element, name: 'email', data_type: 'email', form: survey.forms.first
       expect(survey.required_form_elements).to eq []
     end
 
     it 'does not require any of the email fields if there are two in different forms' do
       form2 = create :form, formable: survey
-      email2 = create :form_element, name: 'email', data_type: 'email', form: form2
+      create :form_element, name: 'email', data_type: 'email', form: form2
       expect(survey.reload.required_form_elements).to eq []
     end
 
@@ -47,7 +45,7 @@ describe Plugins::Survey do
     end
 
     it 'requires the email field if there is only one' do
-      form2 = create :form, formable: survey
+      create :form, formable: survey
       expect(survey.required_form_elements).to eq FormElement.where(form_id: survey.forms.first.id).map(&:id)
     end
   end

--- a/spec/requests/form_elements_spec.rb
+++ b/spec/requests/form_elements_spec.rb
@@ -21,7 +21,7 @@ describe 'deleting survey elements' do
   it 'returns 200 when deleting a normal element' do
     form = survey.forms.first
     el = create :form_element, form: form
-    expect { delete("/forms/#{form.id}/form_elements/#{el.id}") }.to change { FormElement.count }.by -1
+    expect { delete("/forms/#{form.id}/form_elements/#{el.id}") }.to change { FormElement.count }.by(-1)
     expect(response.status).to eq 200
     expect(response.body).to eq '{"status":"ok"}'
   end

--- a/spec/requests/form_elements_spec.rb
+++ b/spec/requests/form_elements_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'deleting survey elements' do
+  let(:user) { instance_double('User', id: '1') }
+  let(:page) { create :page }
+  let(:survey) { create :plugins_survey, page: page }
+
+  before :each do
+    login_as(create(:user), scope: :user)
+  end
+
+  it 'returns an error message instead of deleting the last email' do
+    form = survey.forms.first
+    el = form.form_elements.first # it should be auto-created
+    expect { delete("/forms/#{form.id}/form_elements/#{el.id}") }.not_to change { FormElement.count }
+    expect(response.status).to eq 422
+    expect(response.body).to eq '{"errors":{"base":["is required for this Survey"]},"name":"form_element"}'
+  end
+
+  it 'returns 200 when deleting a normal element' do
+    form = survey.forms.first
+    el = create :form_element, form: form
+    expect { delete("/forms/#{form.id}/form_elements/#{el.id}") }.to change { FormElement.count }.by -1
+    expect(response.status).to eq 200
+    expect(response.body).to eq '{"status":"ok"}'
+  end
+end


### PR DESCRIPTION
This is the last round of edits for the survey tool. It makes a bunch of changes -
* survey plugins auto-create a form with an email field when the survey is created
* survey forms can be re-ordered
* if the answers to the first section of a survey are included in the link as URL params, the first section is submitted on page load
* visual polish