### PR TITLE
Fundraiser.js, member registration and localization refactor.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,9 @@ Lint/BlockAlignment:
 
 Lint/InheritException:
   Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  MaxLineLength: 40

--- a/app/assets/javascripts/member-facing.js.erb
+++ b/app/assets/javascripts/member-facing.js.erb
@@ -19,6 +19,8 @@
 require("<%= Settings.external_js_path %>");
 <% end %>
 
+window.URI = require('urijs');
+
 window.sumofus = window.sumofus || {} // for legacy templates that reference window.sumofus
 window.champaign = window.champaign || window.sumofus || {};
 window.champaign.Petition      = require('member-facing/backbone/petition');
@@ -32,3 +34,4 @@ window.champaign.Notification  = require('member-facing/backbone/notification');
 window.champaign.SweetPlaceholder      = require('member-facing/backbone/sweet_placeholder');
 window.champaign.CampaignerOverlay     = require('member-facing/backbone/campaigner_overlay');
 window.champaign.BraintreeHostedFields = require('member-facing/backbone/braintree_hosted_fields');
+window.champaign.redirectors  = require('member-facing/redirectors')

--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -34,9 +34,6 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
   },
 
   // options: object with any of the following keys
-  //    followUpUrl: the url to redirect to after success
-  //    submissionCallback: a function to call after success, receives the
-  //      arguments received by the ajax call posting the donation
   //    member: an object for an existing member. registered and email fields are used
   //    currency: the three letter capitalized currency code to use
   //    amount: a preselected donation amount, if > 0 the first step will be skipped
@@ -49,10 +46,6 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     this.initializeCurrency(options.currency, options.donationBands);
     this.changeStep(1);
     this.donationAmount = 0;
-    this.followUpUrl = options.followUpUrl;
-    if (typeof options.submissionCallback === 'function') {
-      this.submissionCallback = options.submissionCallback;
-    }
     if (typeof options.member === 'object') {
       this.member = options.member;
     } else {
@@ -317,39 +310,38 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     this.disableOneClickButton();
     $.post(url, this.oneClickDonationData())
       .then(this.onSubmission.bind(this))
-      .then(this.onOneClickSuccess.bind(this), this.onOneClickFailed.bind(this));
+      .then(this.transactionSuccess.bind(this), this.onOneClickFailed.bind(this));
   },
 
-  onOneClickSuccess(data) {
-    if ( this.memberShouldRegister() ) {
-      this.followRedirect(this.registrationPath(this.member.email));
+  formData() {
+    return {
+      storeInVault: this.readStoreInVault(),
+      member: _.pick(this.currentUser(), 'email', 'registered')
+    };
+  },
+
+  currentUser() {
+    var formUser = this.serializeUserForm();
+    if(this.member.email === formUser.email) {
+      return this.member;
     } else {
-      this.followRedirect((data && data.follow_up_url) || this.followUpUrl);
+      return formUser;
     }
   },
 
   transactionSuccess(data) {
-    let url = (data && data.follow_up_url) || this.followUpUrl;
-
-    if ( this.memberShouldRegister() ) {
-      const user = this.serializeUserForm();
-      url = this.registrationPath(user.email);
-    }
-
-    this.followRedirect(url);
-  },
-
-  registrationPath(email) {
-    return `/member_authentication/new?page_id=${this.pageId}&email=${encodeURIComponent(email)}`;
+    $.publish('fundraiser:transaction_success', [data, this.formData()])
   },
 
   onOneClickFailed() {
+    $.publish('fundraiser:transaction_error');
     this.enableOneClickButton();
     const $errors = this.$('.fundraiser-bar__errors');
     $errors.removeClass('hidden-closed');
   },
 
   transactionFailed(data, status) {
+    $.publish('fundraiser:transaction_error');
     this.enableButton();
     let $errors = this.$('.fundraiser-bar__errors');
     $errors.removeClass('hidden-closed');
@@ -428,21 +420,6 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
       .prop('disabled', false);
   },
 
-  followRedirect(url) {
-    // If we have no redirect URL or submission callback,
-    // we display a thank you message
-    if (!url && !this.submissionCallback) {
-      window.alert(I18n.t('fundraiser.thank_you'));
-      return;
-    }
-
-    this.redirectTo(url);
-  },
-
-  redirectTo(url) {
-    window.location.href = url;
-  },
-
   displayDirectDebit(show) {
     if (show === true) {
       $('.hosted-fields__direct-debit-container').removeClass('hidden-irrelevant');
@@ -456,9 +433,9 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     $(window).on('message', (e) => {
       if (typeof e.originalEvent.data === 'object') {
         if (e.originalEvent.data.event === 'follow_up:loaded') {
-          this.redirectTo(this.followUpUrl);
           e.originalEvent.source.close();
           $.publish('direct_debit:donated');
+          this.transactionSuccess({});
         } else if (e.originalEvent.data.event === 'donation:error') {
           const messages = e.originalEvent.data.errors.map(({ message }) => message);
           this.showErrors(messages);
@@ -468,13 +445,6 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     });
   },
 
-  memberRegistered() {
-    return this.member.registered;
-  },
-
-  memberShouldRegister() {
-    return !this.memberRegistered() && this.readStoreInVault();
-  },
 }));
 
 module.exports = Fundraiser;

--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -289,7 +289,6 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     data.device_data = JSON.parse(obj.deviceData);
 
     $.post(`/api/payment/braintree/pages/${this.pageId}/transaction`, data)
-      .then(this.onSubmission.bind(this))
       .then(this.transactionSuccess.bind(this), this.transactionFailed.bind(this));
 
     if (this.directDebitOpened) {
@@ -297,19 +296,11 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
     }
   },
 
-  onSubmission(data, status) {
-    if (this.submissionCallback) {
-      this.submissionCallback(data, status);
-    }
-    return data;
-  },
-
   submitOneClick(event) {
     event.preventDefault();
     const url = `/api/payment/braintree/pages/${this.pageId}/one_click`;
     this.disableOneClickButton();
     $.post(url, this.oneClickDonationData())
-      .then(this.onSubmission.bind(this))
       .then(this.transactionSuccess.bind(this), this.onOneClickFailed.bind(this));
   },
 

--- a/app/assets/javascripts/member-facing/redirectors.js
+++ b/app/assets/javascripts/member-facing/redirectors.js
@@ -1,0 +1,43 @@
+const RegisterMemberRedirector = {
+  attemptRedirect:  function(followUpUrl, member) {
+
+    if(typeof(member) !== 'object') {
+      member = window.champaign.personalization.member;
+    }
+
+    if ( shouldMemberRegister() ) {
+      redirectToRegistration();
+      return true;
+    } else {
+      return false;
+    }
+
+    function shouldMemberRegister() {
+      return !member.registered;
+    }
+
+    function redirectToRegistration() {
+      var url = `/member_authentication/new?follow_up_url=${encodeURIComponent(followUpUrl)}&email=${encodeURIComponent(member.email)}`;
+      window.location.href = url;
+    }
+  }
+};
+
+const AfterDonationRedirector = {
+  attemptRedirect: function (followUpUrl, donationFormData) {
+    if(!(donationFormData.storeInVault && RegisterMemberRedirector.attemptRedirect(followUpUrl, donationFormData.member))) {
+      redirectTo(followUpUrl);
+    }
+
+    return true;
+
+    function redirectTo(url) {
+      window.location.href = url;
+    }
+  }
+};
+
+module.exports = {
+  RegisterMemberRedirector: RegisterMemberRedirector,
+  AfterDonationRedirector:  AfterDonationRedirector
+};

--- a/app/assets/javascripts/member-facing/redirectors.js
+++ b/app/assets/javascripts/member-facing/redirectors.js
@@ -1,5 +1,7 @@
+import uri from 'urijs';
+
 const RegisterMemberRedirector = {
-  attemptRedirect:  function(followUpUrl, member) {
+  attemptRedirect(followUpUrl, member) {
 
     if(typeof(member) !== 'object') {
       member = window.champaign.personalization.member;
@@ -17,14 +19,22 @@ const RegisterMemberRedirector = {
     }
 
     function redirectToRegistration() {
-      var url = `/member_authentication/new?follow_up_url=${encodeURIComponent(followUpUrl)}&email=${encodeURIComponent(member.email)}`;
-      redirectTo(url);
+      redirectTo(
+        registrationUrl(followUpUrl, member.email)
+      );
+    }
+
+    function registrationUrl(url, email) {
+      return uri('/member_authentication/new')
+        .query(`follow_up_url=${uri.encode(url)}`)
+        .query(`email=${uri.encode(email)}`)
+        .toString();
     }
   }
 };
 
 const AfterDonationRedirector = {
-  attemptRedirect: function (followUpUrl, donationFormData) {
+  attemptRedirect(followUpUrl, donationFormData) {
     if(!(donationFormData.storeInVault && RegisterMemberRedirector.attemptRedirect(followUpUrl, donationFormData.member))) {
       redirectTo(followUpUrl);
     }

--- a/app/assets/javascripts/member-facing/redirectors.js
+++ b/app/assets/javascripts/member-facing/redirectors.js
@@ -18,7 +18,7 @@ const RegisterMemberRedirector = {
 
     function redirectToRegistration() {
       var url = `/member_authentication/new?follow_up_url=${encodeURIComponent(followUpUrl)}&email=${encodeURIComponent(member.email)}`;
-      window.location.href = url;
+      redirectTo(url);
     }
   }
 };
@@ -30,12 +30,12 @@ const AfterDonationRedirector = {
     }
 
     return true;
-
-    function redirectTo(url) {
-      window.location.href = url;
-    }
   }
 };
+
+function redirectTo(url) {
+  window.location.href = url;
+}
 
 module.exports = {
   RegisterMemberRedirector: RegisterMemberRedirector,

--- a/app/assets/stylesheets/member-facing/fundraiser.scss
+++ b/app/assets/stylesheets/member-facing/fundraiser.scss
@@ -1,6 +1,8 @@
 @import "compass/css3/filter";
 
 .fundraiser-bar {
+  text-align: left;
+
   &__steps {
     position: relative;
     width: 100%;
@@ -101,6 +103,7 @@
     position: relative;
 
     font-size: 20px;
+    line-height: 20px;
     &--past {
       color: white;
       background: $slate-gray;
@@ -227,6 +230,40 @@
       width: 12px;
       position: relative;
       top: 2px;
+    }
+  }
+  &--freestanding.fundraiser-bar {
+    position: static;
+    max-width: 400px;
+
+    .fundraiser-bar__top, .fundraiser-bar__main {
+      background-color: transparent;
+      position: relative;
+    }
+
+    .fundraiser-bar__top h2 {
+      font-size: 24px;
+      font-weight: normal;
+      text-align: center;
+    }
+
+    .form--big input,
+    .form--big select,
+    .form--big textarea,
+    .form--big .selectize-control.single .selectize-input,
+    .form--big .hosted-fields__host,
+    .hosted-fields__host, input, select, .selectize-input {
+      border-color: $slate-gray;
+    }
+
+    .braintree-hosted-fields-focused {
+      border-color: $teal;
+    }
+    .overlay-toggle__close-button {
+      display: none;
+    }
+    .fundraiser-bar__step-number--upcoming {
+      background: white;
     }
   }
 }

--- a/app/assets/stylesheets/member-facing/fundraiser.scss
+++ b/app/assets/stylesheets/member-facing/fundraiser.scss
@@ -254,17 +254,34 @@
     .form--big .hosted-fields__host,
     .hosted-fields__host, input, select, .selectize-input {
       border-color: $slate-gray;
+      &.braintree-hosted-fields-focused {
+        border-color: $teal;
+      }
     }
 
-    .braintree-hosted-fields-focused {
-      border-color: $teal;
-    }
     .overlay-toggle__close-button {
       display: none;
     }
+
     .fundraiser-bar__step-number--upcoming {
       background: white;
     }
+
+    @media(max-width: 736px) {
+      label.checkbox-label input[type='checkbox'] {
+        position: relative;
+        vertical-align: middle;
+      }
+
+      .action-form__welcome-name {
+        line-height: 14px;
+      }
+
+      .action-form__clear-form {
+        line-height: 12px;
+      }
+    }
+
   }
 }
 

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class Api::ActionsController < ApplicationController
-  before_filter :localize_from_page_id
+  before_action :localize_from_page_id
+  before_action :store_locale_in_session, only: :create
+
   skip_before_action :verify_authenticity_token
 
   def create

--- a/app/controllers/api/survey_responses_controller.rb
+++ b/app/controllers/api/survey_responses_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class Api::SurveyResponsesController < ApplicationController
   skip_before_action :verify_authenticity_token
+  before_action :localize_from_page_id, :store_locale_in_session, only: :create
 
   def create
     service = ManageSurveyResponse.new(

--- a/app/controllers/member_authentications_controller.rb
+++ b/app/controllers/member_authentications_controller.rb
@@ -21,7 +21,7 @@ class MemberAuthenticationsController < ApplicationController
       email: params[:email],
       password: params[:password],
       password_confirmation: params.fetch(:password_confirmation, ''),
-      language_code: 'en' # TODO: use language from cookies
+      language_code: session[:language] || I18n.default_locale
     )
 
     if auth.valid?

--- a/app/controllers/member_authentications_controller.rb
+++ b/app/controllers/member_authentications_controller.rb
@@ -21,7 +21,7 @@ class MemberAuthenticationsController < ApplicationController
       email: params[:email],
       password: params[:password],
       password_confirmation: params.fetch(:password_confirmation, ''),
-      language_code: 'en' # TODO use language from cookies
+      language_code: 'en' # TODO: use language from cookies
     )
 
     if auth.valid?

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -2,6 +2,7 @@
 
 class PaymentController < ApplicationController
   skip_before_action :verify_authenticity_token
+  before_action :localize_from_page_id, :store_locale_in_session, only: :transaction
 
   def transaction
     if builder.success?

--- a/app/controllers/reset_passwords_controller.rb
+++ b/app/controllers/reset_passwords_controller.rb
@@ -2,7 +2,7 @@
 
 class ResetPasswordsController < ApplicationController
   before_action :set_page_title
-  before_action :set_locale
+  before_action :set_locale_from_param
   layout 'generic'
 
   def default_url_options
@@ -54,7 +54,7 @@ class ResetPasswordsController < ApplicationController
     @title = t('reset_passwords.new.title')
   end
 
-  def set_locale
-    I18n.locale = params[:locale] || I18n.default_locale
+  def set_locale_from_param
+    set_locale(params[:locale]) if params[:locale].present?
   end
 end

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -137,7 +137,6 @@
         });
         chmp.myFundraiser = new chmp.Fundraiser({
           pageId:           "{{ id }}",
-          followUpUrl:      "{{ follow_up_url }}",
           member:           chmp.personalization.member,
           showDirectDebit:  chmp.personalization.showDirectDebit,
           currency:         chmp.personalization.urlParams.currency || chmp.personalization.location.currency,

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -1,6 +1,6 @@
 {% if plugins.fundraiser[ref].active %}
-  <div class="fundraiser-bar sidebar {{ extra_class }}">
-    <div class="overlay-toggle__mobile-view overlay-toggle__mobile-view--closed">
+  <div class="fundraiser-bar sidebar {{ extra_class }} {% if freestanding %} fundraiser-bar--freestanding {% endif %}">
+    <div class="{% unless freestanding %}overlay-toggle__mobile-view overlay-toggle__mobile-view--closed{% endunless %}">
       <div class="fundraiser-bar__content">
         <div class="fundraiser-bar__top script-dependent__for-height">
           <div class="overlay-toggle__mobile-ui">
@@ -145,7 +145,9 @@
           recurringDefault: chmp.personalization.urlParams.recurring_default || "{{ plugins.fundraiser[ref].recurring_default }}",
           paymentMethods:   chmp.personalization.paymentMethods
         });
-        chmp.mySidebar     = new chmp.Sidebar({petitionTextMinHeight: 162, baseClass: 'fundraiser-bar'});
+        {% unless freestanding %}
+          chmp.mySidebar     = new chmp.Sidebar({petitionTextMinHeight: 162, baseClass: 'fundraiser-bar'});
+        {% endunless %}
         chmp.hostedFields  = new chmp.BraintreeHostedFields();
         chmp.overlayToggle = new chmp.OverlayToggle();
       });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "browserify": "~> 10.2.4",
     "browserify-incremental": "^3.0.1",
     "js-cookie": "^2.1.3",
-    "lodash": "^4.16.1"
+    "lodash": "^4.16.1",
+    "urijs": "^1.18.2"
   },
   "license": "MIT",
   "engines": {

--- a/spec/controllers/member_authentications_controller_spec.rb
+++ b/spec/controllers/member_authentications_controller_spec.rb
@@ -19,7 +19,7 @@ describe MemberAuthenticationsController do
         .with(password: 'p', password_confirmation: 'p', email: 'test@example.com', language_code: 'en')
     end
 
-    # TODO test it's being set from cookies
+    # TODO: test it's being set from cookies
     xit 'sets locale' do
       expect(I18n).to have_received(:locale=).with('en')
     end

--- a/spec/controllers/member_authentications_controller_spec.rb
+++ b/spec/controllers/member_authentications_controller_spec.rb
@@ -9,8 +9,10 @@ describe MemberAuthenticationsController do
     before do
       allow(MemberAuthenticationBuilder).to receive(:build) { auth }
       allow(Page).to receive(:first) { page }
+      allow(I18n).to receive(:locale=)
 
       session[:follow_up_url] = '/a/b'
+      session[:language] = 'en'
       post :create, email: 'test@example.com', password: 'p', password_confirmation: 'p'
     end
 
@@ -19,8 +21,7 @@ describe MemberAuthenticationsController do
         .with(password: 'p', password_confirmation: 'p', email: 'test@example.com', language_code: 'en')
     end
 
-    # TODO: test it's being set from cookies
-    xit 'sets locale' do
+    it 'sets locale' do
       expect(I18n).to have_received(:locale=).with('en')
     end
 

--- a/spec/controllers/member_authentications_controller_spec.rb
+++ b/spec/controllers/member_authentications_controller_spec.rb
@@ -8,12 +8,10 @@ describe MemberAuthenticationsController do
 
     before do
       allow(MemberAuthenticationBuilder).to receive(:build) { auth }
-      allow(Page).to receive(:find) { page }
-      allow(Page).to receive(:find_by) { page }
-      allow(I18n).to receive(:locale=)
-      allow(PageFollower).to receive(:follow_up_path) { '/a/b' }
+      allow(Page).to receive(:first) { page }
 
-      post :create, email: 'test@example.com', password: 'p', password_confirmation: 'p', page_id: '1'
+      session[:follow_up_url] = '/a/b'
+      post :create, email: 'test@example.com', password: 'p', password_confirmation: 'p'
     end
 
     it 'builds authentication' do
@@ -21,16 +19,12 @@ describe MemberAuthenticationsController do
         .with(password: 'p', password_confirmation: 'p', email: 'test@example.com', language_code: 'en')
     end
 
-    it 'sets locale' do
+    # TODO test it's being set from cookies
+    xit 'sets locale' do
       expect(I18n).to have_received(:locale=).with('en')
     end
 
     context 'successfully creates authentication' do
-      it 'generates follow up path' do
-        expect(PageFollower).to have_received(:follow_up_path)
-          .with(page, member_id: 34)
-      end
-
       it 'returns with js snippet to redirect that includes member id' do
         expect(response.body).to match("window.location = '/a/b'")
       end

--- a/spec/features/express_donations/email_one_click_spec.rb
+++ b/spec/features/express_donations/email_one_click_spec.rb
@@ -15,12 +15,12 @@ feature 'Express From Mailing Link' do
   end
 
   def register_member(member)
-    visit new_member_authentication_path(page_id: donation_page.id, email: member.email)
+    visit new_member_authentication_path(follow_up_url: '/a/page', email: member.email)
 
     fill_in 'password', with: 'password'
     fill_in 'password_confirmation', with: 'password'
     click_button 'Register'
-    expect(page).to have_content("window.location = '/a/foo-bar/follow-up?member_id=#{member.id}'")
+    expect(page).to have_content("window.location = '/a/page'")
   end
 
   def authenticate_member(auth)

--- a/spec/javascripts/member-ui/fundraiser_spec.js
+++ b/spec/javascripts/member-ui/fundraiser_spec.js
@@ -270,97 +270,6 @@ describe("Fundraiser", function() {
         Backbone.off();
       });
 
-      describe('when store_in_vault is checked', function(){
-
-        beforeEach(function(){
-          $('input.fundraiser-bar__store-in-vault').prop('checked', true);
-        });
-
-        it('redirects to the member signup url if no url supplied in constructor or response', function(){
-          suite.fundraiser = new window.champaign.Fundraiser({pageId: '1'});
-          sinon.stub(suite.fundraiser, 'redirectTo');
-          suite.triggerSuccess();
-          expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.memberAuthUrl);
-          suite.fundraiser.redirectTo.restore();
-        });
-
-        it('overrides all follow up paths with member_authentication', function(){
-          suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: '/not-used', pageId: '1'});
-          sinon.stub(suite.fundraiser, 'redirectTo');
-          suite.triggerSuccess('{ "success": "true", "follow_up_url": "/this-one?a=b" }');
-          expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.memberAuthUrl);
-          suite.fundraiser.redirectTo.restore();
-        });
-
-        it('calls the callback function if it is supplied', function(){
-          var callback = sinon.spy();
-          suite.fundraiser = new window.champaign.Fundraiser({submissionCallback: callback, pageId: '1'});
-          sinon.stub(suite.fundraiser, 'redirectTo');
-          suite.triggerSuccess();
-          expect(suite.fundraiser.redirectTo).to.have.been.calledWith(suite.memberAuthUrl);
-          expect(callback.called).to.eq(true);
-          suite.fundraiser.redirectTo.restore();
-        });
-
-        it('redirects to passed followUpUrl if member is already registered', function(){
-          suite.fundraiser = new window.champaign.Fundraiser({
-            followUpUrl: '/not-used',
-            pageId: '1',
-            member: { registered: true, email: 'adsf@asdf.com' }
-          });
-          sinon.stub(suite.fundraiser, 'redirectTo');
-          suite.triggerSuccess('{ "success": "true", "follow_up_url": "/this-one?a=b" }');
-          expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/this-one?a=b');
-          suite.fundraiser.redirectTo.restore();
-        });
-      });
-
-      describe('when store_in_vault is not checked', function() {
-
-        beforeEach(function(){
-          $('input.fundraiser-bar__store-in-vault').prop('checked', false);
-        });
-
-        it('redirects to the followUpUrl if it is supplied', function(){
-          suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: '/other-url', pageId: '1'});
-          sinon.stub(suite.fundraiser, 'redirectTo');
-          suite.triggerSuccess();
-          expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/other-url');
-          suite.fundraiser.redirectTo.restore();
-        });
-
-        it('redirects to the follow_up_url in the response if one is present', function(){
-          suite.fundraiser = new window.champaign.Fundraiser({followUpUrl: '/not-used', pageId: '1'});
-          sinon.stub(suite.fundraiser, 'redirectTo');
-          suite.triggerSuccess('{ "success": "true", "follow_up_url": "/this-one?a=b" }');
-          expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/this-one?a=b');
-          suite.fundraiser.redirectTo.restore();
-        });
-
-        it('sends an alert if neither callback nor followUpUrl passed', function(){
-          window.alert = sinon.spy();
-          suite.fundraiser = new window.champaign.Fundraiser({pageId: '1'});
-          suite.triggerSuccess();
-          expect(window.alert.called).to.eq(true);
-        });
-
-        it('calls the callback function if it is supplied', function(){
-          var callback = sinon.spy();
-          suite.fundraiser = new window.champaign.Fundraiser({submissionCallback: callback, pageId: '1'});
-          suite.triggerSuccess();
-          expect(callback.called).to.eq(true);
-        });
-
-        it('calls the callback function and redirects to the followUpUrl if both supplied', function(){
-          var callback = sinon.spy();
-          suite.fundraiser = new window.champaign.Fundraiser({submissionCallback: callback, followUpUrl: '/other-url', pageId: '1'});
-          sinon.stub(suite.fundraiser, 'redirectTo');
-          suite.triggerSuccess();
-          expect(suite.fundraiser.redirectTo).to.have.been.calledWith('/other-url');
-          expect(callback.called).to.eq(true);
-          suite.fundraiser.redirectTo.restore();
-        });
-      });
     });
   });
 
@@ -370,12 +279,7 @@ describe("Fundraiser", function() {
 
       suite.follow_up_url = "/pages/636/follow-up";
       suite.fundraiser = new window.champaign.Fundraiser({ pageId: '1', followUpUrl: suite.follow_up_url });
-      sinon.stub(suite.fundraiser, 'redirectTo');
       suite.server.respond(); // respond to request for token
-    });
-
-    afterEach(function() {
-      suite.fundraiser.redirectTo.restore();
     });
 
     describe('loading and first panel', function(){

--- a/spec/liquid/liquid_renderer_spec.rb
+++ b/spec/liquid/liquid_renderer_spec.rb
@@ -176,7 +176,7 @@ describe LiquidRenderer do
       let(:fundraiser) { create :plugins_fundraiser, page: page, form: form }
 
       before :each do
-        fundraiser = create :plugins_fundraiser, page: page, form: form, recurring_default: 'recurring'
+        create :plugins_fundraiser, page: page, form: form, recurring_default: 'recurring'
         allow(DirectDebitDecider).to receive(:decide).and_return(true)
       end
 


### PR DESCRIPTION
Extracted redirect logic into Redirector services in redirectors.js. Fundraiser.js doesn't handle the redirect logic anymore, instead what it does is simply publish an event `fundraiser:success` that should be captured by the view loading this widget. 

I also refactored the member authentication flow. It used to require a page_id param to be passed. Now I've replaced `page_id` with a new optional param `follow_up_url`. If `follow_up_url` is not passed, then the user is redirected to the home page after signing up.

This PR depends on these changes to the templates on sou-assets:
https://github.com/SumOfUs/sou-assets/pull/11