### PR TITLE
(True) oneclick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'readthis'
 gem 'hiredis'
 gem 'redis', '>= 3.2.0', require: ['redis', 'redis/connection/hiredis']
 gem 'pg'
-gem 'sass-rails', '~> 5.0'
+gem 'sass-rails', '~> 5.0.6'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'
 gem 'jquery-rails'
@@ -43,7 +43,7 @@ gem 'compass-rails', git: 'https://github.com/compass/compass-rails'
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 
-gem 'slim-rails'
+gem 'slim-rails', '~> 3.1.1'
 gem 'liquid'
 gem 'remotipart', '~> 1.2'
 gem 'i18n-js', '>= 3.0.0.rc12'
@@ -139,6 +139,7 @@ group :test do
   gem 'webmock'
   gem 'timecop'
   gem 'coveralls', require: false
+  gem 'poltergeist'
 end
 
 # Rails Assets - reference any Bower components that you need as gems.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
     chunky_png (1.3.5)
     climate_control (0.0.3)
       activesupport (>= 3.0)
+    cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     codemirror-rails (5.11)
@@ -242,7 +243,7 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
-    i18n-js (3.0.0.rc12)
+    i18n-js (3.0.0.rc14)
       i18n (~> 0.6, >= 0.6.6)
     i18n_data (0.7.0)
     inherited_resources (1.6.0)
@@ -292,7 +293,7 @@ GEM
     mime-types-data (3.2016.0521)
     mimemagic (0.3.0)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     money (6.7.1)
       i18n (>= 0.6.4, <= 0.7.0)
       sixarm_ruby_unaccent (>= 1.1.1, < 2)
@@ -301,9 +302,8 @@ GEM
     multipart-post (2.0.0)
     nenv (0.3.0)
     newrelic_rpm (3.15.2.317)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     notiffany (0.1.0)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -338,7 +338,10 @@ GEM
     parser (2.3.1.2)
       ast (~> 2.2)
     pg (0.18.4)
-    pkg-config (1.1.7)
+    poltergeist (1.11.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     polyamorous (1.3.0)
       activerecord (>= 3.0)
     powerpack (0.1.1)
@@ -395,7 +398,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.2.2)
+    rake (11.3.0)
     ransack (1.7.0)
       actionpack (>= 3.0)
       activerecord (>= 3.0)
@@ -447,8 +450,8 @@ GEM
     ruby_dep (1.3.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
-    sass-rails (5.0.4)
-      railties (>= 4.0.0, < 5.0)
+    sass-rails (5.0.6)
+      railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
@@ -467,7 +470,7 @@ GEM
     slim (3.0.7)
       temple (~> 0.7.6)
       tilt (>= 1.3.3, < 2.1)
-    slim-rails (3.1.0)
+    slim-rails (3.1.1)
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (~> 3.0)
@@ -517,6 +520,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -574,6 +580,7 @@ DEPENDENCIES
   paper_trail
   paperclip
   pg
+  poltergeist
   puma (~> 2.15.3)
   rack-cors
   rails (= 4.2.7.1)
@@ -596,11 +603,11 @@ DEPENDENCIES
   rmagick
   rspec-rails
   rubocop
-  sass-rails (~> 5.0)
+  sass-rails (~> 5.0.6)
   sdoc (~> 0.4.0)
   selectize-rails
   share_progress!
-  slim-rails
+  slim-rails (~> 3.1.1)
   spring
   spring-commands-rspec
   sprockets-rails (< 3.0)
@@ -618,4 +625,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.13.2
+   1.13.5

--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -15,6 +15,26 @@ class Api::Payment::BraintreeController < PaymentController
     end
   end
 
+  def link_payment
+    pmid = current_member.customer.payment_methods.first.id
+
+    opts = ActionController::Parameters.new(
+      payment: {
+        payment_method_id: pmid,
+        currency: params[:currency],
+        amount: params[:amount]
+      },
+      user: {
+        email: current_member.email
+      },
+      page_id: params[:page_id]
+    )
+
+    client::OneClick.new(opts).run
+
+    render text: page.title
+  end
+
   def one_click
     client::OneClick.new(params).run
     render json: { success: true }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -35,7 +35,44 @@ class PagesController < ApplicationController
   end
 
   def show
-    render_liquid(@page.liquid_layout, :show)
+    if one_click?
+      process_one_click
+      flash[:notice] = t('fundraiser.thank_you_with_amount', amount: "#{view_context.number_to_currency(params[:amount], unit: params[:currency])}")
+      redirect_to PageFollower.new_from_page(@page, member_id: recognized_member.id).follow_up_path
+    else
+      render_liquid(@page.liquid_layout, :show)
+    end
+  end
+
+  def one_click?
+    params.fetch(:one_click, '') == 'true' &&
+      payment_method_id &&
+      params.fetch(:amount, 0).to_f > 0 &&
+      params[:currency].present?
+  end
+
+  def process_one_click
+    opts = ActionController::Parameters.new(
+      payment: {
+        payment_method_id: payment_method_id,
+        currency: params[:currency],
+        amount: params[:amount]
+      },
+      user: {
+        email: recognized_member.email
+      },
+      page_id: @page.id
+    )
+
+    PaymentProcessor::Braintree::OneClick.new(opts).run
+  end
+
+  def payment_method_id
+    if current_member
+      current_member.customer.payment_methods.first.id
+    else
+      Payment::Braintree::PaymentMethod.find_by(token: (cookies.signed[:payment_methods] || '').split(',').first)
+    end
   end
 
   def follow_up

--- a/app/services/action_params_builder.rb
+++ b/app/services/action_params_builder.rb
@@ -33,6 +33,12 @@ class ActionParamsBuilder
   end
 
   def fields
-    Form.find(params[:form_id]).form_elements.map(&:name)
+    form = Form.find_by(id: params[:form_id])
+
+    if form
+      form.form_elements.map(&:name)
+    else
+      []
+    end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,7 +34,6 @@ Rails.application.configure do
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/config/locales/member_facing.en.yml
+++ b/config/locales/member_facing.en.yml
@@ -21,6 +21,7 @@ en:
     make_recurring: Make my donation monthly
     store_in_vault: Securely store my payment information
     thank_you: Thank you for your donation!
+    thank_you_with_amount: "Thank you for your donation of %{amount}"
     card_declined: Your card was declined by the payment processor. Please try a different payment method.
     unknown_error: Our technical team has been notified. Please double check your info or try a different payment method.
     fine_print: "" # override this with org-specific details in your own yml file.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,8 +94,9 @@ Rails.application.routes.draw do
     namespace :payment do
       namespace :braintree, defaults: { format: 'json' } do
         get 'token'
-        post 'pages/:page_id/transaction',  action: 'transaction', as: 'transaction'
-        post 'pages/:page_id/one_click',    action: 'one_click',   as: 'one_click'
+        post 'pages/:page_id/transaction',  action: 'transaction',  as: 'transaction'
+        post 'pages/:page_id/one_click',    action: 'one_click',    as: 'one_click'
+        get  'pages/:page_id/link_payment', action: 'link_payment', as: 'link_payment'
         post 'webhook', action: 'webhook'
       end
     end

--- a/lib/champaign_queue.rb
+++ b/lib/champaign_queue.rb
@@ -9,6 +9,7 @@ module ChampaignQueue
     if Rails.env.production? || Settings.publish_champaign_events
       client.push(payload, opts)
     else
+      # Clients::Direct.push(opts)
       false
     end
   end

--- a/lib/champaign_queue.rb
+++ b/lib/champaign_queue.rb
@@ -9,7 +9,6 @@ module ChampaignQueue
     if Rails.env.production? || Settings.publish_champaign_events
       client.push(payload, opts)
     else
-      # Clients::Direct.push(opts)
       false
     end
   end

--- a/lib/payment_processor/braintree/one_click.rb
+++ b/lib/payment_processor/braintree/one_click.rb
@@ -4,9 +4,10 @@ module PaymentProcessor::Braintree
   class OneClick
     attr_reader :params, :payment_options
 
-    def initialize(params)
+    def initialize(params, member = nil)
       @params = params
       @payment_options = BraintreeServices::PaymentOptions.new(params)
+      @member = member
     end
 
     def run

--- a/lib/payment_processor/braintree/one_click_from_uri.rb
+++ b/lib/payment_processor/braintree/one_click_from_uri.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module PaymentProcessor::Braintree
+  class OneClickFromUri
+    attr_reader :params, :page, :member, :cookied_payment_methods
+
+    def initialize(params, page:, member: nil, cookied_payment_methods: '')
+      @params = params
+      @page = page
+      @member = member
+      @cookied_payment_methods = cookied_payment_methods
+    end
+
+    def process
+      return false unless one_click?
+
+      PaymentProcessor::Braintree::OneClick.new(options).run
+      true
+    end
+
+    private
+
+    def one_click?
+      params.fetch(:one_click, '') == 'true' &&
+        payment_method_id &&
+        params.fetch(:amount, 0).to_f > 0 &&
+        params[:currency].present?
+    end
+
+    def options
+      ActionController::Parameters.new(
+        payment: {
+          payment_method_id: payment_method_id,
+          currency: params[:currency],
+          amount: params[:amount]
+        },
+        user: {
+          email: member.email
+        },
+        page_id: page.id
+      )
+    end
+
+    def payment_method_id
+      if member
+        member.customer.payment_methods.first.id
+      else
+        Payment::Braintree::PaymentMethod.find_by(token: token_from_cookie)
+      end
+    end
+
+    def token_from_cookie
+      (cookied_payment_methods || '').split(',').first
+    end
+  end
+end

--- a/spec/factories/liquid_layouts.rb
+++ b/spec/factories/liquid_layouts.rb
@@ -32,6 +32,11 @@ FactoryGirl.define do
       content %( {% include 'petition' %} )
     end
 
+    trait :donation do
+      title 'donation template'
+      content %( {% include 'donation' %} )
+    end
+
     trait :thermometer do
       title 'thermometer template'
       content %( {% include 'thermometer' %} )

--- a/spec/features/express_donations/email_one_click_spec.rb
+++ b/spec/features/express_donations/email_one_click_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+feature 'Express From Mailing Link' do
+  let(:follow_up_layout) { create :liquid_layout, default_follow_up_layout: nil }
+  let(:liquid_layout)    { create :liquid_layout, default_follow_up_layout: follow_up_layout }
+  let(:donation_page)    { create(:page, slug: 'foo-bar', title: 'Foo Bar', follow_up_liquid_layout: liquid_layout) }
+
+  let(:email)    { 'donor@example.com' }
+  let(:member)   { Member.find_by(email: email) }
+  let(:customer) { Payment::Braintree::Customer.find_by(email: email) }
+
+  before do
+    allow(ChampaignQueue).to receive(:push)
+  end
+
+  def register_member(member)
+    visit new_member_authentication_path(page_id: donation_page.id, email: member.email)
+
+    fill_in 'password', with: 'password'
+    fill_in 'password_confirmation', with: 'password'
+    click_button 'Register'
+    expect(page).to have_content("window.location = '/a/foo-bar/follow-up?member_id=#{member.id}'")
+  end
+
+  def authenticate_member(auth)
+    visit email_confirmation_path(token: auth.token, email: member.email)
+
+    expect(page).to have_content('You have successfully confirmed your account')
+    expect(auth.reload.confirmed_at).not_to be nil
+  end
+
+  def store_payment_in_vault
+    params = {
+      payment_method_nonce: 'fake-valid-nonce',
+      recurring: false,
+      amount: 1.00,
+      currency: 'GBP',
+      store_in_vault: true,
+      user: {
+        name: 'Foo Bar',
+        email: email,
+        country: 'US',
+        postal: '12345',
+        address1: 'The Avenue'
+      }
+    }
+
+    VCR.use_cassette('feature_store_card_in_vault') do
+      page.driver.post api_payment_braintree_transaction_path(donation_page.id), params
+    end
+
+    expect(JSON.parse(page.body)['success']).to eq(true)
+  end
+
+  scenario 'Authenticated member makes a one-click donation' do
+    store_payment_in_vault
+    register_member(member)
+    authenticate_member(member.authentication)
+
+    expect(Action.count).to eq(1)
+    expect(customer.transactions.count).to eq(1)
+
+    VCR.use_cassette('feature_member_email_donation') do
+      visit page_path(donation_page, amount: '2.10', currency: 'GBP', one_click: true)
+    end
+
+    expect(customer.reload.transactions.count).to eq(2)
+    expect(Action.count).to eq(2)
+
+    # Redirects to follow up url for campaign page
+    expect(current_url).to match(%r{/foo-bar/follow-up\?member_id=#{member.id}})
+  end
+
+  scenario 'Cookied member makes a one-click donation' do
+    store_payment_in_vault
+
+    expect(customer.transactions.count).to eq(1)
+    expect(Action.count).to eq(1)
+
+    VCR.use_cassette('feature_one_click_cookie') do
+      visit page_path(donation_page, amount: 1.50, currency: 'GBP', one_click: true)
+    end
+
+    expect(customer.reload.transactions.count).to eq(2)
+    expect(Action.count).to eq(2)
+    expect(current_url).to match(%r{/foo-bar/follow-up\?member_id=#{customer.member.id}})
+  end
+
+  scenario 'Stanger makes a one-click donation' do
+    VCR.use_cassette('feature_one_click_stranger') do
+      visit page_path(donation_page, amount: 1.50, currency: 'GBP', one_click: true)
+    end
+
+    expect(Action.count).to eq(0)
+    expect(current_url).to match(%r{/foo-bar})
+  end
+end

--- a/spec/fixtures/vcr_cassettes/feature_member_email_donation.yml
+++ b/spec/fixtures/vcr_cassettes/feature_member_email_donation.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/<merchant_id>/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <payment-method-token>6xp2ty</payment-method-token>
+          <amount>2.10</amount>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.54.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic djlmcGMyZ3pxZnh4NDVucTo0MWFlNWIxOGJlNTRjNTdjN2NiZmQyMTYxNDcxN2M2ZA==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 25 Oct 2016 11:14:51 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 2vtm97htjg9x4v78
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"8e0d4cf140b17947344d2d3407cbdc09"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5744a840-bbea-4db5-8d10-ee8b8799c24c
+      X-Runtime:
+      - '0.603454'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAKs+D1gAA+xYTXPbNhC9+1d4dIdJypYje2i6zbTpNJl4OpO47eTiAYmV
+        iJoEWACUpfz6LgiSIk3Qdm899CbuPiywH9h9UHy7L4vTHSjNpbhZRGfh4hRE
+        JhkX25vF/dcPZL24TU5io6jQNDOISk5OT2POkpyW37WqVBzgh5VpQ02tE1qb
+        XCr+HVgctCKrNYcKEk0LiIPmp5VltVK424FwLQluCsn9l5/iYCq2YFrKWphk
+        eRaFcdB+WHkJKsupMIRmmRUSPI6uS7mpdRz4lM1Z65R4dKeCFzcLo2pYBM44
+        1QbUm6BSMUR6FJkCaoARak6t5zcLhp+Gl7BIlmF0SaKQLFdfo+g6urhehd/Q
+        /35Bs76u2L9bf1zQRlkbiR7YD5e61dX5Kry8XHWpQ+mGK22IoCUkH6SMg8G3
+        AxS0+35PMefHT6fOZFlRcXjuPGqgpLxImBRS/QB7WlYFnCE6DpzCgZ4g1dyA
+        Z3mVS+GTb+h+Eulg6Gqc8qLAMu7d9hnpvfQoexc9unl3tVEAWCiMKdDaF4+9
+        AcFsemYhhcxowY3PvIIt3kFfnCRetqK5Lt7zYtWqw7w7Tm1XE1pUOV2+CXX+
+        GkrUmA2eTTM1SA76tKkF812dXqPb0qdK0cNIiYEcNCefkYoqwzE0GowpoAS8
+        vuMVPuPHLvaa+YHZlJos92JyXlX/1+J/tBaH2Wm7JdlwKJhua2GnCSglFcEY
+        VVJo8LrW4Aauj9HJrzi1XgR0JsZZ81t5EdO4sdtNV06FFrrFYfFED6j5C1yV
+        4/zR08TGlZIZ7oZx6G4HbeCNpU8fo893f8bBi6CxlfFRojAMh8unB/XoDFZw
+        8mOFmp3lG3OIJrSMcXsSDP4UNvF1J3lmE7TBxOMKrJ0U1DQiteUFuIsb/jMo
+        Q/fEERavCvZQVt1sT6UsgIpFsqGFtlypB3RcAr0gGVXd4DbyEURyua+W5oDw
+        5stpUi6SizBarte23YphJ7lIovU6aqf4RXdZ0ChpuNnvXFOslv67axYVVy6Z
+        pRQmT6IlDvHnwgn2AFQhUVmGI3AjbfdthzaxraZhmPdfjqP8KD2eMpdFE25/
+        A+El3QKpVZHkxlT6Ogioxiatz1JFubAXp614S0OCih5s734oAauVPRRyK4Md
+        +n9Wie0tiB1XUljAjaaCpXKPnKm333Y7BRVFInUnbQG6306TAy1MjidGYise
+        hXwScTCQORCDlJuj3n22qlph4rAKt3VhGd0A9VzTjwJLVXHaHaEDWXteelCy
+        GCA6QRs+rWtshjjMxOMRM5KOm6vcEKulIoPEbjeVdnGSrM4aCn7c+ihzoFrw
+        v2tobxKKMfIce7FKwtW75eoqSlfperW+WL67Or9gy3N6lZ6zkNE1VtfsUmd5
+        B6KURLPHmZvW61sqOb5p7euG5BzLUh1GjKGftg0C0FCbQHs9kaejoqzeyN17
+        fG/hxWdVg5h5Gbl4agzAzzj23kt85JV4rRtJf7wBt9ESuxkktOJ4jKncORk8
+        97KXtJFxfbGgfq5UpzpTvJrlUgN938UaokgqnN2SEaQrxMbQc++fIfFYynix
+        eORn+9jhQHAOeIgg47opaa8OnBXZ1dhMR5p7w2APmZ5tbBRJln0Oo18zZdvr
+        3XzAV6qAqVXM+c4OtA3A3Ciy28on4rI50WIY0lppx3MZGHy66a5LjVT+3AxI
+        sn/7MWbyD8Ab4bC3AcDurPzHsA8GrFSkdj6DdZZ5ODBmZMZ363lVG/CVRjtW
+        CBdI1Wr36LCj1LWVB9tW4mAONCY7A0fHnGjId2ZBr9tqGNJrtnoapbh+tFmm
+        x78TflvdfQzP//i0+vTtl8FfCgwybv9W6viZLe1W0oR1ZCk2OQ5mgtfW1jNg
+        SDZynIlRU0pO/gEAAP//AwDBkeD9uhIAAA==
+    http_version: 
+  recorded_at: Tue, 25 Oct 2016 11:14:51 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/feature_one_click_cookie.yml
+++ b/spec/fixtures/vcr_cassettes/feature_one_click_cookie.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/<merchant_id>/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <payment-method-token>6xp2ty</payment-method-token>
+          <amount>1.5</amount>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.54.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic djlmcGMyZ3pxZnh4NDVucTo0MWFlNWIxOGJlNTRjNTdjN2NiZmQyMTYxNDcxN2M2ZA==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 25 Oct 2016 11:14:48 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 2vtm97htjg9x4v78
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"5757219aa299bf36e0d9fa44db5cf956"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5c1ce088-080e-4370-ab8f-e71c24151db7
+      X-Runtime:
+      - '0.718860'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAKg+D1gAA+xYTXPbNhC951d4dIdJypIje2i6ddukTWcy7STOoRcPSKxE
+        1CTAAqAs9dd3QZAUaYK2e+uhN3H3YYH9wO6D4ttDWZztQWkuxc0iOg8XZyAy
+        ybjY3Szuv34gm8Vt8i42igpNM4Oo5N3ZWcxZovINwEFs4wA/rEwbamqd0Nrk
+        UvG/gcVBK7Jac6wg0bSAOGh+WllWK4W7HQnXkuCmkNx/+TEOpmILpqWshUmi
+        83UYB+2HlZegspwKQ2iWWSHB4+i6lNtax4FP2Zy1TolHdyZ4cbMwqoZF4IxT
+        bUC9CSoVQ6RHkSmgBhih5sx6frNg+Gl4CYtkGUaXJArJcv01iq6j1fVq8wf6
+        3y9o1tcV+3frTwvaKGsj0QP74VK3vrpYh5eX6y51KN1ypQ0RtITkg5RxMPh2
+        gIJ233dUxcHp06kzWVZUHJ87jxooKS8SJoVU38GBllUB54iOA6dwoCdINTfg
+        WV7lUvjkW3qYRDoYuhqnvCiwjHu3fUZ6Lz3K3kWPbt5dbRQAFgpjCrT2xeNg
+        QDCbnllIITNacOMzr2CHd9AXJ4mXrWiui/e8WLXqOO+OU9vVhBZVTpdvQl28
+        hhI1ZoNn00wNkoM+bWvBfFen1+i29KlS9DhSYiAHzclnpKLKcAyNBmMKKAGv
+        73iFz/ipi71mfmA2pSbLvZicV9X/tfgfrcVhdtpuSbYcCqbbWthrAkpJRTBG
+        lRQavK41uIHrY3TyC06tFwGdiXHW/FZexDRu7PfTlVOhhe5wWDzRI2r+BFfl
+        OH/0NLFxpWSGu2EcuttBG3hj6feP4fr9z3HwImhsZXyUKAzD4fLpQT06gxWc
+        fF+hZm/5xhyiCS1j3J4Egz+FTXzdS57ZBG0x8bgCaycFNY1IbXkB7uKG/wzK
+        0ANxhMWrggOUVTfbUykLoGKRbGmhLVfqAR2XQC9IRlU3uI18BJFcHqqlOSK8
+        +XKalItkFUbLzca2WzHsJKsk2myidoqvusuCRknDzb5xTbFa+u+uWVRcuWSW
+        Upg8iZY4xJ8LJ9gjUIVEZRmOwI203bcd2sS2moZh3n85jfKT9HTKXBZNuP0N
+        hJd0B6RWRZIbU+nrIKAam7Q+TxXlwl6ctuItDQkqerS9+6EErFb2UMidDPbo
+        /3kldrcg9lxJYQE3mgqWygNypt5+2+0UVBSJ1GdpC9D9dpocaGFyPDESW/Eo
+        5JOIg4HMgRik3Jz07rNV1QoTh1W4qwvL6Aao55p+FFiqitPuBB3I2vPSo5LF
+        ANEJ2vBpXWMzxGEmHk+YkXTcXOWWWC0VGSR2u6m0i5NkddZQ8NPWJ5kD1YL/
+        VUN7k1CMkefYi1WC3WW5vorSdbpZb1bL91cXK7a8oFfpBQsZ3WB1zS51lvcg
+        Skk0e5y5ab2+pZLjm9a+bkjOsSzVccQY+mnbIAANtQm01xN5OirK6o3cvcf3
+        Fl58VjWImZeRi6fGAPyEY+9O4iOvxGvdSPrjDbiNltjNIKEVx2NM5c7J4LmX
+        vaSNjOuLBfVzpTrVmeLVLJca6Psu1hBFUuHslowgXSE2hp57/wyJx1LGi8Uj
+        P9vHDgeCc8BDBBnXTUl7deCsyK7GZjrS3BsGe8j0bGOjSLLscxj9minbXu/m
+        A75SBUytYs73dqBtAeZGkd1WPhGXzYkWw5DWSjuey8Dg0013XWqk8udmQJL9
+        248xk38A3giHgw0AdmflP4Z9MGClIrXzGayzzMOBMSMzvlvPq9qArzTasUK4
+        QKpWu0eHHaWurTzYthIHc6Ax2Rk4OuZEQ74zC3rdVsOQXrPV0yjF9aPNMj39
+        nfDb+vOn8NdPFz/cffw2+EuBQcbt30odP7Ol3UqasI4sxSbHwUzw2tp6BgzJ
+        Vo4zMWpKybt/AAAA//8DANuXOdK6EgAA
+    http_version: 
+  recorded_at: Tue, 25 Oct 2016 11:14:48 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/feature_store_card_in_vault.yml
+++ b/spec/fixtures/vcr_cassettes/feature_store_card_in_vault.yml
@@ -1,0 +1,122 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/<merchant_id>/transactions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <transaction>
+          <amount>1.0</amount>
+          <payment-method-nonce>fake-valid-nonce</payment-method-nonce>
+          <merchant-account-id>GBP</merchant-account-id>
+          <device-data>
+          </device-data>
+          <options>
+            <submit-for-settlement type="boolean">true</submit-for-settlement>
+            <store-in-vault-on-success type="boolean">true</store-in-vault-on-success>
+          </options>
+          <customer>
+            <first-name>Foo</first-name>
+            <last-name>Bar</last-name>
+            <email>donor@example.com</email>
+          </customer>
+          <billing>
+            <first-name>Foo</first-name>
+            <last-name>Bar</last-name>
+            <postal-code>12345</postal-code>
+            <street-address>The Avenue</street-address>
+            <country-code-alpha2>US</country-code-alpha2>
+          </billing>
+          <type>sale</type>
+        </transaction>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 2.54.0
+      X-Apiversion:
+      - '4'
+      Authorization:
+      - Basic djlmcGMyZ3pxZnh4NDVucTo0MWFlNWIxOGJlNTRjNTdjN2NiZmQyMTYxNDcxN2M2ZA==
+      Content-Type:
+      - application/xml
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 25 Oct 2016 11:14:46 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Authentication:
+      - basic_auth
+      X-User:
+      - 2vtm97htjg9x4v78
+      Vary:
+      - Accept-Encoding
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"7c30f8ff2b7fce5038a41f0b2dc23292"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 59b8fc9a-bada-44a9-9d59-94d1ebfd2e90
+      X-Runtime:
+      - '0.964056'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAKY+D1gAA8RYS2/bOBC+91cYvjPyM3UKRd1ksd1FgS0C9HHoJaDEscVG
+        IrUk5dj99TsUJVmyqMR7KPZmzXwcch6c+ejw/SHPJntQmktxO51fzaYTEIlk
+        XOxup1+/fCCb6fvoTWgUFZomBlHRm8kk5CxaLM2KLX/EYYAfVqYNNaWOdBnn
+        3Bhgj1upHjUYk0EOwoRBDbBYcywg0jSDMKh+WllSKoV7HwnXkuARIPrz/iEM
+        hmILprkshYnwwLMwqD+sPAeVpFQYQpPECgkerjLjU1SnLmPi0U0Ez26nRpUw
+        DZxhqg2oi6BSMUR6FIkCioEh1Eys17dThp+G5zCNFrP5NZnPyGL9ZT5/N1+9
+        W11/R9/bBdX6smD/bf1pQR1hbSR6YD9cEtc3y/Xs+nrdJBGlW660IYLmEH2Q
+        Mgw63w6Q0eb7nqowOH06dSLzgorjufOogZzyLGJSSPUbHGheZHCF6DBwCgd6
+        hlhzA57lRSqFT76lh0Gkg66rYcyzDAu6ddtn5Jd5rY0CwHphTIHW0ZcUJnd7
+        ECXYC9FT1VE6GBDMJs2JPSYzmdCMG99uCnZ4R33Rk3j9MneB5ovlClPeFTVe
+        YEmro3Psq8A8sMlnvLWgJ3I7ucN48oRicLuw/kprjNCsSOki+vr5BO3Kx1Ys
+        ccWdb8nSt0SU1XGizWp2tqbRVIXQyT0GZ1sK5ruZrUbXN4sqRY89JWak0wV9
+        RgqqDMeAnnre2QqfcVqaVCr+83XzHbMxNUnqxaS8KC4udV9p0XHdpTXuu/q/
+        vKi95z2V6QvqTmlehFq+hqrrb9iUutmpmzHZcsiYrmthrwkoJRXBGBVSaPC6
+        VuE6rvfR0d84EF8ENCb6WfNbeRFTubHfD1cOhRa6w0byTI+o+QGuynG86WFi
+        w0LJBHfDODS3g1bwytLDp29v/8I9XgT1rfSPMp9ZzjCmHVlpsIKjuwI1e2De
+        1RWiCi1j3J4Egz+EDXzdS57YBG0x8bgCaycGNYxIaWkH7uK4xQjK0ANxXMir
+        ggPkRUMdYikzoGIabWmmLQ1rAQ1VQS9IQlXDC4x8AhFdH4qFOSK8+nKamIto
+        NZsvNhvbbkW3k6yi+WYzr8flqrksaJRUtO8b13actN9Nsyi4csnMpTApzivk
+        COfCAfYIVCEPWsx64Epa71tzAmJbTUVlqwk1kJ5OmcqsCre/gfCc7oCUKotS
+        Ywr9Lgioxiatr2JFubAXp654y3KCgh5t737MAauVPWZyJ4M9+n9ViN17EHuu
+        pLCAW00Fi+UBKVlrv+52CgqKPO2TtAXofjtNCjQzKZ7YTu0nIZ9FGHRkDsQg
+        5uakd5+1qlSYOKzCXZlZwthBnWvaUWCZME67E7Qjq89Lj0pmHUQjqMOndYnN
+        EIeZeDphetJ+c5VbYrVUJBCdRn5X2sRJsjKpGP5p65PMgUrB/ymhvkkoxshz
+        7MUqmq3fLtY383gdb9ab1eLtzXLFFkt6Ey/ZjNENVtfoUmcZyV0uiWZPIzet
+        1ddMtX/T6mcUSTmWpTr2GEM7bSsEoKE6gfZ64jMAFXlx4dOgxbcW6ufZiZB0
+        X2wVYuTR5eKpMQB/4Ni7l/iazPFaV5L2eB1uoyV2M4howfEYQ7lzMhh6+Ysd
+        v+Th+v+HoZXUBeLGQ0b9lLGMdaJ4MUopO/q2mVd8mRRIYSQjyNqIjain/Z0h
+        8VjKeLF45LN97IwkOA49fJhxXd1srw6cFdlctZHGPPZSxFY6PFvfKHJN+4cD
+        +jVye1u9G5MpFQKGVjHnezvXtwBjE9luK5+Jy+ZAi2GIS6Ud3Wdg8IHcPBD7
+        Kn9uOm8F//Z9zOA/lgvhcLABwCGl/Mew7yasVGS4PoNlknieApiREd+t50Vp
+        H6PD0qinK+ECGWvp3l6WUbju+mi7axiMgfqcr+Nonxp2ad8o6HVbFVF8zVbL
+        JhXXTzbL9PSnzcP608fZ95vl/e8fHzp/3DBIuP0br6GptrRrSRXWnqXQpMhP
+        CF5bW8+AIdnKfiZ6TSl68y8AAAD//wMAXVX99yoUAAA=
+    http_version: 
+  recorded_at: Tue, 25 Oct 2016 11:14:47 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Allows campaigners to email 'one click' donation links. 

If a member clicking through has a payment method cookie or is logged in, then the donation will be processed immediately, otherwise they'll be presented with the original campaign page view. 

To enable one-click, URIs must take this format:

`/a/page-slug?one_click=true&amount=10&currency=GBP`