### PR TITLE
Only necessary to set og:image for FB

### DIFF
--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -121,6 +121,8 @@ module PagesHelper
   end
 
   def facebook_meta(page, share_card = {})
+    share_card.delete_if { |_, v| v.blank? }
+
     {
       site_name: 'SumOfUs',
       title: page.title,
@@ -128,18 +130,8 @@ module PagesHelper
       url: member_facing_page_url(page),
       type: 'website',
       article: { publisher: Settings.facebook_url },
-      image: {
-        width: '1200',
-        height: '630',
-        url: page.primary_image.try(:content).try(:url)
-      }
-    }.merge(share_card) do |key, v1, v2|
-      if key == :image
-        v2.blank? ? v1 : v1.merge(url: v2)
-      else
-        v2.blank? ? v1 : v2
-      end
-    end
+      image: page.primary_image.try(:content).try(:url)
+    }.merge(share_card)
   end
 
   def share_card(page)

--- a/app/views/pages/_show.slim
+++ b/app/views/pages/_show.slim
@@ -1,6 +1,7 @@
 - share_card = share_card(@page)
 - meta twitter: twitter_meta(@page, share_card)
 - meta og: facebook_meta(@page, share_card)
+
 - meta optimization_tags: @page.meta_tags
 
 = @rendered

--- a/spec/helpers/pages_helper_spec.rb
+++ b/spec/helpers/pages_helper_spec.rb
@@ -197,11 +197,7 @@ describe PagesHelper do
         description: 'scripting',
         image: 'this/is/a/url'
       }
-      expect(facebook_meta(page, share_data)).to include(share_data.merge(image: {
-        width: '1200',
-        height: '630',
-        url: 'this/is/a/url'
-      }))
+      expect(facebook_meta(page, share_data)).to include(share_data.merge(image: 'this/is/a/url'))
     end
 
     it 'ignores share_card if empty' do
@@ -218,11 +214,7 @@ describe PagesHelper do
       expect(facebook_meta(page, share_card)).to include(
         title: page.title,
         description: 'scripting',
-        image: {
-          width: '1200',
-          height: '630',
-          url: 'this/is/a/url'
-        }
+        image: 'this/is/a/url'
       )
     end
   end


### PR DESCRIPTION
We're currently setting a family of `image` related og meta tags, which FB doesn't use. I'm pretty sure (from the [docs](https://developers.facebook.com/docs/sharing/webmasters#markup)) that they only require a single `og:image` meta tag that points to the image's file location. 