### PR TITLE
Make pages api show 30 most recent

### DIFF
--- a/app/services/page_service.rb
+++ b/app/services/page_service.rb
@@ -5,14 +5,15 @@ module PageService
   def list(language: nil, limit: 30)
     Page.language(language)
       .limit(limit)
-      .order('created_at desc')
+      .order('updated_at desc')
       .published
   end
 
-  def list_featured(language: nil)
+  def list_featured(language: nil, limit: 30)
     Page.language(language)
       .featured
-      .order('created_at desc')
+      .limit(limit)
+      .order('updated_at desc')
       .published
   end
 end

--- a/spec/services/page_service_spec.rb
+++ b/spec/services/page_service_spec.rb
@@ -2,10 +2,13 @@
 require 'rails_helper'
 
 describe PageService do
+  let(:english) { create(:language, :english) }
+  let(:french) { create(:language, :french) }
+
   describe '.list' do
-    let!(:en_page) { create(:page, :published, language: create(:language, :english), created_at: 1.year.ago) }
-    let!(:en_unpublished) { create(:page, :unpublished, language: create(:language, :english)) }
-    let!(:fr_page) { create(:page, :published, language: create(:language, :french)) }
+    let!(:en_page) { create(:page, :published, language: english, updated_at: 1.year.ago) }
+    let!(:en_unpublished) { create(:page, :unpublished, language: english) }
+    let!(:fr_page) { create(:page, :published, created_at: 1.year.ago, language: french) }
 
     it 'returns pages by language' do
       expect(subject.list(language: 'fr')).to match_array([fr_page])
@@ -24,18 +27,18 @@ describe PageService do
       expect(subject.list(limit: 1).size).to eq(1)
     end
 
-    it 'orders pages by date (newest first)' do
+    it 'orders pages by date (most recently updated first)' do
       expect(subject.list).to match([fr_page, en_page])
     end
   end
 
   describe '.list_featured' do
     let!(:en_page) do
-      create(:page, :published, featured: true, language: create(:language, :english), created_at: 1.year.ago)
+      create(:page, :published, featured: true, language: english, updated_at: 1.year.ago)
     end
-    let!(:en_unpublished) { create(:page, :unpublished, language: create(:language, :english)) }
-    let!(:en_unfeatured) { create(:page, :published, language: create(:language, :english)) }
-    let!(:fr_page) { create(:page, :published, featured: true, language: create(:language, :french)) }
+    let!(:en_unpublished) { create(:page, :unpublished, language: english) }
+    let!(:en_unfeatured) { create(:page, :published, language: english) }
+    let!(:fr_page) { create(:page, :published, featured: true, created_at: 1.year.ago, language: french) }
 
     it 'returns featured pages by language' do
       expect(subject.list_featured(language: 'en')).to match_array([en_page])
@@ -45,7 +48,16 @@ describe PageService do
       expect(subject.list_featured).to match_array([en_page, fr_page])
     end
 
-    it 'orders pages by date (newest first)' do
+    it 'limits result to 30 by default' do
+      expect_any_instance_of(ActiveRecord::QueryMethods).to receive(:limit).with(30) { Page.all }
+      subject.list
+    end
+
+    it 'limits result by passed value' do
+      expect(subject.list(limit: 1).size).to eq(1)
+    end
+
+    it 'orders pages by date (most recently updated  first)' do
       expect(subject.list_featured).to match([fr_page, en_page])
     end
   end


### PR DESCRIPTION
We want the pages API to sort by the most recently updated campaigns, not most recently created, and we want the same limits interface for featured ones as unfeatured ones.