### PR TITLE
Accept only HTML requests to pages#show

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -46,33 +46,37 @@ class PagesController < ApplicationController
   end
 
   def show
-    one_click_processor = process_one_click
+    respond_to do |format|
+      format.html do
+        one_click_processor = process_one_click
 
-    if one_click_processor
-      i18n_options = {
-        amount: view_context.number_to_currency(
-          params[:amount],
-          unit: PaymentProcessor.currency_to_symbol(params[:currency]).html_safe
-        )
-      }
+        if one_click_processor
+          i18n_options = {
+            amount: view_context.number_to_currency(
+              params[:amount],
+              unit: PaymentProcessor.currency_to_symbol(params[:currency]).html_safe
+            )
+          }
 
-      i18n_key = if one_click_processor.recurring?
-                   'fundraiser.recurring_thank_you_with_amount'
-                 else
-                   'fundraiser.thank_you_with_amount'
-                 end
+          i18n_key = if one_click_processor.recurring?
+                       'fundraiser.recurring_thank_you_with_amount'
+                     else
+                       'fundraiser.thank_you_with_amount'
+                     end
 
-      flash[:notice] =
-        t(i18n_key, i18n_options).html_safe
+          flash[:notice] =
+            t(i18n_key, i18n_options).html_safe
 
-      redirect_to new_member_authentication_path(
-        email: recognized_member.email,
-        follow_up_url: PageFollower.new_from_page(@page, member_id: recognized_member.id).follow_up_path
-      )
-    else
-      @rendered = renderer.render
-      @data = renderer.personalization_data
-      render :show, layout: 'member_facing'
+          redirect_to new_member_authentication_path(
+            email: recognized_member.email,
+            follow_up_url: PageFollower.new_from_page(@page, member_id: recognized_member.id).follow_up_path
+          )
+        else
+          @rendered = renderer.render
+          @data = renderer.personalization_data
+          render :show, layout: 'member_facing'
+        end
+      end
     end
   end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -170,6 +170,13 @@ describe PagesController do
 
     include_examples 'show and follow-up'
 
+    context 'unsupported mimetype' do
+      it 'raises 415' do
+        expect do
+          get :show, id: 'foo-BaR', format: :json
+        end.to raise_error(ActionController::UnknownFormat)
+      end
+    end
     it 'finds page by un-altered slug' do
       expect(Page).to receive(:find).with('foo-BaR')
       get :show, id: 'foo-BaR'


### PR DESCRIPTION
Put an end to the 500s being raised whenever a JSON request is made to `pages#show` (mainly by scraping bots). See https://sumofus.airbrake.io/projects/132582/groups/1809838475682145060

#894

