### PR TITLE
Pass delay_seconds to SQS client

### DIFF
--- a/lib/champaign_queue.rb
+++ b/lib/champaign_queue.rb
@@ -5,9 +5,9 @@ require_relative 'champaign_queue/clients/direct'
 module ChampaignQueue
   extend self
 
-  def push(opts)
+  def push(payload, opts = {})
     if Rails.env.production?
-      client.push(opts)
+      client.push(payload, opts)
     else
       false
     end

--- a/lib/champaign_queue/clients/sqs.rb
+++ b/lib/champaign_queue/clients/sqs.rb
@@ -4,20 +4,24 @@ module ChampaignQueue
   module Clients
     class Sqs
       class << self
-        def push(params)
-          new(params).push
+        # +params+ - The message to send. String maximum 256 KB in size.
+        # +delay+  - The number of seconds (0 to 900 - 15 minutes) to delay a specific message.
+        def push(params, delay: 0)
+          new(params, delay).push
         end
       end
 
-      def initialize(params)
+      def initialize(params, delay)
         @params = params
+        @delay = delay
       end
 
       def push
         return false if queue_url.blank?
 
         client.send_message(queue_url:    queue_url,
-                            message_body: @params.to_json)
+                            message_body: @params.to_json,
+                            delay_seconds: @delay)
       end
 
       private

--- a/lib/payment_processor/braintree/webhook_handler.rb
+++ b/lib/payment_processor/braintree/webhook_handler.rb
@@ -66,12 +66,12 @@ module PaymentProcessor
         record = Payment::Braintree.write_transaction(notification, original_action.page_id, original_action.member_id, customer, false)
         record.update(subscription: subscription)
 
-        ChampaignQueue.push(
+        ChampaignQueue.push({
           type: 'subscription-payment',
           params: {
             recurring_id: original_action.form_data['subscription_id']
           }
-        )
+        }, { delay: 120 })
 
         true
       end

--- a/spec/lib/champaign_queue/clients/sqs_spec.rb
+++ b/spec/lib/champaign_queue/clients/sqs_spec.rb
@@ -16,7 +16,7 @@ describe ChampaignQueue::Clients::Sqs do
         </SendMessageResponse>)
     end
 
-    let(:request_body) { 'Action=SendMessage&MessageBody=%7B%22foo%22%3A%22bar%22%7D&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F679051310897%2Fdemo&Version=2012-11-05' }
+    let(:request_body) { 'Action=SendMessage&DelaySeconds=0&MessageBody=%7B%22foo%22%3A%22bar%22%7D&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F679051310897%2Fdemo&Version=2012-11-05' }
     let(:request_uri)  { 'https://sqs.us-east-1.amazonaws.com/679051310897/demo' }
 
     before do
@@ -46,7 +46,6 @@ describe ChampaignQueue::Clients::Sqs do
 
     it 'does not deliver payload to AWS SQS Queue' do
       expect_any_instance_of(Aws::SQS::Client).to_not receive(:send_message)
-
       ChampaignQueue::Clients::Sqs.push(foo: :bar)
     end
   end

--- a/spec/lib/champaign_queue_spec.rb
+++ b/spec/lib/champaign_queue_spec.rb
@@ -10,7 +10,7 @@ describe ChampaignQueue do
 
       it 'delegates to Client::Sqs' do
         expect(ChampaignQueue::Clients::Sqs)
-          .to receive(:push).with(foo: 'bar')
+          .to receive(:push).with({ foo: 'bar' }, {})
 
         ChampaignQueue.push(foo: 'bar')
       end

--- a/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
@@ -50,13 +50,15 @@ describe PaymentProcessor::Braintree::WebhookHandler do
       end
 
       it 'posts events' do
+        expected_payload = {
+          type: 'subscription-payment',
+          params: {
+            recurring_id: 'foo'
+          }
+        }
+
         expect(ChampaignQueue).to receive(:push)
-          .with(
-            type: 'subscription-payment',
-            params: {
-              recurring_id: 'foo'
-            }
-          )
+          .with(expected_payload, delay: 120)
 
         subject
       end

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -94,10 +94,14 @@ describe 'Braintree API' do
         end
 
         it 'pushes to the queue with the right params' do
-          expect(ChampaignQueue).to receive(:push).with(type: 'subscription-payment',
-                                                        params: {
-                                                          recurring_id: /[a-z0-9]{6}/
-                                                        })
+          expected_payload = {
+            type: 'subscription-payment',
+            params: {
+              recurring_id: /[a-z0-9]{6}/
+            }
+          }
+
+          expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)
 
           subject
         end
@@ -140,10 +144,14 @@ describe 'Braintree API' do
         end
 
         it 'pushes to the queue with the right params' do
-          expect(ChampaignQueue).to receive(:push).with(type: 'subscription-payment',
-                                                        params: {
-                                                          recurring_id: /[a-z0-9]{6}/
-                                                        })
+          expected_payload = {
+            type: 'subscription-payment',
+            params: {
+              recurring_id: /[a-z0-9]{6}/
+            }
+          }
+
+          expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)
 
           subject
         end


### PR DESCRIPTION
We're processing a subscription transaction before the subscription record has been created on AK. This PR delays the processing of any webhook events by 2 minutes.