### PR TITLE
Pass amount in the event pushed to the queue on braintree subscription payments

### DIFF
--- a/app/models/payment/braintree/transaction.rb
+++ b/app/models/payment/braintree/transaction.rb
@@ -38,7 +38,8 @@ class Payment::Braintree::Transaction < ActiveRecord::Base
         created_at: created_at.strftime('%Y-%m-%d %H:%M:%S'),
         recurring_id: subscription.try(:action).form_data['subscription_id'],
         success: status == 'success' ? 1 : 0,
-        status: status == 'success' ? 'completed' : 'failed'
+        status: status == 'success' ? 'completed' : 'failed',
+        amount: amount.to_s
       }
     }, { delay: 120 })
   end

--- a/lib/payment_processor/braintree/webhook_handler.rb
+++ b/lib/payment_processor/braintree/webhook_handler.rb
@@ -78,13 +78,21 @@ module PaymentProcessor
       def handle_subscription_charge(status)
         return unless subscription
         record = Payment::Braintree::Transaction.create!(
+          transaction_id: '',
           subscription: subscription,
           page: subscription.action.page,
           customer: customer,
-          status: status
+          status: status,
+          amount: subscription_amount
         )
         record.publish_subscription_charge
         true
+      end
+
+      def subscription_amount
+        # The subscription hook contains an array of transactions with the latest one first. We need to pass the
+        # amount to ActionKit to be able to override subscription prices when we've updated a subscription on BT.
+        notification.subscription.transactions.first&.amount || 0
       end
 
       # This method should only be called if @notification.subscription is a subscription object

--- a/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/braintree/webhook_handler_spec.rb
@@ -58,7 +58,8 @@ describe PaymentProcessor::Braintree::WebhookHandler do
               created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
               recurring_id: 'foo',
               success: 1,
-              status: 'completed'
+              status: 'completed',
+              amount: /\A\d+[.]\d+\z/
             }
           }
 
@@ -163,7 +164,8 @@ describe PaymentProcessor::Braintree::WebhookHandler do
             created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
             recurring_id: 'foo',
             success: 0,
-            status: 'failed'
+            status: 'failed',
+            amount: '0.0'
           }
         }
         expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)

--- a/spec/models/payment/braintree/transaction_spec.rb
+++ b/spec/models/payment/braintree/transaction_spec.rb
@@ -100,7 +100,12 @@ describe Payment::Braintree::Transaction do
   describe 'publish subscription payment' do
     let(:action) { create(:action, form_data: { 'subscription_id' => 'subscription_id' }) }
     let(:subscription) { create(:payment_braintree_subscription, subscription_id: 'subscription_id', action: action) }
-    let!(:transaction) { create(:payment_braintree_transaction, subscription: subscription, status: 'success') }
+    let!(:transaction) do
+      create(:payment_braintree_transaction,
+             subscription: subscription,
+             status: 'success',
+             amount: 123)
+    end
     it 'pushes a subscription payment event with a status to the queue' do
       expected_payload = {
         type: 'subscription-payment',
@@ -109,7 +114,8 @@ describe Payment::Braintree::Transaction do
           created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
           recurring_id: 'subscription_id',
           success: 1,
-          status: 'completed'
+          status: 'completed',
+          amount: '123.0'
         }
       }
       expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -103,7 +103,8 @@ describe 'Braintree API' do
                 created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
                 recurring_id: /[a-z0-9]{6}/,
                 success: 1,
-                status: 'completed'
+                status: 'completed',
+                amount: /\A\d+[.]\d+\z/
               }
             }
 
@@ -167,7 +168,8 @@ describe 'Braintree API' do
                 created_at: /\A\d{4}(-\d{2}){2} (\d{2}:){2}\d{2}\z/,
                 recurring_id: /[a-z0-9]{6}/,
                 success: 1,
-                status: 'completed'
+                status: 'completed',
+                amount: /\A\d+[.]\d+\z/
               }
             }
 


### PR DESCRIPTION
Right now we're updating some subscriptions manually through the Braintree console. This means that the payments coming through to those subscriptions come in with a different amount than what the subscription is associated with, and this isn't reflected on the data in AK in that if you don't override the amount parameter, it just fetches the amount from the price of the subscription.