### PR TITLE
Optimizely snippet into member registration page

### DIFF
--- a/app/views/layouts/generic.slim
+++ b/app/views/layouts/generic.slim
@@ -7,6 +7,7 @@ html lang= I18n.locale
     = stylesheet_link_tag "member-facing"
     = javascript_include_tag "member-facing"
 
+    = render partial: 'shared/optimizely_snippet'
     = render partial: 'shared/google_analytics_snippet'
     = csrf_meta_tags
     = favicon_link_tag 'images/favicon.ico'


### PR DESCRIPTION
Notes:
- I'm not sure if this template is used for any other pages than the member registration page, but as it's member-facing I assume we want the snippet there (and I want it to test on the member registration page)
- Presumably the Optimizely snippet should be a setting, rather than hard coded into a partial, but I'm leaving that