### PR TITLE
Translation fixes

### DIFF
--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class Api::ActionsController < ApplicationController
   before_action :localize_from_page_id
-  before_action :store_locale_in_session, only: :create
 
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/api/survey_responses_controller.rb
+++ b/app/controllers/api/survey_responses_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class Api::SurveyResponsesController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :localize_from_page_id, :store_locale_in_session, only: :create
+  before_action :localize_from_page_id, only: :create
 
   def create
     service = ManageSurveyResponse.new(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   private
 
   def set_default_locale
-    set_locale(session[:language] || I18n.default_locale)
+    set_locale(I18n.default_locale)
   end
 
   def set_locale(code)
@@ -33,10 +33,6 @@ class ApplicationController < ActionController::Base
     # by setting the +i18n.enforce_available_locales+ flag to true but
     # catching the resulting error, it allows us to only set the locale
     # if it's one explicitly registered under +i18n.available_locales+
-  end
-
-  def store_locale_in_session
-    session[:language] = I18n.locale
   end
 
   def localize_from_page_id

--- a/app/controllers/member_authentications_controller.rb
+++ b/app/controllers/member_authentications_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class MemberAuthenticationsController < ApplicationController
-  before_action :redirect_signed_up_members
+  before_action :redirect_signed_up_members, :localize_by_recent_action
   skip_before_action :verify_authenticity_token
 
   def new
@@ -16,7 +16,7 @@ class MemberAuthenticationsController < ApplicationController
       email: params[:email],
       password: params[:password],
       password_confirmation: params.fetch(:password_confirmation, ''),
-      language_code: session[:language] || I18n.default_locale
+      language_code: I18n.locale
     )
 
     if auth.valid?
@@ -32,6 +32,11 @@ class MemberAuthenticationsController < ApplicationController
 
   def member
     @member ||= Member.find_by(id: cookies.signed[:member_id], email: params[:email])
+  end
+
+  def localize_by_recent_action
+    code = member&.actions&.sort_by(&:created_at)&.first&.page&.language&.code
+    set_locale(code) if code.present?
   end
 
   def redirect_signed_up_members

--- a/app/controllers/member_authentications_controller.rb
+++ b/app/controllers/member_authentications_controller.rb
@@ -35,7 +35,7 @@ class MemberAuthenticationsController < ApplicationController
   end
 
   def localize_by_recent_action
-    code = member&.actions&.sort_by(&:created_at)&.first&.page&.language&.code
+    code = member&.actions&.last&.page&.language&.code
     set_locale(code) if code.present?
   end
 

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -2,7 +2,7 @@
 
 class PaymentController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :localize_from_page_id, :store_locale_in_session, only: :transaction
+  before_action :localize_from_page_id, only: :transaction
 
   def transaction
     if builder.success?

--- a/app/frontend/components/DonationBands/DonationBands.js
+++ b/app/frontend/components/DonationBands/DonationBands.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { Component } from 'react';
-import { FormattedNumber } from 'react-intl';
+import { FormattedNumber, injectIntl } from 'react-intl';
 import classnames from 'classnames';
 import Button from '../Button/Button';
 import './DonationBands.css';
@@ -17,6 +17,7 @@ type Props = {
   currency: string;
   customAmount?: number;
   proceed: () => void;
+  intl: any,
   selectAmount: (amount: ?number) => void;
   toggleProceedButton?: (visible: boolean) => void;
 };
@@ -114,7 +115,7 @@ export class DonationBands extends Component {
           ref="customAmount"
           id="DonationBands-custom-amount"
           className="DonationBands__input"
-          placeholder="Other"
+          placeholder={this.props.intl.formatMessage({id: 'fundraiser.other_amount'})}
           pattern={/^[0-9]+$/}
           value={this.customFieldDisplay()}
           onFocus={(e) => this.onInputFocused(e.target.value)}
@@ -125,4 +126,4 @@ export class DonationBands extends Component {
   }
 }
 
-export default DonationBands;
+export default injectIntl(DonationBands);

--- a/app/frontend/components/MemberDetailsForm/MemberDetailsForm.js
+++ b/app/frontend/components/MemberDetailsForm/MemberDetailsForm.js
@@ -21,6 +21,7 @@ type OwnProps = {
   fields: Object;
   prefillValues: Object;
   outstandingFields: any[];
+  pageId: number;
   formId: number;
 };
 
@@ -96,7 +97,7 @@ export class MemberDetailsForm extends Component {
   handleFailure(response: any) {
     const errors = mapValues(response.errors, ([message]) => {
       return {
-        id: 'field_error_message',
+        id: 'errors.this_field_with_message',
         defaultMessage: 'This field {message}',
         values: { message }
       };
@@ -118,7 +119,7 @@ export class MemberDetailsForm extends Component {
     // HACKISH
     // Use a proper xhr lib if we want to make our lives easy.
     // Ideally a
-    fetch(`/api/pages/${this.props.formId}/actions/validate`, {
+    fetch(`/api/pages/${this.props.pageId}/actions/validate`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',

--- a/app/frontend/containers/FundraiserView/FundraiserView.js
+++ b/app/frontend/containers/FundraiserView/FundraiserView.js
@@ -109,19 +109,20 @@ export class FundraiserView extends Component {
           </StepContent>
 
           { this.showStepTwo() &&
-            <StepContent title="details">
+            <StepContent title={<FormattedMessage id="fundraiser.details" />}>
               <MemberDetailsForm
                 buttonText={<FormattedMessage id="fundraiser.proceed_to_payment" defaultMessage="Proceed to payment" />}
                 fields={fields}
                 outstandingFields={outstandingFields}
                 prefillValues={formValues}
                 formId={formId}
+                pageId={this.props.fundraiser.pageId}
                 proceed={this.proceed.bind(this)}
               />
             </StepContent>
           }
 
-          <StepContent title="payment">
+          <StepContent title={<FormattedMessage id="fundraiser.payment" />}>
             <Payment disableFormReveal={this.showStepTwo()} setSubmitting={s => this.props.setSubmitting(s)} />
           </StepContent>
         </StepWrapper>

--- a/app/frontend/containers/FundraiserView/FundraiserView.test.js
+++ b/app/frontend/containers/FundraiserView/FundraiserView.test.js
@@ -102,7 +102,7 @@ describe('Initial rendering', function () {
      // 0 index, 1 is third step when seconds step is hidden
     expect(suite.wrapper.find('Stepper').prop('currentStep')).toEqual(1);
     const lastStep = suite.wrapper.find('StepContent').last();
-    expect(lastStep.prop('title')).toEqual('payment');
+    expect(lastStep.prop('title').props['id']).toEqual('fundraiser.payment');
     expect(lastStep.prop('visible')).toEqual(true);
   });
 });

--- a/app/views/layouts/generic.slim
+++ b/app/views/layouts/generic.slim
@@ -10,6 +10,7 @@ html lang= I18n.locale
     = render partial: 'shared/optimizely_snippet'
     = render partial: 'shared/google_analytics_snippet'
     = render partial: 'shared/facebook_pixel' unless Rails.env.test?
+    = render partial: 'shared/js_locale'
 
     = csrf_meta_tags
     = favicon_link_tag 'images/favicon.ico'

--- a/config/locales/member_facing.de.yml
+++ b/config/locales/member_facing.de.yml
@@ -85,6 +85,7 @@ de:
     probably_invalid: sieht nicht richtig aus
     is_invalid: ist ungültig
     this_field: Dieses Feld
+    this_field_with_message: Dieses Feld %{message}
   validation:
     is_required: wird benötigt
     is_invalid_email: ist keine gültige E-Mail-Adresse

--- a/config/locales/member_facing.en.yml
+++ b/config/locales/member_facing.en.yml
@@ -101,6 +101,7 @@ en:
     probably_invalid: doesn't look right
     is_invalid: is invalid
     this_field: This field
+    this_field_with_message: This field %{message}
   validation:
     is_required: is required
     is_invalid_email: is not a valid email address

--- a/config/locales/member_facing.fr.yml
+++ b/config/locales/member_facing.fr.yml
@@ -85,6 +85,7 @@ fr:
     probably_invalid: semble invalide
     is_invalid: est invalide
     this_field: Ce champ
+    this_field_with_message: Ce champ %{message}
   validation:
     is_required: est requis
     is_invalid_email: n’est pas une adresse email valide

--- a/spec/controllers/member_authentications_controller_spec.rb
+++ b/spec/controllers/member_authentications_controller_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe MemberAuthenticationsController do
   describe 'POST create' do
     let(:auth) { double('auth', valid?: true, member_id: 34) }
-    let(:page) { double('page', slug: 'heyo', page_id: '1', language: double('language', code: 'en')) }
+    let(:page) { double('page', slug: 'heyo', page_id: '1', language: double('language', code: :en)) }
 
     before do
       allow(MemberAuthenticationBuilder).to receive(:build) { auth }
@@ -12,17 +12,16 @@ describe MemberAuthenticationsController do
       allow(I18n).to receive(:locale=)
 
       session[:follow_up_url] = '/a/b'
-      session[:language] = 'en'
       post :create, email: 'test@example.com', password: 'p', password_confirmation: 'p'
     end
 
     it 'builds authentication' do
       expect(MemberAuthenticationBuilder).to have_received(:build)
-        .with(password: 'p', password_confirmation: 'p', email: 'test@example.com', language_code: 'en')
+        .with(password: 'p', password_confirmation: 'p', email: 'test@example.com', language_code: :en)
     end
 
     it 'sets locale' do
-      expect(I18n).to have_received(:locale=).with('en')
+      expect(I18n).to have_received(:locale=).with(:en)
     end
 
     context 'successfully creates authentication' do

--- a/spec/requests/localization_spec.rb
+++ b/spec/requests/localization_spec.rb
@@ -2,6 +2,11 @@
 require 'rails_helper'
 
 describe 'Localization for pages' do
+  let(:english_page) { create :page, language: (create :language, code: :en) }
+  let(:german_page) { create :page, language: (create :language, code: :de) }
+  let(:form) { create :form_with_email_and_name }
+  let(:form_params) { { form_id: form.id, email: 'asdf@test.com', name: 'Metiulous Tester' } }
+
   Champaign::Application.config.i18n.available_locales.each do |locale|
     it "sets localization for a page in #{locale}" do
       page = create :page, language: (create :language, code: locale)
@@ -37,5 +42,53 @@ describe 'Localization for pages' do
     get "/pages/#{french_page.id}"
     expect(response).to be_successful
     expect(I18n.locale).to eq :fr
+  end
+
+  it 'resets to default locale viewing a back-end page after taking action on another language page' do
+    expect(I18n.default_locale).not_to eq :de
+    login_as(create(:user), scope: :user)
+
+    get '/pages'
+    expect(response).to be_successful
+    expect(I18n.locale).to eq I18n.default_locale
+
+    get "/a/#{german_page.slug}"
+    post "/api/pages/#{german_page.id}/actions", form_params.merge(page_id: german_page.id)
+    expect(response).to be_successful
+    expect(I18n.locale).to eq :de
+
+    get '/pages'
+    expect(response).to be_successful
+    expect(I18n.locale).to eq I18n.default_locale
+  end
+
+  it "validates in the current page's language" do
+    get "/a/#{german_page.slug}"
+    post "/api/pages/#{german_page.id}/actions/validate", form_params.merge(page_id: german_page.id)
+    expect(response).to be_successful
+    expect(I18n.locale).to eq :de
+    post "/api/pages/#{german_page.id}/actions", form_params.merge(page_id: german_page.id)
+    expect(response).to be_successful
+    expect(I18n.locale).to eq :de
+
+    get "/a/#{english_page.slug}"
+    post "/api/pages/#{english_page.id}/actions/validate", form_params.merge(page_id: english_page.id)
+    expect(response).to be_successful
+    expect(I18n.locale).to eq :en
+    post "/api/pages/#{english_page.id}/actions", form_params.merge(page_id: english_page.id)
+    expect(response).to be_successful
+    expect(I18n.locale).to eq :en
+  end
+
+  it 'mails and shows member auth signup with language of most recent page' do
+    allow(ConfirmationMailer).to receive(:confirmation_email) { double(deliver_now: true) }
+
+    get "/a/#{german_page.slug}"
+    post "/api/pages/#{german_page.id}/actions", form_params.merge(page_id: german_page.id)
+    get '/member_authentication/new', email: form_params[:email]
+    expect(response).to be_successful
+    expect(I18n.locale).to eq :de
+    post '/member_authentication', email: 'asdf@test.com', password: 'asdfasdf', password_confirmation: 'asdfasdf'
+    expect(ConfirmationMailer).to have_received(:confirmation_email).with(a_hash_including(language: :de))
   end
 end


### PR DESCRIPTION
[The bug](https://www.pivotaltracker.com/story/show/137511937) that Paul reported with German translations on an English page was because the form_id was being submitted in place of the page_id. In fixing that though, I uncovered plenty of issues with the localization both with react and without, and fixed everything I found.