### PR TITLE
Clone form

### DIFF
--- a/app/controllers/clone_pages_controller.rb
+++ b/app/controllers/clone_pages_controller.rb
@@ -7,7 +7,8 @@ class ClonePagesController < ApplicationController
   end
 
   def create
-    new_page = PageCloner.clone(@page, params[:page][:title])
+    override_forms = (params[:override_forms].to_i == 1)
+    new_page = PageCloner.clone(@page, params[:page][:title], params[:page][:language_id], override_forms)
     QueueManager.push(new_page, job_type: :create)
     redirect_to edit_page_path(new_page)
   end

--- a/app/models/plugins/has_form.rb
+++ b/app/models/plugins/has_form.rb
@@ -44,7 +44,7 @@ module Plugins::HasForm
     return if form.present? && !form.form_elements.empty?
     locale = try(:page).try(:language).try(:code) || I18n.default_locale
     self.form = FormDuplicator.duplicate(
-      DefaultFormBuilder.create(locale: locale)
+      DefaultFormBuilder.find_or_create(locale: locale)
     )
   end
 

--- a/app/services/default_form_builder.rb
+++ b/app/services/default_form_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class DefaultFormBuilder
   class << self
-    def create(locale: 'en')
+    def find_or_create(locale: 'en')
       @locale = locale
       form = Form.masters.find_or_initialize_by(name: default_name)
 

--- a/app/views/clone_pages/new.html.slim
+++ b/app/views/clone_pages/new.html.slim
@@ -3,14 +3,25 @@
 .edit-block
   h1.page-edit-step__title
     = t('.title')
-  = form_for Page.new, url: clone_pages_path, class: '' do |f|
 
-    .form-group
-      = f.label :title, t('.labels.title')
-      = f.text_field :title, class: 'form-control', value: @page.title
-    .form-group
-      p
-        = f.submit t('.labels.submit'), class: 'btn btn-sm btn-primary submit-new-page'
-        = link_to t('common.cancel'), :back, class: 'btn btn-sm'
-      = hidden_field_tag :id, @page.id
+  .col-md-6
+    = form_for Page.new, url: clone_pages_path, class: '' do |f|
+      .form-group
+        = f.label :title, t('.labels.title')
+        = f.text_field :title, class: 'form-control', value: @page.title
+
+      .form-group
+        = f.label :language_id, t('pages.edit.language_label')
+        = f.select :language_id, Language.all.map { |lang| [lang.name, lang.id] }, { selected: @page.language_id}, class: "form-control"
+
+      .form-group
+        label.edit-page-checkbox
+          = check_box_tag :override_forms
+          = t('.labels.override_forms')
+
+      .form-group
+        p
+          = f.submit t('.labels.submit'), class: 'btn btn-sm btn-primary submit-new-page'
+          = link_to t('common.cancel'), :back, class: 'btn btn-sm'
+        = hidden_field_tag :id, @page.id
 

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -111,6 +111,7 @@ en:
       title: "Clone Page"
       labels:
         title: "Edit Page Title"
+        override_forms: Replace page's forms with the default in the selected language
         submit: "Clone!"
   pages:
     index:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ puts 'Seeding...'
 
 # Forms
 %w(en fr de).each do |locale|
-  DefaultFormBuilder.create(locale: locale)
+  DefaultFormBuilder.find_or_create(locale: locale)
 end
 
 # Liquid Markup

--- a/spec/controllers/clone_pages_controller_spec.rb
+++ b/spec/controllers/clone_pages_controller_spec.rb
@@ -39,7 +39,7 @@ describe ClonePagesController do
       allow(PageCloner).to receive(:clone) { cloned_page }
       allow(QueueManager).to receive(:push)
 
-      post :create, id: '1', page: { title: 'foo' }
+      post :create, id: '1', page: { title: 'foo', language_id: 3 }, override_forms: '1'
     end
 
     it 'authenticates session' do
@@ -51,7 +51,7 @@ describe ClonePagesController do
     end
 
     it 'clones page' do
-      expect(PageCloner).to have_received(:clone).with(page, 'foo')
+      expect(PageCloner).to have_received(:clone).with(page, 'foo', '3', true)
     end
 
     it 'posts page to queue' do

--- a/spec/services/default_form_builder_spec.rb
+++ b/spec/services/default_form_builder_spec.rb
@@ -4,51 +4,51 @@ require 'rails_helper'
 describe DefaultFormBuilder do
   it 'creates a default master form' do
     expect do
-      DefaultFormBuilder.create
+      DefaultFormBuilder.find_or_create
     end.to change { Form.count }.from(0).to(1)
   end
 
   it 'creates fields' do
-    expect(DefaultFormBuilder.create.form_elements.size).to eq(4)
+    expect(DefaultFormBuilder.find_or_create.form_elements.size).to eq(4)
   end
 
   describe 'i18n' do
     it 'translates the fields to German' do
-      expect(DefaultFormBuilder.create(locale: 'de').form_elements.first.label).to eq 'E-MAIL'
+      expect(DefaultFormBuilder.find_or_create(locale: 'de').form_elements.first.label).to eq 'E-MAIL'
     end
 
     it 'translates the fields to French' do
-      expect(DefaultFormBuilder.create(locale: :fr).form_elements.first.label).to eq 'ADRESSE EMAIL'
+      expect(DefaultFormBuilder.find_or_create(locale: :fr).form_elements.first.label).to eq 'ADRESSE EMAIL'
     end
 
     it 'translates the fields to English' do
-      expect(DefaultFormBuilder.create.form_elements.first.label).to eq 'Email Address'
+      expect(DefaultFormBuilder.find_or_create.form_elements.first.label).to eq 'Email Address'
     end
 
     it 'marks the German form as DE' do
-      expect(DefaultFormBuilder.create(locale: 'de').name).to eq 'Basic (DE)'
+      expect(DefaultFormBuilder.find_or_create(locale: 'de').name).to eq 'Basic (DE)'
     end
 
     it 'marks the French form as FR' do
-      expect(DefaultFormBuilder.create(locale: 'fr').name).to eq 'Basic (FR)'
+      expect(DefaultFormBuilder.find_or_create(locale: 'fr').name).to eq 'Basic (FR)'
     end
 
     it 'marks the English form as EN' do
-      expect(DefaultFormBuilder.create(locale: :en).name).to eq 'Basic (EN)'
+      expect(DefaultFormBuilder.find_or_create(locale: :en).name).to eq 'Basic (EN)'
     end
   end
 
   context 'when form already exists' do
-    before { DefaultFormBuilder.create }
+    before { DefaultFormBuilder.find_or_create }
 
     it "doesn't create a new form" do
       expect do
-        DefaultFormBuilder.create
+        DefaultFormBuilder.find_or_create
       end.to_not change { Form.count }.from(1)
     end
 
     it 'returns existing form' do
-      expect(DefaultFormBuilder.create.name).to eq('Basic (EN)')
+      expect(DefaultFormBuilder.find_or_create.name).to eq('Basic (EN)')
     end
   end
 end


### PR DESCRIPTION
This gives an option in the cloning interface to allow people to change the language, and convert the language of the accompanying forms.

<img width="694" alt="screenshot 2017-02-14 17 13 33" src="https://cloud.githubusercontent.com/assets/102218/22956866/70290ea8-f2d9-11e6-8dff-a8285cde4706.png">
