### PR TITLE
Failed gc subscription charges

### DIFF
--- a/app/models/payment/go_cardless/transaction.rb
+++ b/app/models/payment/go_cardless/transaction.rb
@@ -77,14 +77,13 @@ class Payment::GoCardless::Transaction < ActiveRecord::Base
   end
 
   def publish_failed_subscription_charge
-    return if self.subscription.blank?
+    return if subscription.blank?
     ChampaignQueue.push({
-                          type: 'subscription-payment',
-                          params: {
-                            recurring_id: self.subscription.go_cardless_id,
-                            success: 0
-                          }
-                        }, { delay: 120 })
-
+      type: 'subscription-payment',
+      params: {
+        recurring_id: subscription.go_cardless_id,
+        success: 0
+      }
+    }, { delay: 120 })
   end
 end

--- a/app/models/payment/go_cardless/transaction.rb
+++ b/app/models/payment/go_cardless/transaction.rb
@@ -68,11 +68,23 @@ class Payment::GoCardless::Transaction < ActiveRecord::Base
     end
 
     event :run_fail do
-      transitions to: :failed
+      transitions to: :failed, after: :publish_failed_subscription_charge
     end
 
     event :run_charge_back do
       transitions to: :charged_back
     end
+  end
+
+  def publish_failed_subscription_charge
+    return if self.subscription.blank?
+    ChampaignQueue.push({
+                          type: 'subscription-payment',
+                          params: {
+                            recurring_id: self.subscription.go_cardless_id,
+                            success: 0
+                          }
+                        }, { delay: 120 })
+
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
     params = event.payload[:params].reject do |k|
       %w(controller action).include? k
     end
-    log_hash = { 'params' => params, 'time' => event.time }
+    log_hash = { 'params' => params.except!(*:bt_payload), 'time' => event.time }
     unless event.payload[:exception].blank?
       log_hash['exception'] = event.payload[:exception]
     end

--- a/lib/payment_processor/go_cardless/webhook_handler/process_events.rb
+++ b/lib/payment_processor/go_cardless/webhook_handler/process_events.rb
@@ -28,7 +28,6 @@ module PaymentProcessor::GoCardless
 
       def process_event(event)
         klass_name = event['resource_type'].classify
-
         if ::PaymentProcessor::GoCardless::WebhookHandler.const_defined?(klass_name)
           processor = ::PaymentProcessor::GoCardless::WebhookHandler.const_get(klass_name).new(event)
           processor.process

--- a/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
@@ -73,18 +73,14 @@ describe PaymentProcessor::Braintree::WebhookHandler do
         )
       end
 
-      it 'returns false' do
-        expect(subject).to be false
-      end
-
       it 'does not write transaction' do
         expect { subject }
           .not_to change { subscription.transactions.count }
       end
 
       it 'logs error' do
-        expect(Rails.logger).to receive(:info)
-          .with(/Failed to handle Braintree::WebhookNotification/)
+        expect(Rails.logger).to receive(:error)
+          .with(/Braintree webhook handling failed for 'subscription_charged_successfully', for subscription ID 'invalid_subscription_id'/)
 
         subject
       end

--- a/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
@@ -80,6 +80,8 @@ describe PaymentProcessor::Braintree::WebhookHandler do
 
       it 'logs error' do
         expect(Rails.logger).to receive(:error)
+          .with(/Braintree webhook handling failed for 'subscription_charged_successfully', for subscription ID 'invalid_subscription_id'/)
+        expect(Rails.logger).to receive(:error)
           .with(/No locally persisted Braintree subscription found for subscription id invalid_subscription_id/)
         subject
       end

--- a/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
@@ -80,8 +80,7 @@ describe PaymentProcessor::Braintree::WebhookHandler do
 
       it 'logs error' do
         expect(Rails.logger).to receive(:error)
-          .with(/Braintree webhook handling failed for 'subscription_charged_successfully', for subscription ID 'invalid_subscription_id'/)
-
+          .with(/No locally persisted Braintree subscription found for subscription id invalid_subscription_id/)
         subject
       end
 

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -125,6 +125,7 @@ describe 'Braintree API' do
 
           it 'logs an error about a missing subscription' do
             expect(Rails.logger).to receive(:error).with(/No locally persisted Braintree subscription found for subscription id xxx/)
+            expect(Rails.logger).to receive(:error).with(/Braintree webhook handling failed for 'subscription_charged_successfully', for subscription ID 'xxx'/)
             subject
           end
 

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -89,7 +89,7 @@ describe 'Braintree API' do
           @subscription = Payment::Braintree::Subscription.last
         end
 
-        it 'creates a Payment::Braintree::Transaction record with the right params' do
+        it 'creates a Payment::Braintree::Transaction that is associated with a page' do
           expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
           expect(Payment::Braintree::Transaction.last.page_id).to eq(page.id)
         end
@@ -123,8 +123,8 @@ describe 'Braintree API' do
             )
           end
 
-          it 'logs an error' do
-            expect(Rails.logger).to receive(:error).with("Braintree webhook handling failed for 'subscription_charged_successfully', for subscription ID 'xxx'")
+          it 'logs an error about a missing subscription' do
+            expect(Rails.logger).to receive(:error).with(/No locally persisted Braintree subscription found for subscription id xxx/)
             subject
           end
 
@@ -146,7 +146,7 @@ describe 'Braintree API' do
           end
         end
 
-        it 'creates a Payment::Braintree::Transaction record with the right params' do
+        it 'creates a Payment::Braintree::Transaction associated with a page' do
           expect { subject }.to change { Payment::Braintree::Transaction.count }.by 1
           expect(Payment::Braintree::Transaction.last.page_id).to eq(page.id)
         end
@@ -163,6 +163,10 @@ describe 'Braintree API' do
           expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)
 
           subject
+        end
+
+        it 'does not create an action' do
+          expect { subject }.to_not change { Action.count }
         end
 
         include_examples 'has no unintended consequences'

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -123,9 +123,15 @@ describe 'Braintree API' do
             )
           end
 
-          it 'returns not found' do
+          it 'logs an error' do
+            expect(Rails.logger).to receive(:error).with("Braintree webhook handling failed for 'subscription_charged_successfully', for subscription ID 'xxx'")
             subject
-            expect(response.status).to eq 404
+          end
+
+          it 'does not create a transaction' do
+            expect(Payment::Braintree::Transaction.count).to eq(0)
+            subject
+            expect(@subscription.reload.transactions.count).to eq(0)
           end
         end
       end


### PR DESCRIPTION
There are a couple changes here:
- I tidied up `PaymentProcessor::Braintree::WebhookHandler` a little and would particularly appreciate an eye on the changes there.
- After realizing today that the log feed on staging for the webhooks coming in from Braintree are really not very useful, I've changed the logging in `WebhookHandler`. We are currently only getting the request path, controller, action and parameters. The unparsed `bt_payload` field is [taking a *ton* of log space](https://papertrailapp.com/systems/champaign-staging/events?q=bt_payload&focus=740269293195022337) while providing no information at all, and we handle all the webhooks through the same path, so there really is not much information about what was being processed. I filtered the bt_payload parameter on Lograge and am now logging which type of webhook is failing for which subscription,
- A GoCardless payments failure webhook now pushes a failed submission charge to the queue after we've verified that the transaction it's associated with belongs to a subscription. I'm still waiting verifiation from GoCardless to make sure I've understood the order of the webhooks correctly.
  - One question that now comes to mind, since this is something I implemented in the transactions class for subscriptions, is whether we're passing data about unsuccessful one-off donations to AK.
  - I also noticed that we're not persisting a failed transaction locally when there's a failed subscription charge. Is this behavior intentional? I don't think it was caused by my changes.