### PR TITLE
Better image size handling

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -30,7 +30,8 @@ class Image < ActiveRecord::Base
                       }
                     },
                     convert_options: {
-                      all: '-strip -interlace Plane'
+                      all: '-strip -interlace Plane',
+                      large: '-quality 80'
                     },
                     default_url: '/images/:style/missing.png'
 

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: 'fix.image_compression'
+    branch: 'development'
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,7 @@ deployment:
       - docker push soutech/champaign_web
       - ./deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: 'development'
+    branch: 'fix.image_compression'
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push soutech/champaign_web

--- a/spec/support/paperclip.rb
+++ b/spec/support/paperclip.rb
@@ -17,7 +17,7 @@ module Paperclip
   class Thumbnail
     def make
       src = Rails.root.join('spec', 'fixtures', 'test-image.gif')
-      dst = Tempfile.new([@basename, @format].compact.join('.'))
+      dst = Tempfile.new([@basename, 'gif'].compact.join('.'))
       dst.binmode
       FileUtils.cp(src, dst.path)
       dst


### PR DESCRIPTION
+ Reduce quality for all image styles
+ Turn to jpg for medium and large

These changes reduced the image at https://actions.sumofus.org/a/segolene-royal-defendez-les-abeilles-contre-les-lobbies-de-l-industrie-chimique from 2.2mb to 100k, without noticeably affecting image quality on a retina display.  