### PR TITLE
Raise errors on unexpected failure

### DIFF
--- a/app/controllers/plugins/petitions_controller.rb
+++ b/app/controllers/plugins/petitions_controller.rb
@@ -4,7 +4,9 @@ class Plugins::PetitionsController < ApplicationController
 
   def update
     @plugin = Plugins::Petition.find(params[:id])
-    @plugin.update_attributes(permitted_params)
+    # TODO; check for update result and return 422
+    # in case of error.
+    @plugin.update(permitted_params)
     @page = @plugin.page
 
     respond_to do |format|

--- a/app/controllers/plugins/surveys_controller.rb
+++ b/app/controllers/plugins/surveys_controller.rb
@@ -20,7 +20,7 @@ class Plugins::SurveysController < Plugins::BaseController
   def sort_forms
     ids = params[:form_ids].split(',')
     ids.each_with_index do |id, index|
-      Form.where(id: id).first.update_attributes(position: index)
+      Form.where(id: id).first.update!(position: index)
     end
 
     head :ok

--- a/app/models/payment/go_cardless.rb
+++ b/app/models/payment/go_cardless.rb
@@ -7,13 +7,13 @@ module Payment::GoCardless
 
     def write_customer(customer_gc_id, member_id)
       local_customer = Payment::GoCardless::Customer.find_or_initialize_by(go_cardless_id: customer_gc_id)
-      local_customer.update_attributes(member_id: member_id)
+      local_customer.update!(member_id: member_id)
       local_customer
     end
 
     def write_mandate(mandate_gc_id, scheme, next_possible_charge_date, customer_id)
       local_mandate = Payment::GoCardless::PaymentMethod.find_or_initialize_by(go_cardless_id: mandate_gc_id)
-      local_mandate.update_attributes(scheme: scheme, next_possible_charge_date: next_possible_charge_date, customer_id: customer_id)
+      local_mandate.update!(scheme: scheme, next_possible_charge_date: next_possible_charge_date, customer_id: customer_id)
       local_mandate
     end
 

--- a/app/models/plugins.rb
+++ b/app/models/plugins.rb
@@ -18,7 +18,7 @@ module Plugins
       plugin.page_id = page.id
       plugin.active = true
       plugin.ref = ref if ref.present?
-      plugin.save
+      plugin.save!
     end
 
     def registered

--- a/app/models/plugins/has_form.rb
+++ b/app/models/plugins/has_form.rb
@@ -31,7 +31,7 @@ module Plugins::HasForm
 
   def dup
     clone = super
-    clone.save
+    clone.save!
 
     clone.form.form_elements = form.form_elements.map(&:dup) if clone.form
 

--- a/app/services/form_duplicator.rb
+++ b/app/services/form_duplicator.rb
@@ -14,7 +14,7 @@ class FormDuplicator
     @form.form_elements.each do |element|
       element = element.dup
       element.form = new_form
-      element.save
+      element.save!
     end
 
     new_form
@@ -25,7 +25,7 @@ class FormDuplicator
   def new_form
     @new_form ||= @form.dup.tap do |f|
       f.master = false
-      f.save
+      f.save!
     end
   end
 end

--- a/app/services/form_element_builder.rb
+++ b/app/services/form_element_builder.rb
@@ -12,7 +12,7 @@ class FormElementBuilder
   end
 
   def create
-    element.save
+    element.save!
     element
   end
 

--- a/app/services/manage_donation.rb
+++ b/app/services/manage_donation.rb
@@ -79,7 +79,7 @@ class DonationActionBuilder
     update_member_fields
     update_donor_status
 
-    @user.save if @user.changed
+    @user.save! if @user.changed
     @user
   end
 

--- a/app/services/member_updater.rb
+++ b/app/services/member_updater.rb
@@ -13,7 +13,7 @@ class MemberUpdater
     @member.name = @params[:name] if @params.key? :name
     @member.actionkit_user_id = action_kit_user_id if action_kit_user_id.present?
     @member.assign_attributes(filtered_params)
-    @member.save
+    @member.save!
   end
 
   private

--- a/app/services/page_cloner.rb
+++ b/app/services/page_cloner.rb
@@ -29,9 +29,9 @@ class PageCloner
     @cloned_page.title = @title unless @title.blank?
 
     ActiveRecord::Base.transaction do
-      @cloned_page.save # so the new page will have an id to associate with
+      @cloned_page.save! # so the new page will have an id to associate with
       yield(self)
-      @cloned_page.save
+      @cloned_page.save!
     end
 
     @cloned_page
@@ -41,7 +41,7 @@ class PageCloner
     page.links.each do |link|
       link.dup.tap do |clone|
         clone.page = cloned_page
-        clone.save
+        clone.save!
       end
     end
   end
@@ -52,7 +52,7 @@ class PageCloner
     page.plugins.each do |plugin|
       plugin.dup.tap do |clone|
         clone.page = cloned_page
-        clone.save
+        clone.save!
       end
     end
   end


### PR DESCRIPTION
Hey team! I replaced some `save` and `update` calls with their matching bang versions where I thought appropriate. Again, I strongly believe that the bang version should we used in all cases where an error is not expected to happen. And if an error is part of the regular user flow, then we should be checking the result of the call to `save` or `update` and act accordingly. 

There's a chance that these changes break some existing functionality, in places where errors are happening and we're just missing them. That's why I'm asking you to review this thoroughly, signing off every change separately.

As an extra I also replaced the `update_attributes` call with the newer shorter nicer version `update` in a couple places.
