### PR TITLE
Handle failed subscription charges - Braintree

### DIFF
--- a/app/models/payment/braintree.rb
+++ b/app/models/payment/braintree.rb
@@ -142,7 +142,6 @@ module Payment::Braintree
       create_customer
       create_payment_method
       record = create_transaction
-
       return false unless successful?
       @customer.update(customer_attrs) if @save_customer && @customer
       record

--- a/app/models/payment/braintree/transaction.rb
+++ b/app/models/payment/braintree/transaction.rb
@@ -35,8 +35,8 @@ class Payment::Braintree::Transaction < ActiveRecord::Base
     ChampaignQueue.push({
       type: 'subscription-payment',
       params: {
-        recurring_id: self.subscription.try(:action).form_data['subscription_id'],
-        success: self.status == 'success' ? 1 : 0
+        recurring_id: subscription.try(:action).form_data['subscription_id'],
+        success: status == 'success' ? 1 : 0
       }
     }, { delay: 120 })
   end

--- a/app/models/payment/braintree/transaction.rb
+++ b/app/models/payment/braintree/transaction.rb
@@ -30,4 +30,14 @@ class Payment::Braintree::Transaction < ActiveRecord::Base
   enum status: [:success, :failure]
 
   scope :one_off, -> { where(subscription_id: nil) }
+
+  def publish_subscription_charge
+    ChampaignQueue.push({
+      type: 'subscription-payment',
+      params: {
+        recurring_id: self.subscription.try(:action).form_data['subscription_id'],
+        success: self.status == 'success' ? 1 : 0
+      }
+    }, { delay: 120 })
+  end
 end

--- a/spec/models/payment/braintree/transaction_spec.rb
+++ b/spec/models/payment/braintree/transaction_spec.rb
@@ -96,4 +96,22 @@ describe Payment::Braintree::Transaction do
       expect(Payment::Braintree::Transaction.one_off).to match_array([transaction_without_subscription])
     end
   end
+
+  describe 'publish subscription payment' do
+    let(:action) { create(:action, form_data: {'subscription_id' => 'subscription_id'}) }
+    let(:subscription) { create(:payment_braintree_subscription, subscription_id: 'subscription_id', action: action) }
+    let(:transaction) { create(:payment_braintree_transaction, subscription: subscription, status: 'success') }
+    it 'pushes a subscription payment event with a status to the queue' do
+      expected_payload = {
+                            type: 'subscription-payment',
+                            params: {
+                              recurring_id: 'subscription_id',
+                              success: 1
+                            }
+                          }
+      expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)
+      transaction.publish_subscription_charge
+    end
+
+  end
 end

--- a/spec/models/payment/braintree/transaction_spec.rb
+++ b/spec/models/payment/braintree/transaction_spec.rb
@@ -98,20 +98,19 @@ describe Payment::Braintree::Transaction do
   end
 
   describe 'publish subscription payment' do
-    let(:action) { create(:action, form_data: {'subscription_id' => 'subscription_id'}) }
+    let(:action) { create(:action, form_data: { 'subscription_id' => 'subscription_id' }) }
     let(:subscription) { create(:payment_braintree_subscription, subscription_id: 'subscription_id', action: action) }
     let(:transaction) { create(:payment_braintree_transaction, subscription: subscription, status: 'success') }
     it 'pushes a subscription payment event with a status to the queue' do
       expected_payload = {
-                            type: 'subscription-payment',
-                            params: {
-                              recurring_id: 'subscription_id',
-                              success: 1
-                            }
-                          }
+        type: 'subscription-payment',
+        params: {
+          recurring_id: 'subscription_id',
+          success: 1
+        }
+      }
       expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)
       transaction.publish_subscription_charge
     end
-
   end
 end

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -98,7 +98,8 @@ describe 'Braintree API' do
           expected_payload = {
             type: 'subscription-payment',
             params: {
-              recurring_id: /[a-z0-9]{6}/
+              recurring_id: /[a-z0-9]{6}/,
+              success: 1
             }
           }
 
@@ -148,7 +149,8 @@ describe 'Braintree API' do
           expected_payload = {
             type: 'subscription-payment',
             params: {
-              recurring_id: /[a-z0-9]{6}/
+              recurring_id: /[a-z0-9]{6}/,
+              success: 1
             }
           }
 


### PR DESCRIPTION
Missing logic to handle failed GoCardless subscription charges. Looking into it now.