### PR TITLE
Remove chatty logging for when a subscription that receives a webhook…

### DIFF
--- a/lib/payment_processor/braintree/webhook_handler.rb
+++ b/lib/payment_processor/braintree/webhook_handler.rb
@@ -101,11 +101,6 @@ module PaymentProcessor
 
       def subscription
         @subscription ||= Payment::Braintree::Subscription.find_by(subscription_id: @notification.subscription.id)
-        if @subscription.blank?
-          Rails.logger.error("No locally persisted Braintree subscription found for subscription id #{@notification.subscription.id}!")
-          log_failure
-        end
-        @subscription
       end
 
       def member

--- a/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
@@ -79,12 +79,10 @@ describe PaymentProcessor::Braintree::WebhookHandler do
           .not_to change { subscription.transactions.count }
       end
 
-      it 'logs error' do
-        expect(Rails.logger).to receive(:error)
-          .with(/Braintree webhook handling failed for 'subscription_charged_successfully', for subscription ID 'invalid_subscription_id'/)
-        expect(Rails.logger).to receive(:error)
-          .with(/No locally persisted Braintree subscription found for subscription id invalid_subscription_id/)
-        subject
+      # We're failing silently if the subscription isn't persisted locally because we get a lot of webhooks
+      # for subscriptions that were created on our legacy platform.
+      it 'fails silently' do
+        expect(Rails.logger).to_not receive(:error)
       end
 
       it 'writes notification' do

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -124,9 +124,10 @@ describe 'Braintree API' do
             )
           end
 
-          it 'logs an error about a missing subscription' do
-            expect(Rails.logger).to receive(:error).with(/No locally persisted Braintree subscription found for subscription id xxx/)
-            expect(Rails.logger).to receive(:error).with(/Braintree webhook handling failed for 'subscription_charged_successfully', for subscription ID 'xxx'/)
+          # We're failing silently if the subscription isn't persisted locally because we get a lot of webhooks
+          # for subscriptions that were created on our legacy platform.
+          it 'fails silently on a missing subscription' do
+            expect(Rails.logger).to_not receive(:error)
             subject
           end
 


### PR DESCRIPTION
… is not persisted locally.