### PR TITLE
Raise 404 if email not present or member not found

### DIFF
--- a/app/controllers/email_confirmation_controller.rb
+++ b/app/controllers/email_confirmation_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class EmailConfirmationController < ApplicationController
+  before_filter :find_member
+
   def verify
     begin
       I18n.locale = params[:language]
@@ -8,8 +10,14 @@ class EmailConfirmationController < ApplicationController
     end
 
     @title = I18n.t('confirmation_mailer.title')
-    @member = Member.find_by_email(params[:email])
     @errors = EmailVerifierService.verify(params[:token], params[:email], cookies)
     render 'email_confirmation/follow_up', layout: 'generic'
+  end
+
+  private
+
+  def find_member
+    raise ActiveRecord::RecordNotFound if params[:email].blank?
+    @member = Member.find_by_email!(params[:email])
   end
 end

--- a/spec/requests/email_confirmation_spec.rb
+++ b/spec/requests/email_confirmation_spec.rb
@@ -50,4 +50,16 @@ describe 'Email Confirmation when signing up to express donations' do
       expect(auth.reload.confirmed_at).to be nil
     end
   end
+
+  context 'with missing memeber' do
+    it 'renders error' do
+      expect do
+        get '/email_confirmation'
+      end.to raise_error(ActiveRecord::RecordNotFound)
+
+      expect do
+        get '/email_confirmation', email: 'no@example.com'
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
 end


### PR DESCRIPTION
`GET /email_confirmation` is an easy endpoint to spam. This fix will quieten down the errors:

https://sumofus.airbrake.io/projects/132582/groups/1808966452919560309?tab=overview