### PR TITLE
Extend formtastic with missing field type

### DIFF
--- a/config/initializers/formtastic_ext.rb
+++ b/config/initializers/formtastic_ext.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class JsonbInput < Formtastic::Inputs::StringInput
+end


### PR DESCRIPTION
Member services are currently unable to edit member details because active admin crashes when trying to render the edit form. We recently added a new attribute of type JSONB which formtastic has no matching class definition.  This PR defines that missing type.