### PR TITLE
Populate referrer_email from referring_akid if no referrer_id present

### DIFF
--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -72,10 +72,10 @@ module ActionBuilder
 
   def form_data
     @params.tap do |params|
-      if params[:referrer_id]
-        member = Member.find_by(id: params[:referrer_id])
-        params[:action_referrer_email] = member.email if member.try(:email).present?
-      end
+      member = nil
+      member = Member.find_by_akid(params[:referring_akid]) if params[:referring_akid].present?
+      member = Member.find_by(id: params[:referrer_id]) if params[:referrer_id].present?
+      params[:action_referrer_email] = member.email if member.try(:email).present?
     end
   end
 end

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -220,6 +220,9 @@ describe ActionBuilder do
 
   describe 'action_referrer_email' do
     let(:base_params) { { page_id: page.id, email: member.email } }
+    let(:akid) { '1234.5678.tKK7gX' }
+    let(:ak_user_id) { akid.split('.')[1] }
+
     describe 'is not added if referrer_id' do
       it 'is not included' do
         action = MockActionBuilder.new(base_params).build_action
@@ -243,9 +246,24 @@ describe ActionBuilder do
       end
     end
 
-    it 'is added to form_data if it is the id of a member' do
+    it 'is added to form_data if referrer_id is the id of a member' do
       m2 = create :member, email: 'asdf@hjkl.com'
       action = MockActionBuilder.new(base_params.merge(referrer_id: m2.id)).build_action
+      expect(action.form_data['action_referrer_email']).to eq 'asdf@hjkl.com'
+    end
+
+    it 'is added to form_data if referring_akid has the ak_user_id of a member' do
+      m3 = create :member, email: 'qwer@hjkl.com', actionkit_user_id: ak_user_id
+      action = MockActionBuilder.new(base_params.merge(referring_akid: akid)).build_action
+      expect(action.form_data['action_referrer_email']).to eq 'qwer@hjkl.com'
+    end
+
+    it 'adds the email of a matching referrer_id if both referrer_id and referring_akid are present' do
+      m2 = create :member, email: 'asdf@hjkl.com'
+      m3 = create :member, email: 'qwer@hjkl.com', actionkit_user_id: ak_user_id
+      action = MockActionBuilder.new(base_params.merge(
+        referrer_id: m2.id, referring_akid: akid
+      )).build_action
       expect(action.form_data['action_referrer_email']).to eq 'asdf@hjkl.com'
     end
   end


### PR DESCRIPTION
This will help us track sharing credit from forwarded emails too, and enable the share-success notification emails.