### PR TITLE
Express donations bugfix: currency and submit for settlement.

### DIFF
--- a/lib/payment_processor/braintree/one_click.rb
+++ b/lib/payment_processor/braintree/one_click.rb
@@ -75,7 +75,11 @@ module PaymentProcessor::Braintree
     def make_sale
       @make_sale ||= ::Braintree::Transaction.sale(
         payment_method_token: payment_options.token,
-        amount: payment_options.amount
+        amount: payment_options.amount,
+        merchant_account_id: payment_options.merchant_account_id,
+        options: {
+          submit_for_settlement: true
+        }
       )
     end
 

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -153,6 +153,7 @@ describe 'Express Donation' do
 
   describe 'transaction' do
     before do
+      allow(Braintree::Transaction).to receive(:sale).and_call_original
       VCR.use_cassette('braintree_express_donation') do
         body = {
           payment: {
@@ -229,6 +230,18 @@ describe 'Express Donation' do
           },
           meta: hash_including({})
         )
+    end
+
+    it 'submits the transaction for settlement' do
+      expect(Braintree::Transaction).to have_received(:sale).with(hash_including(
+        options: { submit_for_settlement: true }
+      ))
+    end
+
+    it 'calls the Braintree API with the merchant_account_id' do
+      expect(Braintree::Transaction).to have_received(:sale).with(hash_including(
+        merchant_account_id: 'GBP'
+      ))
     end
   end
 end


### PR DESCRIPTION
There was a bug that was causing express donations to be charged in the default currency and not being settled (only authorised) 

We now pass `merchant_account_id` and `submit_for_settlement` in one click donations.