### PR TITLE
Call tool.target by country

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Style/BracesAroundHashParameters:
 Lint/BlockAlignment:
   AlignWith: start_of_block
 
+Lint/EndAlignment:
+  AlignWith: keyword
+
 Lint/InheritException:
   Enabled: false
 
@@ -42,4 +45,3 @@ Style/IfUnlessModifier:
 
 Lint/HandleExceptions:
   Enabled: false
-

--- a/app/frontend/components.js
+++ b/app/frontend/components.js
@@ -51,16 +51,17 @@ window.mountFundraiser = (root: string, initialState?: any = {})  => {
   }
 };
 
-type callToolInitialState = {
+type callToolProps = {
   locale: string;
   title?: string;
   targets: any[];
   targetCountries: any[];
   countriesPhoneCodes: any[];
   pageId: string | number;
+  targetByCountryEnabled: boolean;
 };
 
-window.mountCallTool = (root: string, props: callToolInitialState) => {
+window.mountCallTool = (root: string, props: callToolProps) => {
   props = camelizeKeys(props);
 
   render(
@@ -68,11 +69,12 @@ window.mountCallTool = (root: string, props: callToolInitialState) => {
       <CallToolView
         title={props.title}
         targets={props.targets}
-        targetCountries={props.targetCountries}
+        countries={props.countries}
         pageId={props.pageId}
         onSuccess={props.onSuccess}
         countriesPhoneCodes={props.countriesPhoneCodes}
-        targetCountryCode={props.targetCountryCode} />
+        countryCode={props.countryCode} />
+        targetByCountryEnabled={props.targetByCountryEnabled}
     </ComponentWrapper>,
     document.getElementById(root)
   );

--- a/app/frontend/components.js
+++ b/app/frontend/components.js
@@ -66,15 +66,7 @@ window.mountCallTool = (root: string, props: callToolProps) => {
 
   render(
     <ComponentWrapper locale={props.locale}>
-      <CallToolView
-        title={props.title}
-        targets={props.targets}
-        countries={props.countries}
-        pageId={props.pageId}
-        onSuccess={props.onSuccess}
-        countriesPhoneCodes={props.countriesPhoneCodes}
-        countryCode={props.countryCode} />
-        targetByCountryEnabled={props.targetByCountryEnabled}
+      <CallToolView {...props} />
     </ComponentWrapper>,
     document.getElementById(root)
   );

--- a/app/frontend/components/CallTool/Form.js
+++ b/app/frontend/components/CallTool/Form.js
@@ -9,13 +9,13 @@ import type { Field } from '../../components/FieldShape/FieldShape';
 
 type OwnProps = {
   targetByCountryEnabled: boolean;
-  targetCountries: Country[];
+  countries: Country[];
   targets: Target[];
   countriesPhoneCodes: CountryPhoneCode[];
   selectedTarget: Target;
   form: FormType;
   errors: Errors;
-  onTargetCountryCodeChange: (string) => void;
+  onCountryCodeChange: (string) => void;
   onMemberPhoneNumberChange: (string) => void;
   onMemberPhoneCountryCodeChange: (string) => void;
   onSubmit: (any) => void;
@@ -40,7 +40,7 @@ const memberPhoneCountryCodeField:Field = {
   disabled: false
 };
 
-const targetCountryCodeField:Field = {
+const countryCodeField:Field = {
   data_type: 'select',
   name: 'call_tool[country_code]',
   label: <FormattedMessage id='call_tool.form.country' />,
@@ -60,12 +60,12 @@ class Form extends Component {
     this.fields = {
       memberPhoneNumberField: memberPhoneNumberField,
       memberPhoneCountryCodeField: memberPhoneCountryCodeField,
-      targetCountryCodeField: { ...targetCountryCodeField, choices: this.targetCountryCodeOptions() }
+      countryCodeField: { ...countryCodeField, choices: this.countryCodeOptions() }
     };
   }
 
-  targetCountryCodeOptions() {
-    return this.props.targetCountries.map((country) => {
+  countryCodeOptions() {
+    return this.props.countries.map((country) => {
       return { value: country.code, label: country.name };
     });
   }
@@ -82,16 +82,14 @@ class Form extends Component {
   render() {
     return(
       <form className='action-form form--big' data-remote="true" >
-        { this.props.targetByCountryEnabled &&
-          <FieldShape
-          key="targetCountryCode"
-          errorMessage={this.props.errors.targetCountryCode}
-          onChange={this.props.onTargetCountryCodeChange}
-          value={this.props.form.targetCountryCode}
-          field={this.fields.targetCountryCodeField}
-          className="targetCountryCodeField"
-          />
-        }
+        <FieldShape
+        key="countryCode"
+        errorMessage={this.props.errors.countryCode}
+        onChange={this.props.onCountryCodeChange}
+        value={this.props.form.countryCode}
+        field={this.fields.countryCodeField}
+        className="countryCodeField"
+        />
 
         <FieldShape
         key="memberPhoneCountryCode"

--- a/app/frontend/containers/CallToolView/CallToolView.js
+++ b/app/frontend/containers/CallToolView/CallToolView.js
@@ -28,13 +28,13 @@ export type CountryPhoneCode = {
 export type FormType = {
   memberPhoneNumber: string;
   memberPhoneCountryCode: string;
-  targetCountryCode: string;
+  countryCode: string;
 }
 
 export type Errors = {
   memberPhoneNumber?: any;
   memberPhoneCountryCode?: any;
-  targetCountryCode?: any;
+  countryCode?: any;
   base?: any[];
 }
 
@@ -48,11 +48,11 @@ type OwnState = {
 type OwnProps = {
   targetByCountryEnabled: boolean;
   memberPhoneNumber?: string;
-  targetCountryCode?: string;
+  countryCode?: string;
   title?: string;
   pageId: string | number;
   targets: Target[];
-  targetCountries: Country[];
+  countries: Country[];
   countriesPhoneCodes: CountryPhoneCode[];
   onSuccess?: () => void;
   intl: IntlShape;
@@ -64,16 +64,16 @@ class CallToolView extends Component {
 
   constructor(props: OwnProps) {
     super(props);
-    // Assign targetCountryCode only if it's a valid one
+    // Assign countryCode only if it's a valid one
     const preselectedTarget = _.find(this.props.targets, target => {
-      return target.countryCode === this.props.targetCountryCode;
+      return target.countryCode === this.props.countryCode;
     });
 
     this.state = {
       form: {
         memberPhoneNumber: '',
         memberPhoneCountryCode: '',
-        targetCountryCode: preselectedTarget ? preselectedTarget.countryCode : '',
+        countryCode: preselectedTarget ? preselectedTarget.countryCode : '',
       },
       errors: {},
       loading: false
@@ -82,25 +82,31 @@ class CallToolView extends Component {
 
   componentDidMount() {
     if(this.props.targetByCountryEnabled) {
-      this.targetCountryCodeChanged(this.state.form.targetCountryCode);
+      this.countryCodeChanged(this.state.form.countryCode);
     } else {
       this.setState({selectedTarget: this.selectNewTarget() });
     }
   }
 
-  targetCountryCodeChanged(targetCountryCode: string) {
-    this.setState((prevState, props) => {
-      return {
-        form: { ...prevState.form, memberPhoneCountryCode: this.guessMemberPhoneCountryCode(targetCountryCode), targetCountryCode },
-        selectedTarget: this.selectNewTarget(targetCountryCode),
-        errors: {...prevState.errors, targetCountryCode: null }
-      };
-    });
+  countryCodeChanged(countryCode: string) {
+    if(this.props.targetByCountryEnabled) {
+      this.setState((prevState, props) => {
+        return {
+          form: { ...prevState.form, memberPhoneCountryCode: this.guessMemberPhoneCountryCode(countryCode), countryCode },
+          selectedTarget: this.selectNewTarget(countryCode),
+          errors: {...prevState.errors, countryCode: null }
+        };
+      });
+    } else {
+      this.setState((prevState, props) => {
+        return { form: { ...prevState.form, memberPhoneCountryCode: this.guessMemberPhoneCountryCode(countryCode), countryCode }};
+      });
+    }
   }
 
   guessMemberPhoneCountryCode(countryCode: string) {
-    const target = _.find(this.props.targetCountries, t => { return t.code === countryCode; });
-    return target ? `+${target.phoneCode}` : '';
+    const country = _.find(this.props.countries, t => { return t.code === countryCode; });
+    return country ? `+${country.phoneCode}` : '';
   }
 
   memberPhoneNumberChanged(memberPhoneNumber: string) {
@@ -121,10 +127,10 @@ class CallToolView extends Component {
     });
   }
 
-  selectNewTarget(targetCountryCode: ?string = null) {
+  selectNewTarget(countryCode: ?string = null) {
     let candidates;
-    if(targetCountryCode) {
-      candidates = _.filter(this.props.targets, t => { return t.countryCode === targetCountryCode; });
+    if(countryCode) {
+      candidates = _.filter(this.props.targets, t => { return t.countryCode === countryCode; });
     } else {
       candidates = this.props.targets;
     }
@@ -155,8 +161,8 @@ class CallToolView extends Component {
         newErrors.memberPhoneCountryCode = <FormattedMessage id="validation.is_required" />;
       }
 
-      if(_.isEmpty(this.state.form.targetCountryCode)) {
-        newErrors.targetCountryCode = <FormattedMessage id="validation.is_required" />;
+      if(_.isEmpty(this.state.form.countryCode)) {
+        newErrors.countryCode = <FormattedMessage id="validation.is_required" />;
       }
     }
 
@@ -221,13 +227,13 @@ class CallToolView extends Component {
 
         <Form
           targetByCountryEnabled={this.props.targetByCountryEnabled}
-          targetCountries={this.props.targetCountries}
+          countries={this.props.countries}
           countriesPhoneCodes={this.props.countriesPhoneCodes}
           targets={this.props.targets}
           selectedTarget={this.state.selectedTarget}
           form={this.state.form}
           errors={this.state.errors}
-          onTargetCountryCodeChange={this.targetCountryCodeChanged.bind(this)}
+          onCountryCodeChange={this.countryCodeChanged.bind(this)}
           onMemberPhoneNumberChange={this.memberPhoneNumberChanged.bind(this)}
           onMemberPhoneCountryCodeChange={this.memberPhoneCountryCodeChanged.bind(this)}
           onSubmit={this.submit.bind(this)}

--- a/app/models/plugins/call_tool.rb
+++ b/app/models/plugins/call_tool.rb
@@ -42,7 +42,7 @@ class Plugins::CallTool < ActiveRecord::Base
       active: active,
       targets: json_targets,
       target_by_country_enabled: target_by_country,
-      target_countries: target_countries,
+      countries: countries,
       countries_phone_codes: countries_phone_codes,
       title: title,
       description: description
@@ -64,12 +64,19 @@ class Plugins::CallTool < ActiveRecord::Base
   end
 
   # Returns [{ code: <country-code>, name: <country-name>}, {..} ...]
-  def target_countries
-    targets.map(&:country_code).uniq.compact.map do |country_code|
-      country = ISO3166::Country[country_code]
+  def countries
+    list = if target_by_country
+      targets.map(&:country_code).uniq.compact.map do |country_code|
+        ISO3166::Country[country_code]
+      end
+    else
+      ISO3166::Country.all
+    end
+
+    list.map do |country|
       {
         name: country.translation(page.language_code),
-        code: country_code,
+        code: country.alpha2,
         phoneCode: country.country_code.to_s
       }
     end

--- a/app/models/plugins/call_tool.rb
+++ b/app/models/plugins/call_tool.rb
@@ -65,13 +65,14 @@ class Plugins::CallTool < ActiveRecord::Base
 
   # Returns [{ code: <country-code>, name: <country-name>}, {..} ...]
   def countries
-    list = if target_by_country
-      targets.map(&:country_code).uniq.compact.map do |country_code|
-        ISO3166::Country[country_code]
+    list =
+      if target_by_country
+        targets.map(&:country_code).uniq.compact.map do |country_code|
+          ISO3166::Country[country_code]
+        end
+      else
+        ISO3166::Country.all
       end
-    else
-      ISO3166::Country.all
-    end
 
     list.map do |country|
       {

--- a/app/services/page_cloner.rb
+++ b/app/services/page_cloner.rb
@@ -53,7 +53,7 @@ class PageCloner
   end
 
   def plugins
-    cloned_page.plugins.each(&:destroy)
+    cloned_page.plugins.each(&:destroy!)
 
     page.plugins.each do |plugin|
       plugin.dup.tap do |clone|

--- a/app/views/plugins/call_tools/_call_tool.liquid
+++ b/app/views/plugins/call_tools/_call_tool.liquid
@@ -4,7 +4,7 @@
   <script>
     $(document).ready(function() {
       var data = _.clone(window.champaign.personalization.callTool['{{ref}}']);
-      data.targetCountryCode = window.champaign.personalization.member.country;
+      data.countryCode = window.champaign.personalization.member.country;
       data.onSuccess = function(selectedTarget) {
         var followUpUrl = window.URI("{{ follow_up_url }}");
         followUpUrl.addQuery({


### PR DESCRIPTION
Updated Call Tool plugin and component to handle different flows. I added a `target_by_country` which changes the way the call tool works

* If `target_by_country` is enabled, then the call tool works as it previously did. When a country is selected from the dropdown, a target belonging to that target is randomly selected.
* If `target_by_country` is disabled, when a country is selected a target is randomly selected. Target countries are not considered here. The dropdown is there to prefill the country code in the phone number field.

