### PR TITLE
Don't return cancelled payment methods

### DIFF
--- a/app/services/payment_method_fetcher.rb
+++ b/app/services/payment_method_fetcher.rb
@@ -35,7 +35,7 @@ class PaymentMethodFetcher
   def payment_methods
     return @payment_methods if @payment_methods
 
-    query = @member.customer.payment_methods.stored
+    query = @member.customer.payment_methods.stored.active
     query = query.where(token: @filter) unless @filter.nil?
 
     @payment_methods = query

--- a/spec/services/payment_method_fetcher_spec.rb
+++ b/spec/services/payment_method_fetcher_spec.rb
@@ -46,4 +46,18 @@ describe PaymentMethodFetcher do
       expect(subject.fetch).to match_array([])
     end
   end
+
+  context 'with cancelled payment method' do
+    subject { PaymentMethodFetcher.new(member) }
+
+    before do
+      method_a.update(cancelled_at: Time.now)
+    end
+
+    it 'only fetches active methods' do
+      expected = [method_b].map(&formatter)
+
+      expect(subject.fetch).to match_array(expected)
+    end
+  end
 end


### PR DESCRIPTION
Currently members can see cancelled payment methods when making a donation.