### PR TITLE
makes pages JSON API report campaign_action_count

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -16,4 +16,8 @@ class Campaign < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
 
   scope :active, -> { where(active: true) }
+
+  def action_count
+    pages.sum(:action_count)
+  end
 end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -120,8 +120,8 @@ class Page < ActiveRecord::Base
   end
 
   def campaign_action_count
-    @campaign_action_count ||= if campaign_id.present?
-                                 Page.where(campaign_id: campaign_id).sum(:action_count)
+    @campaign_action_count ||= if campaign
+                                 campaign.action_count
                                else
                                  action_count
                                end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -119,6 +119,14 @@ class Page < ActiveRecord::Base
     ]
   end
 
+  def campaign_action_count
+    @campaign_action_count ||= if campaign_id.present?
+                                 Page.where(campaign_id: campaign_id).sum(:action_count)
+                               else
+                                 action_count
+                               end
+  end
+
   private
 
   def switch_plugins

--- a/app/views/api/pages/index.json.jbuilder
+++ b/app/views/api/pages/index.json.jbuilder
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 json.array! @pages do |page|
-  json.extract! page, :id, :title, :slug, :content, :created_at, :updated_at, :publish_status, :featured, :action_count
+  json.extract!(
+    page,
+    :id,
+    :title,
+    :slug,
+    :content,
+    :created_at,
+    :updated_at,
+    :publish_status,
+    :featured,
+    :action_count,
+    :campaign_action_count
+  )
   json.language page.language.code
   json.image image_url(page)
   json.url member_facing_page_url(page)

--- a/app/views/api/pages/show.json.jbuilder
+++ b/app/views/api/pages/show.json.jbuilder
@@ -1,3 +1,15 @@
 # frozen_string_literal: true
-json.extract! @page, :id, :title, :slug, :content, :created_at, :updated_at, :publish_status, :featured, :action_count
+json.extract!(
+  @page,
+  :id,
+  :title,
+  :slug,
+  :content,
+  :created_at,
+  :updated_at,
+  :publish_status,
+  :featured,
+  :action_count,
+  :campaign_action_count
+)
 json.language @page.language.code

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -9,7 +9,19 @@
 #  updated_at :datetime
 #
 
+require 'rails_helper'
+
 describe Campaign do
   describe 'validations' do
+  end
+
+  describe '#action_count' do
+    let(:campaign) { create(:campaign) }
+    let!(:page_a) { create(:page, campaign: campaign, action_count: 5) }
+    let!(:page_b) { create(:page, campaign: campaign, action_count: 5) }
+
+    it 'returns sum of counts from associated pages' do
+      expect(campaign.action_count).to eq(10)
+    end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -64,6 +64,7 @@ describe Page do
   it { is_expected.to respond_to :plugins }
   it { is_expected.to respond_to :shares }
   it { is_expected.to respond_to :action_count }
+  it { is_expected.to respond_to :campaign_action_count }
   it { is_expected.to respond_to :tag_names }
   it { is_expected.to respond_to :plugin_names }
   it { is_expected.to respond_to :meta_tags }
@@ -328,6 +329,23 @@ describe Page do
   describe 'action_count' do
     it 'defaults to 0' do
       expect(Page.new.action_count).to eq 0
+    end
+  end
+
+  describe 'campaign_action_count' do
+    it 'gives action count of just page if no associated campaigns' do
+      allow(page).to receive(:campaign_id).and_return(nil)
+      allow(page).to receive(:action_count).and_return(1234)
+      expect(page.campaign_action_count).to equal 1234
+      expect(page).to have_received(:campaign_id)
+    end
+
+    it 'gives action count of campaign if one is associated' do
+      campaign = create :campaign
+      page1 = create :page, action_count: 2000, campaign: campaign
+      page2 = create :page, action_count: 2500, campaign: campaign
+      expect(page1.campaign_action_count).to eq 4500
+      expect(page2.campaign_action_count).to eq 4500
     end
   end
 

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -332,20 +332,23 @@ describe Page do
     end
   end
 
-  describe 'campaign_action_count' do
-    it 'gives action count of just page if no associated campaigns' do
-      allow(page).to receive(:campaign_id).and_return(nil)
-      allow(page).to receive(:action_count).and_return(1234)
-      expect(page.campaign_action_count).to equal 1234
-      expect(page).to have_received(:campaign_id)
+  describe '#campaign_action_count' do
+    context 'without campaign' do
+      subject { create(:page, action_count: 5) }
+
+      it 'returns action count for page' do
+        expect(subject.campaign_action_count).to eq(5)
+      end
     end
 
-    it 'gives action count of campaign if one is associated' do
-      campaign = create :campaign
-      page1 = create :page, action_count: 2000, campaign: campaign
-      page2 = create :page, action_count: 2500, campaign: campaign
-      expect(page1.campaign_action_count).to eq 4500
-      expect(page2.campaign_action_count).to eq 4500
+    context 'with campaign' do
+      let(:campaign) { create(:campaign) }
+      subject { create(:page, campaign: campaign) }
+
+      it 'returns count for all campaign pages' do
+        expect(campaign).to receive(:action_count)
+        subject.campaign_action_count
+      end
     end
   end
 

--- a/spec/requests/api/pages_spec.rb
+++ b/spec/requests/api/pages_spec.rb
@@ -6,6 +6,24 @@ describe 'api/pages' do
     JSON.parse(response.body)
   end
 
+  let(:expected) do
+    %w(
+      id
+      title
+      slug
+      content
+      created_at
+      updated_at
+      publish_status
+      campaign_action_count
+      action_count
+      language
+      featured
+      image
+      url
+    )
+  end
+
   describe 'GET index' do
     before do
       create(:page, :published, title: 'Foo', content: 'Bar')
@@ -18,9 +36,7 @@ describe 'api/pages' do
     it 'returns list of pages' do
       expect(subject.size).to eq(1)
 
-      expect(subject.first.keys).to match(
-        %w(id title slug content created_at updated_at publish_status featured action_count language image url)
-      )
+      expect(subject.first.keys).to match_array(expected)
 
       expect(subject.first.symbolize_keys).to include(title: 'Foo',
                                                       content: 'Bar')
@@ -40,9 +56,7 @@ describe 'api/pages' do
     it 'returns list of pages' do
       expect(subject.size).to eq(1)
 
-      expect(subject.first.keys).to match(
-        %w(id title slug content created_at updated_at publish_status featured action_count language image url)
-      )
+      expect(subject.first.keys).to match_array(expected)
 
       expect(subject.first.symbolize_keys).to include(title: 'Foo',
                                                       content: 'Bar')
@@ -57,9 +71,20 @@ describe 'api/pages' do
     before { get(api_page_path(page, format: :json)) }
 
     it 'returns page' do
-      expect(subject.keys).to match(
-        %w(id title slug content created_at updated_at publish_status featured action_count language)
+      expected = %w(
+        id
+        title
+        slug
+        content
+        created_at
+        updated_at
+        publish_status
+        featured
+        action_count
+        language
+        campaign_action_count
       )
+      expect(subject.keys).to match_array(expected)
 
       expect(subject.symbolize_keys).to include(title: 'Foo',
                                                 id: page.id)


### PR DESCRIPTION
This is to make the tiles on the homepage include the action count of the whole campaign, not just that page.