### PR TITLE
Clean up page searcher and add limit to page search params

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -58,6 +58,9 @@ Metrics/ClassLength:
 # Offense count: 3
 Metrics/CyclomaticComplexity:
   Max: 10
+  Exclude:
+    - 'app/services/search/page_searcher.rb'
+
 
 # Offense count: 51
 # Configuration parameters: CountComments.
@@ -127,7 +130,6 @@ Style/GuardClause:
     - 'app/models/form.rb'
     - 'app/models/link.rb'
     - 'app/services/page_builder.rb'
-    - 'app/services/search/page_searcher.rb'
     - 'lib/payment_processor/braintree/subscription.rb'
 
 # Offense count: 7

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,8 +10,7 @@ class PagesController < ApplicationController
   before_action :localize, only: [:show, :follow_up]
 
   def index
-    @search_params = search_params
-    @pages = Search::PageSearcher.new(@search_params).search.sort_by(&:updated_at).reverse!
+    @pages = Search::PageSearcher.search(search_params)
   end
 
   def analytics
@@ -127,9 +126,12 @@ class PagesController < ApplicationController
   end
 
   def search_params
-    default_params = { publish_status: Page.publish_statuses.values_at(:published, :unpublished) }
-    params[:search] ||= {}
-    params[:search].reverse_merge default_params
+    default_params = {
+      publish_status: Page.publish_statuses.values_at(:published, :unpublished),
+      limit: 500,
+      order_by: [:updated_at, :desc]
+    }
+    @search_params = default_params.merge(params.to_unsafe_hash.symbolize_keys)
   end
 
   def process_one_click

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -83,35 +83,6 @@ module PagesHelper
     registered.fetch(name, 'cubes')
   end
 
-  def determine_ascending
-    if params[:search].nil?
-      'asc'
-    elsif params[:search][:order_by].nil?
-      'asc'
-    elsif params[:search][:order_by][1] == 'desc'
-      'asc'
-    else
-      'desc'
-    end
-  end
-
-  def determine_icon_location
-    return '' if params[:search].nil? || params[:search][:order_by].nil?
-    if params[:search][:order_by].is_a? Array
-      params[:search][:order_by][0]
-    else
-      params[:search][:order_by]
-    end
-  end
-
-  def determine_icon_header
-    if determine_ascending == 'asc'
-      'glyphicon-menu-up'
-    else
-      'glyphicon-menu-down'
-    end
-  end
-
   def twitter_meta(page, share_card = {})
     {
       card: 'summary_large_image',

--- a/app/views/pages/_search.slim
+++ b/app/views/pages/_search.slim
@@ -1,47 +1,44 @@
 .col-md-12.page-filter-form
   form action='/pages' method='get'
+    - multi_select_options = { class: 'selectize-container', multiple: true }
+    - label_class = 'control-label col-lg-3'
     legend Only show pages that...
     .page-filter__row
-      / pass params[:search] that contains all search options for filtering.
-      = label_tag 'search[content_search]', 'Contain the following text: ', class: 'control-label col-lg-3'
+      = label_tag :content_search, 'Contain the following text: ', class: label_class
       .col-lg-3
-        input type='text' class='form-control' placeholder='A long time ago in a galaxy far far away...' id='search[content_search]' name='search[content_search]' value=@search_params[:content_search]
+        = text_field_tag :content_search, @search_params[:content_search], { class: 'form-control' }
 
-      = label_tag 'search[campaign]', 'Belong to one of these campaigns:', class: 'control-label col-lg-3'
+      = label_tag :campaign, 'Belong to one of these campaigns:', class: label_class
       .col-lg-3
-        = select_tag 'search[campaign]', options_from_collection_for_select(Campaign.all, 'id', 'name', @search_params[:campaign]),
-                     html_options= {class: 'selectize-container selectize-tag', multiple: true}
+        = select_tag :campaign, options_from_collection_for_select(Campaign.all, 'id', 'name', @search_params[:campaign]), { class: 'selectize-container selectize-tag', multiple: true }
     .page-filter__row
-      = label_tag 'search[layout]', 'Use one of these layouts:', class: 'control-label col-lg-3'
+      = label_tag :layout, 'Use one of these layouts:', class: label_class
       .col-lg-3
-        = select_tag 'search[layout]', options_from_collection_for_select(LiquidLayout.all, 'id', 'title', @search_params[:layout]),
-                     html_options= {class: 'selectize-container', multiple: true}
+        = select_tag :layout, options_from_collection_for_select(LiquidLayout.all, 'id', 'title', @search_params[:layout]), multi_select_options
 
-      = label_tag 'search[language]', 'Belong to one of these languages: ', class: 'control-label col-lg-3'
+      = label_tag :language, 'Belong to one of these languages: ', class: label_class
       .col-lg-3
-        = select_tag 'search[language]', options_from_collection_for_select(Language.all, 'id', 'name', @search_params[:language]),
-                     html_options= {:class => 'selectize-container', multiple: true}
+        = select_tag :language, options_from_collection_for_select(Language.all, 'id', 'name', @search_params[:language]), multi_select_options
     .page-filter__row
-      = label_tag 'search[tags]', 'Contain all of these tags:', class: 'control-label col-lg-3'
+      = label_tag :tags, 'Contain all of these tags:', class: label_class
       .col-lg-3
-        = select_tag 'search[tags]', options_from_collection_for_select(Tag.all, 'id', 'name', @search_params[:tags]),
-                     html_options= {class: 'selectize-container', multiple: true}
+        = select_tag :tags, options_from_collection_for_select(Tag.all, 'id', 'name', @search_params[:tags]), multi_select_options
 
-      = label_tag 'search[plugin_type]', 'Contain all of these plugins:', class: 'control-label col-lg-3'
+      = label_tag :plugin_type, 'Contain all of these plugins:', class: label_class
       .col-lg-3
-        = select_tag 'search[plugin_type]', options_from_collection_for_select(Plugins.registered, 'to_s',
-                                                                               lambda { |plugin| plugin.name.demodulize },
-                                                                               @search_params[:plugin_type]),
-                     html_options= {class: 'selectize-container', multiple: true}
+        - collection = [Plugins.registered, 'to_s', lambda { |plugin| plugin.name.demodulize }, @search_params[:plugin_type]]
+        = select_tag :plugin_type, options_from_collection_for_select(*collection), multi_select_options
 
     .page-filter__row
-      = label_tag 'search[publish_status]', 'Publish status:', class: 'control-label col-lg-3'
+      = label_tag :publish_status, 'Publish status:', class: label_class
       .col-lg-3
-        = select_tag 'search[publish_status]', options_for_select(Page.publish_statuses.to_a, @search_params[:publish_status]),
-                     html_options= {class: 'selectize-container', multiple: true}
+        = select_tag :publish_status, options_for_select(Page.publish_statuses.to_a, @search_params[:publish_status]), multi_select_options
+      = label_tag :limit, 'Limit number of pages loaded:', class: label_class
+      .col-lg-3
+        = select_tag :limit, options_for_select([500, 1000], @search_params[:limit]), { class: 'form-control', include_blank: 'No limit' }
 
       .col-md-12
-        = submit_tag 'Filter by these criteria', class: 'btn btn-primary page-filter__submit', id: 'search_button'
+        = submit_tag 'Filter by these criteria', class: 'btn btn-primary page-filter__submit', id: 'search_button', name: nil
         = button_tag 'Reset filters', type: 'button',  class: 'btn btn-danger page-filter__reset', id: 'filter_reset_button'
 
   javascript:


### PR DESCRIPTION
Loading all the pages is starting to drag quite a bit on production, so this change loads the last 500 pages by default, and lets campaigners set whether they wish to load 500, 1000, or unlimited. It also cleans up some of the search code, which was written quite early, and it cleans up the appearance of the URL params for searching.

<img width="915" alt="screenshot 2017-02-20 13 56 36" src="https://cloud.githubusercontent.com/assets/102218/23143139/a7d4002a-f774-11e6-89ec-eb606981e8c2.png">
