### PR TITLE
404 for certain paths

### DIFF
--- a/app/controllers/uris_controller.rb
+++ b/app/controllers/uris_controller.rb
@@ -2,6 +2,9 @@
 class UrisController < ApplicationController
   before_action :authenticate_user!, except: [:show]
   before_action :find_uri, only: [:edit, :update, :destroy]
+  before_action :filter_requests, only: [:show]
+
+  SKIP_PATTERN = %r{\A/(api|assets)}
 
   def index
     @uris = Uri.all
@@ -63,6 +66,12 @@ class UrisController < ApplicationController
   def localize_from_page(page)
     if page.language.present?
       set_locale(page.language.code)
+    end
+  end
+
+  def filter_requests
+    if request.path =~ SKIP_PATTERN
+      raise ActiveRecord::RecordNotFound
     end
   end
 end

--- a/spec/requests/uris_spec.rb
+++ b/spec/requests/uris_spec.rb
@@ -5,6 +5,14 @@ describe 'URI masking' do
   let(:user) { instance_double('User', id: '1') }
   let(:page) { create :page }
 
+  describe 'when path matches SKIP filter' do
+    it 'raises 404' do
+      %w(/api /assets).each do |path|
+        expect { get(path) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
   describe 'when no record matches' do
     it 'routes to homepage  if requested by an unauthenticated user' do
       expect(get('/random')).to redirect_to(Settings.home_page_url)


### PR DESCRIPTION
Unmatched GET requests are handled by the `Uris` controller which searches the DB for a record with a matching path - this can add a lot of load on our db during busy periods - for example, see https://sumofus.airbrake.io/projects/132582/groups/1829120547621856287?tab=overview
`ActiveRecord::ConnectionTimeoutError` caused by accessing `https://actions.sumofus.org/assets/sumofus/logo-white-08ff551a93422a0b255d2101449ca87b479118b9b6dcffe9ac729aafce7abd5a.png` !

This PR filters out (as a start) any paths starting with `/assets` and `/api`