### PR TITLE
Small fixes

### DIFF
--- a/app/controllers/api/pages_controller.rb
+++ b/app/controllers/api/pages_controller.rb
@@ -23,7 +23,9 @@ class Api::PagesController < ApplicationController
 
   def index
     @pages = PageService.list(language: params[:language], limit: params[:limit])
-    render :index, format: :json
+    respond_to do |format|
+      format.json { render :index }
+    end
   end
 
   def show

--- a/app/controllers/member_authentications_controller.rb
+++ b/app/controllers/member_authentications_controller.rb
@@ -2,6 +2,7 @@
 
 class MemberAuthenticationsController < ApplicationController
   before_action :redirect_signed_up_members
+  skip_before_action :verify_authenticity_token
 
   def new
     session[:follow_up_url] = params[:follow_up_url]


### PR DESCRIPTION
+ respond only to json request on `show#/api/pages`
+ skip `verify_authenticity_token` for new account confirmations. It's not needed here, so ditching as it raising quite a lot