### PR TITLE
Handle Braintree errors in express donations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /tmp
 
 .idea/*
+.vscode/*
 .env.web
 champaign.iml
 out/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'bin/**/*'
     - 'db/schema.rb'
     - 'vendor/**/*'
+    - 'node_modules/**/*'
 
 Style/IndentationConsistency:
   EnforcedStyle: normal

--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -46,7 +46,7 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
   //    pageId: the ID of the plugin's page database record.
   //      and array of numbers, integers or floats, to display as donation amounts
   initialize(options = {}) {
-    this.initializeCurrency(options.currency, options.donationBands)
+    this.initializeCurrency(options.currency, options.donationBands);
     this.changeStep(1);
     this.donationAmount = 0;
     this.followUpUrl = options.followUpUrl;
@@ -345,6 +345,8 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
 
   onOneClickFailed() {
     this.enableOneClickButton();
+    const $errors = this.$('.fundraiser-bar__errors');
+    $errors.removeClass('hidden-closed');
   },
 
   transactionFailed(data, status) {

--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -16,11 +16,21 @@ class Api::Payment::BraintreeController < PaymentController
   end
 
   def one_click
-    client::OneClick.new(params).run
-    render json: { success: true }
+    result = client::OneClick.new(params).run
+    render json: braintree_result_body(result),
+           status: (:unprocessable_entity unless result.success?)
   end
 
   private
+
+  def braintree_result_body(result)
+    {
+      success: result.success?,
+      errors: (result.errors unless result.success?),
+      message: (result.message unless result.success?),
+      params: (result.params unless result.success?)
+    }
+  end
 
   def payment_options
     {

--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -16,21 +16,11 @@ class Api::Payment::BraintreeController < PaymentController
   end
 
   def one_click
-    result = client::OneClick.new(params).run
-    render json: braintree_result_body(result),
-           status: (:unprocessable_entity unless result.success?)
+    @result = client::OneClick.new(params).run
+    render status: :unprocessable_entity unless @result.success?
   end
 
   private
-
-  def braintree_result_body(result)
-    {
-      success: result.success?,
-      errors: (result.errors unless result.success?),
-      message: (result.message unless result.success?),
-      params: (result.params unless result.success?)
-    }
-  end
 
   def payment_options
     {

--- a/app/services/braintree_services/subscription_builder.rb
+++ b/app/services/braintree_services/subscription_builder.rb
@@ -4,9 +4,10 @@ module BraintreeServices
   class SubscriptionBuilder
     attr_reader :subscription, :payment_options
 
-    def initialize(subscription, payment_options)
+    def initialize(subscription, payment_options, action = nil)
       @subscription = subscription
       @payment_options = payment_options
+      @action = action
     end
 
     def build
@@ -22,7 +23,8 @@ module BraintreeServices
         customer: payment_options.customer,
         currency: payment_options.currency,
         billing_day_of_month: subscription.billing_day_of_month,
-        page_id: payment_options.page.id
+        page_id: payment_options.page.id,
+        action: @action
       }
     end
   end

--- a/app/services/braintree_services/transaction_builder.rb
+++ b/app/services/braintree_services/transaction_builder.rb
@@ -19,15 +19,15 @@ module BraintreeServices
       {
         amount:                          transaction.amount,
         currency:                        transaction.currency_iso_code,
-        customer_id:                     payment_options.customer.customer_id,
-        payment_method:                  payment_options.payment_method,
         transaction_id:                  transaction.id,
         transaction_type:                transaction.type,
         merchant_account_id:             transaction.merchant_account_id,
         transaction_created_at:          transaction.created_at,
         payment_instrument_type:         transaction.payment_instrument_type,
         processor_response_code:         transaction.processor_response_code,
-        page_id:                         payment_options.page.id
+        customer_id:                     payment_options.customer.customer_id,
+        payment_method:                  payment_options.payment_method,
+        page_id:                         payment_options.page.id,
       }
     end
   end

--- a/app/services/braintree_services/transaction_builder.rb
+++ b/app/services/braintree_services/transaction_builder.rb
@@ -27,7 +27,7 @@ module BraintreeServices
         processor_response_code:         transaction.processor_response_code,
         customer_id:                     payment_options.customer.customer_id,
         payment_method:                  payment_options.payment_method,
-        page_id:                         payment_options.page.id,
+        page_id:                         payment_options.page.id
       }
     end
   end

--- a/app/views/api/payment/braintree/one_click.json.jbuilder
+++ b/app/views/api/payment/braintree/one_click.json.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 json.success @result.success?
-json.params @result.params if @result.params
-json.errors @result.errors if @result.errors
-json.message @result.message if @result.message
+json.params @result.params unless @result.success?
+json.errors @result.errors unless @result.success?
+json.message @result.message unless @result.success?

--- a/app/views/api/payment/braintree/one_click.json.jbuilder
+++ b/app/views/api/payment/braintree/one_click.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 json.success @result.success?
-unless result.success?
+unless @result.success?
   json.params @result.params
   json.errors @result.errors
   json.message @result.message

--- a/app/views/api/payment/braintree/one_click.json.jbuilder
+++ b/app/views/api/payment/braintree/one_click.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+json.success @result.success?
+json.params @result.params if @result.params
+json.errors @result.errors if @result.errors
+json.message @result.message if @result.message

--- a/app/views/api/payment/braintree/one_click.json.jbuilder
+++ b/app/views/api/payment/braintree/one_click.json.jbuilder
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 json.success @result.success?
-json.params @result.params unless @result.success?
-json.errors @result.errors unless @result.success?
-json.message @result.message unless @result.success?
+unless result.success?
+  json.params @result.params
+  json.errors @result.errors
+  json.message @result.message
+end

--- a/spec/fixtures/vcr_cassettes/express_donations_invalid_payment_method.yml
+++ b/spec/fixtures/vcr_cassettes/express_donations_invalid_payment_method.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/<merchant_id>/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <payment-method-nonce>fake-processor-declined-visa-nonce</payment-method-nonce>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.54.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic cXFnaDU2ZmY2cThxc2dtNDo3OGEwYTY4OWYwMWQ5YjRjMDhmZDQ2MjM3MGNmMWIwOA==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Date:
+      - Wed, 02 Nov 2016 13:50:56 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - t2g9fjnxgkvr8rdp
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 4a8312f5-852f-4c38-91e5-e9c2a12a8e93
+      X-Runtime:
+      - '0.146901'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAEDvGVgAA4xSzW7CMAy+8xRR7iEwaRKHELTLnmB7AJN4LFqbdHZA69sv
+        FEqhKhs3258/+/OP2fzUlTggcUhxLZfzhRQYXfIh7tby/e1VreTGzgw0QSFR
+        IkXITYqMdiaE6UJ8NC+OyG2DawlE0Ep9hjJBZHC5NDlFptN7rEcHv0SKKLSr
+        5fPiyejOvgYhZwrbfcZzPW7rbaqkhTrtYzb6gt+wamSGHdqXLksEFoTf+0Do
+        50b34KBJ34g6u3zxt6GqytrGQ0xu5Egf5RtX+oasHJB/sMbQVIH35TJ8M94/
+        VH2HW9Y7VmL06ILXw5sGCGr+49QNtDXGrGrMn8mrmKJD+wFfqBpKrrQuf+XR
+        FTHo1SEwnFKMniT2VY9zWYaq5HXmPaWDvAcPXt5l4t1/AQAA//8DANh6Aw4r
+        AwAA
+    http_version: 
+  recorded_at: Wed, 02 Nov 2016 13:50:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -174,11 +174,6 @@ describe 'Express Donation' do
       end
     end
 
-    it 'returns success, always - FIXME' do
-      puts "PAYMENT METHOD: #{payment_method.to_json}"
-      expect(response.body).to eq({ success: true }.to_json)
-    end
-
     describe 'local record' do
       it 'creates action' do
         action = page.actions.first

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -138,7 +138,7 @@ describe 'Express Donation' do
 
       it 'body contains errors serialised' do
         expect(json_hash).to include('errors')
-        expect(json_hash).to satisfy { |v| v['errors'].size > 0 }
+        expect(json_hash).to satisfy { |v| !v['errors'].empty? }
       end
 
       it 'body contains an error message' do
@@ -150,7 +150,6 @@ describe 'Express Donation' do
       end
     end
   end
-
 
   describe 'transaction' do
     before do


### PR DESCRIPTION
Closes PT stories: #133020257 and #130729249

One click endpoint now returns a `422 Unprocessable Entity` if the braintree transaction with the stored payment method results in a failure (`.success? == false`). From the `ErrorResult` object, we send the client a payload (for future use) with the following shape:

```json
{
  "success": false,
  "message": "An error message from Braintree",
  "errors": [],
  "params": {}
}
```