### PR TITLE
Change the time format for the created_at field. (#811)

### DIFF
--- a/app/models/payment/braintree/transaction.rb
+++ b/app/models/payment/braintree/transaction.rb
@@ -35,7 +35,7 @@ class Payment::Braintree::Transaction < ActiveRecord::Base
     ChampaignQueue.push({
       type: 'subscription-payment',
       params: {
-        created_at: created_at,
+        created_at: created_at.strftime('%Y-%m-%d %H:%M:%S'),
         recurring_id: subscription.try(:action).form_data['subscription_id'],
         success: status == 'success' ? 1 : 0,
         status: status == 'success' ? 'completed' : 'failed'

--- a/app/models/payment/go_cardless/transaction.rb
+++ b/app/models/payment/go_cardless/transaction.rb
@@ -81,7 +81,7 @@ class Payment::GoCardless::Transaction < ActiveRecord::Base
     ChampaignQueue.push({
       type: 'subscription-payment',
       params: {
-        created_at: created_at,
+        created_at: created_at.strftime('%Y-%m-%d %H:%M:%S'),
         recurring_id: subscription.go_cardless_id,
         success: 0,
         status: 'failed'

--- a/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
@@ -54,7 +54,8 @@ describe PaymentProcessor::Braintree::WebhookHandler do
           expected_payload = {
             type: 'subscription-payment',
             params: {
-              created_at: Time.now,
+              # Matches the only string format AK accepts, e.g. "2016-12-22 17:47:42"
+              created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
               recurring_id: 'foo',
               success: 1,
               status: 'completed'
@@ -158,7 +159,8 @@ describe PaymentProcessor::Braintree::WebhookHandler do
         expected_payload = {
           type: 'subscription-payment',
           params: {
-            created_at: Time.now,
+            # Matches the only string format AK accepts, e.g. "2016-12-22 17:47:42"
+            created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
             recurring_id: 'foo',
             success: 0,
             status: 'failed'

--- a/spec/models/payment/braintree/transaction_spec.rb
+++ b/spec/models/payment/braintree/transaction_spec.rb
@@ -105,7 +105,8 @@ describe Payment::Braintree::Transaction do
       expected_payload = {
         type: 'subscription-payment',
         params: {
-          created_at: transaction.created_at,
+          # Matches the only string format AK accepts, e.g. "2016-12-22 17:47:42"
+          created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
           recurring_id: 'subscription_id',
           success: 1,
           status: 'completed'

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -99,7 +99,8 @@ describe 'Braintree API' do
             expected_payload = {
               type: 'subscription-payment',
               params: {
-                created_at: Time.now,
+                # Matches the only string format AK accepts, e.g. "2016-12-22 17:47:42"
+                created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
                 recurring_id: /[a-z0-9]{6}/,
                 success: 1,
                 status: 'completed'
@@ -162,7 +163,8 @@ describe 'Braintree API' do
             expected_payload = {
               type: 'subscription-payment',
               params: {
-                created_at: Time.now,
+                # Matches the only string format AK accepts, e.g. "2016-12-22 17:47:42"
+                created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
                 recurring_id: /[a-z0-9]{6}/,
                 success: 1,
                 status: 'completed'

--- a/spec/requests/api/go_cardless/webhooks_spec.rb
+++ b/spec/requests/api/go_cardless/webhooks_spec.rb
@@ -131,7 +131,8 @@ describe 'subscriptions' do
         expect(ChampaignQueue).to receive(:push).with({
           type: 'subscription-payment',
           params: {
-            created_at: transaction.reload.created_at,
+            # Matches the only string format AK accepts, e.g. "2016-12-22 17:47:42"
+            created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
             recurring_id: subscription.go_cardless_id,
             success: 0,
             status: 'failed'


### PR DESCRIPTION
* Push created_at into subscription charge events

* Adhere to the only time format AK supports for created_at

* Adhere to the only time format AK supports for created_at