### PR TITLE
Allow delaying redirects

### DIFF
--- a/app/assets/javascripts/member-facing/redirectors.js
+++ b/app/assets/javascripts/member-facing/redirectors.js
@@ -1,4 +1,5 @@
 import uri from 'urijs';
+import delay from 'lodash/delay';
 
 const RegisterMemberRedirector = {
   attemptRedirect(followUpUrl, member) {
@@ -44,7 +45,9 @@ const AfterDonationRedirector = {
 };
 
 function redirectTo(url) {
-  window.location.href = url;
+  delay(() => {
+    window.location.href = url;
+  }, window.DELAY_REDIRECT || 0);
 }
 
 module.exports = {

--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -37,7 +37,17 @@ class Api::Payment::BraintreeController < PaymentController
 
   def one_click
     @result = client::OneClick.new(params).run
-    render status: :unprocessable_entity unless @result.success?
+
+    if @result.success?
+      payload = { success: true }
+        .merge(member: ::Payment::Braintree::PaymentMethod.find(params[:payment][:payment_method_id]).customer.member)
+        .merge(recurring: recurring?)
+
+      render json: payload
+    else
+      render status: :unprocessable_entity unless @result.success?
+    end
+
   end
 
   private

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -28,9 +28,15 @@ class PaymentController < ApplicationController
 
     end
 
+    payload = { success: true }
+      .merge(follow_up)
+      .merge(id_for_response)
+      .merge(member: Member.find(builder.action.member_id))
+      .merge(recurring: recurring?)
+
     respond_to do |format|
       format.html { redirect_to follow_up_page_path(page) }
-      format.json { render json: { success: true }.merge(follow_up).merge(id_for_response) }
+      format.json { render json: payload }
     end
   end
 


### PR DESCRIPTION
I've updated the redirectTo function to read the global variable and redirect.
It will run immediately if the variable is not set or is not a number.

To use in a campaign page, add a script section:
```js
window.DELAY_REDIRECT = 1000; // time in ms

// you can now bind to the `fundraiser:transaction_success`
$.subscribe('fundraiser:transaction_success', function (event, data) {
  
});
```

The transaction and one_click responses are also updated to return the current member, and if the transaction request a recurring one.