### PR TITLE
Publish actions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,6 +1,6 @@
 Style/BlockDelimiters:
   Exclude:
-    - 'spec/controllers/api/actions_controller_spec.rb'
+    - 'spec/'
 
 Lint/UnusedMethodArgument:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,6 +1,6 @@
 Style/BlockDelimiters:
   Exclude:
-    - 'spec/'
+    - 'spec/**/*'
 
 Lint/UnusedMethodArgument:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1,3 +1,7 @@
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/controllers/api/actions_controller_spec.rb'
+
 Lint/UnusedMethodArgument:
   Exclude:
     - 'lib/payment_processor/braintree/error_processing.rb'

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -48,6 +48,7 @@ require('campaigner-facing/sidebar');
 require('campaigner-facing/tooltips');
 require('campaigner-facing/collection_editor');
 require('campaigner-facing/shares_editor');
+require('campaigner-facing/actions_editor');
 require('campaigner-facing/layout_picker');
 
 window.PageEditBar =  require('campaigner-facing/page_edit_bar');

--- a/app/assets/javascripts/campaigner-facing/actions_editor.js
+++ b/app/assets/javascripts/campaigner-facing/actions_editor.js
@@ -11,7 +11,6 @@ let setupOnce = require('campaigner-facing/setup_once');
 
     initialize(){
       this.pageId = this.$el.data('page-id');
-      console.log('initialized, found page id', this.pageId)
     },
 
     updateButtons($publisher, desired) {
@@ -30,7 +29,7 @@ let setupOnce = require('campaigner-facing/setup_once');
     updateAction($publisher, desired, last) {
       console.log('updateAction', $publisher, desired, last);
       this.updateButtons($publisher, desired);
-      $.ajax(`/api/pages/${this.pageId}/actions/${$publisher.data('id')}/publish`, {
+      $.ajax(`/api/pages/${this.pageId}/actions/${$publisher.data('id')}`, {
         method: 'PUT',
         data: { publish_status: desired }
       }).fail(() => {

--- a/app/assets/javascripts/campaigner-facing/actions_editor.js
+++ b/app/assets/javascripts/campaigner-facing/actions_editor.js
@@ -27,7 +27,6 @@ let setupOnce = require('campaigner-facing/setup_once');
     },
 
     updateAction($publisher, desired, last) {
-      console.log('updateAction', $publisher, desired, last);
       this.updateButtons($publisher, desired);
       $.ajax(`/api/pages/${this.pageId}/actions/${$publisher.data('id')}`, {
         method: 'PUT',

--- a/app/assets/javascripts/campaigner-facing/actions_editor.js
+++ b/app/assets/javascripts/campaigner-facing/actions_editor.js
@@ -1,0 +1,45 @@
+let setupOnce = require('campaigner-facing/setup_once');
+
+(function(){
+
+  let ActionsEditor = Backbone.View.extend({
+
+    events: {
+      'click .action-publisher .btn': 'handleClick',
+      'ajax:success form.shares-editor__new-form': 'clearFormAndConformView',
+    },
+
+    initialize(){
+      this.pageId = this.$el.data('page-id');
+      console.log('initialized, found page id', this.pageId)
+    },
+
+    updateButtons($publisher, desired) {
+      $publisher.find('.btn-primary').removeClass('btn-primary');
+      $publisher.find('[data-state="'+desired+'"]').addClass('btn-primary');
+    },
+
+    handleClick(e) {
+      let $target = $(e.target);
+      let $publisher = $target.parents('.action-publisher');
+      let current = $publisher.find('.btn-primary').data('state');
+      let desired = $target.data('state');
+      this.updateAction($publisher, desired, current);
+    },
+
+    updateAction($publisher, desired, last) {
+      console.log('updateAction', $publisher, desired, last);
+      this.updateButtons($publisher, desired);
+      $.ajax(`/api/pages/${this.pageId}/actions/${$publisher.data('id')}/publish`, {
+        method: 'PUT',
+        data: { publish_status: desired }
+      }).fail(() => {
+        this.updateButtons($publisher, last);
+      });
+    },
+  });
+
+  $.subscribe("actions:edit", function(){
+    setupOnce('.actions-editor', ActionsEditor);
+  });
+}());

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -27,6 +27,14 @@ class Api::ActionsController < ApplicationController
     end
   end
 
+  def publish
+    action = Action.find(params[:id])
+    action.update(publish_status: params[:publish_status])
+    render json: {}, status: 200
+  rescue ArgumentError => e
+    render json: { errors: { publish_status: e.message } }, status: 422
+  end
+
   private
 
   def action_params

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -27,11 +27,11 @@ class Api::ActionsController < ApplicationController
     end
   end
 
-  def publish
+  def update
     action = Action.find(params[:id])
-    action.update(publish_status: params[:publish_status])
+    action.update!(publish_status: params[:publish_status])
     render json: {}, status: 200
-  rescue ArgumentError => e
+  rescue ArgumentError => e # enums raise ArgumentError when given an invalid value
     render json: { errors: { publish_status: e.message } }, status: 422
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -20,8 +20,9 @@ class PagesController < ApplicationController
   def actions
     reader = ActionReader.new({page_id: @page.id}) # rubocop:disable all
     page_number = { page_number: params[:page_number] }
+    @hashes, @headers, @paginator = reader.run(**page_number)
     respond_to do |format|
-      format.html { @hashes, @keys, @headers, @paginator = reader.run(**page_number) }
+      format.html { @hashes, @headers, @paginator = reader.run(**page_number) }
       format.csv { render text: reader.csv(**page_number) }
     end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -20,7 +20,6 @@ class PagesController < ApplicationController
   def actions
     reader = ActionReader.new({page_id: @page.id}) # rubocop:disable all
     page_number = { page_number: params[:page_number] }
-    @hashes, @headers, @paginator = reader.run(**page_number)
     respond_to do |format|
       format.html { @hashes, @headers, @paginator = reader.run(**page_number) }
       format.csv { render text: reader.csv(**page_number) }

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -20,6 +20,8 @@ class Action < ActiveRecord::Base
   belongs_to :page, counter_cache: :action_count
   belongs_to :member
 
+  enum publish_status: [:default, :published, :hidden]
+
   has_paper_trail on: [:update, :destroy]
   scope :donation, -> { where(donation: true) }
   scope :not_donation, -> { where.not(donation: true) }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -39,6 +39,7 @@ class Page < ActiveRecord::Base
   enum follow_up_plan: [:with_liquid, :with_page] # TODO: - :with_link
   enum publish_status: [:published, :unpublished, :archived]
   enum optimizely_status: [:optimizely_enabled, :optimizely_disabled]
+  enum publish_actions: [:secure, :default_hidden, :default_published]
 
   belongs_to :language
   belongs_to :campaign # Note that some pages do not necessarily belong to campaigns

--- a/app/services/action_collator.rb
+++ b/app/services/action_collator.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 class ActionCollator
   PRIVATE_KEYS = %w(action_referrer_email action_referer action_express_donation).freeze
-  PREFIXES = %w(action_textentry_ action_box_ action_dropdown_ action_choice_ action_).freeze
+  PREFIXES = %w(action_ textentry_ box_ dropdown_ choice_).freeze
+  COLUMN_KEYS = %w(publish_status id).freeze
+  COMMA = ','
 
   def self.run(actions)
     new(actions).run
@@ -18,20 +20,23 @@ class ActionCollator
   end
 
   def run
-    [hashes, keys, headers]
+    [hashes, headers]
   end
 
   def csv
     rows = @actions.map do |action|
-      keys.map { |k| action.form_data[k] }
+      keys.map do |k|
+        value = val(k, action)
+        (value.is_a?(String) && value.index(COMMA).present?) ? "\"#{value}\"" : value
+      end
     end
-    rows = rows.unshift(headers) unless @skip_headers
+    rows = rows.unshift(keys.map { |k| headers[k] }) unless @skip_headers
     rows.map { |r| r.join(',') }.join("\n")
   end
 
   def hashes
     @hashes ||= @actions.map do |action|
-      keys.map { |k| [k, action.form_data[k]] }.to_h
+      keys.map { |k| [k, val(k, action)] }.to_h.symbolize_keys
     end
   end
 
@@ -39,12 +44,21 @@ class ActionCollator
     return @keys if @keys.present?
     all_keys = @actions.map { |a| a.form_data.keys }.flatten.uniq
     @keys = all_keys.reject { |k| PRIVATE_KEYS.include?(k) }.select { |k| ActionKitFields.has_valid_form(k) }
+    @keys = (@keys + COLUMN_KEYS).map(&:to_sym)
   end
 
   def headers
     @headers ||= keys.map do |key|
-      PREFIXES.each { |p| key = key.remove(p) }
-      key.titleize
-    end
+      short = key.to_s
+      PREFIXES.each { |p| short = short.remove(p) }
+      [key, short.titleize]
+    end.to_h.symbolize_keys
+  end
+
+  private
+
+  def val(key, action)
+    val = action.try(key.to_sym)
+    val.blank? ? action.form_data[key.to_s] : val
   end
 end

--- a/app/views/pages/_settings_form.slim
+++ b/app/views/pages/_settings_form.slim
@@ -48,6 +48,10 @@
         = f.select :campaign_id, options_from_collection_for_select(Campaign.all.order(name: :asc), 'id', 'name', page.campaign_id), {include_blank: true}, class: 'form-control'
 
       .form-group
+        = label_with_tooltip(f, :publish_actions, t('pages.edit.publish_actions'), t('tooltips.publish_actions'))
+        = f.select :publish_actions, Page.publish_actions.to_a.map{ |k, v| [k.humanize, k] }, {}, class: "form-control"
+
+      .form-group
         = label_with_tooltip(f, :optimizely_status, t('pages.edit.optimizely_status'), t('tooltips.optimizely_status'))
         = f.select :optimizely_status, Page.optimizely_statuses.to_a.map{ |k, v| [k.humanize, k] }, {}, class: "form-control"
 

--- a/app/views/pages/actions.html.slim
+++ b/app/views/pages/actions.html.slim
@@ -1,21 +1,31 @@
 - content_for(:title, "Actions | #{@page.title}")
 
 = render "sidebar", action: :actions, id: @page.id
+- keys = @headers.keys
 
 .edit-block
   h1.edit-block__title= "Actions - #{@page.title}"
   
   .edit-block__constrained-width
-    table.table
+    table.table.actions-editor data-page-id="#{@page.id}"
       thead
-        - @headers.each do |header|
-          th = header
+        th
+          | Publish status
+        - keys.each do |key|
+          th = @headers[key]
 
       tbody
         - @hashes.each do |row|
           tr
-            - @keys.each do |key|
-              td = row[key]
+            td
+              .action-publisher.btn-group-vertical data-id="#{row[:id]}"
+                = toggle_switch 'default', row[:publish_status], 'Page default'
+                = toggle_switch 'published', row[:publish_status], 'Published'
+                = toggle_switch 'hidden', row[:publish_status], 'Hidden'
+
+            - keys.each do |key|
+              td
+                = row[key]
 
 
   - range = 'actions ' + record_range(@paginator.current_page, @paginator.size)
@@ -35,3 +45,6 @@
     = ' | ' 
   - if show_all_csv
     = link_to "Download all actions in CSV", actions_page_path(@page, format: :csv)
+
+javascript:
+  $.publish('actions:edit');

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -75,6 +75,7 @@ en:
     campaign: "Action counters of pages belonging to the same campaign are consolidated."
     canonical_url: "If a page is accessible through multiple URLs, then pick the best one for SEO. Defaults to https://our.site/a/page-slug"
     optimizely_status: "Optimizely can be slow to load, but we load it on all pages so we can run site-wide experiments. Please only disable for exceptional pages like microsites."
+    publish_actions: 'Use this to make member responses to the page accessible through the API.'
     shares:
       link_explanation: "Please keep the {LINK} in your text. Champaign will replace this with the actual link to your page."
       new: "Once you have uploaded the photos you want to test, use this box to create your shares. Champaign will use ShareProgress to serve the best-performing version when there's a winner."
@@ -180,6 +181,7 @@ en:
       saving: "Saving..."
       canonical_url: "Canonical URL"
       optimizely_status: "Optimizely"
+      publish_actions: 'Publish actions'
       more_settings: "More options"
     analytics:
       hours_chart_title: "Total actions last 12 hours"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,9 +121,8 @@ Rails.application.routes.draw do
       get 'featured', on: :collection
 
       resource  :analytics
-      resources :actions, only: [:create] do
+      resources :actions, only: [:create, :update] do
         post 'validate', on: :collection, action: 'validate'
-        put 'publish', on: :member, action: 'publish'
       end
       resources :survey_responses, only: [:create]
       resource :call, only: [:create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,11 +117,13 @@ Rails.application.routes.draw do
 
     resources :pages do
       get 'share-rows', on: :member, action: 'share_rows'
+      get 'actions', on: :member, action: 'actions'
       get 'featured', on: :collection
 
       resource  :analytics
       resources :actions, only: [:create] do
         post 'validate', on: :collection, action: 'validate'
+        put 'publish', on: :member, action: 'publish'
       end
       resources :survey_responses, only: [:create]
       resource :call, only: [:create]

--- a/db/migrate/20170222221621_add_publish_to_actions.rb
+++ b/db/migrate/20170222221621_add_publish_to_actions.rb
@@ -1,0 +1,6 @@
+class AddPublishToActions < ActiveRecord::Migration
+  def change
+    add_column :pages, :publish_actions, :integer, default: 0, null: false
+    add_column :actions, :publish_status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20170224140212) do
     t.jsonb    "form_data",         default: {}
     t.boolean  "subscribed_member", default: true
     t.boolean  "donation",          default: false
+    t.integer  "publish_status",    default: 0,     null: false
   end
 
   add_index "actions", ["member_id"], name: "index_actions_on_member_id", using: :btree
@@ -238,6 +239,7 @@ ActiveRecord::Schema.define(version: 20170224140212) do
     t.boolean  "allow_duplicate_actions",    default: false
     t.boolean  "enforce_styles",             default: false,     null: false
     t.text     "notes"
+    t.integer  "publish_actions",            default: 0,         null: false
   end
 
   add_index "pages", ["campaign_id"], name: "index_pages_on_campaign_id", using: :btree

--- a/spec/controllers/api/actions_controller_spec.rb
+++ b/spec/controllers/api/actions_controller_spec.rb
@@ -184,18 +184,18 @@ describe Api::ActionsController do
     end
   end
 
-  describe 'PUT publish' do
+  describe 'PUT update' do
     let!(:a) { create :action }
 
     describe 'successful' do
       it 'returns 200' do
-        put :publish, page_id: 2, id: a.id, publish_status: 'published'
+        put :update, page_id: 2, id: a.id, publish_status: 'published'
         expect(response).to be_success
       end
 
       it 'changes the status to published' do
         expect {
-          put :publish, page_id: 2, id: a.id, publish_status: 'published'
+          put :update, page_id: 2, id: a.id, publish_status: 'published'
         }.to change {
           a.reload.publish_status
         }.from('default').to('published')
@@ -203,7 +203,7 @@ describe Api::ActionsController do
 
       it 'changes the status to hidden' do
         expect {
-          put :publish, page_id: 2, id: a.id, publish_status: 'hidden'
+          put :update, page_id: 2, id: a.id, publish_status: 'hidden'
         }.to change {
           a.reload.publish_status
         }.from('default').to('hidden')
@@ -212,7 +212,7 @@ describe Api::ActionsController do
       it 'changes the status to default' do
         a.published!
         expect {
-          put :publish, page_id: 2, id: a.id, publish_status: 'default'
+          put :update, page_id: 2, id: a.id, publish_status: 'default'
         }.to change {
           a.reload.publish_status
         }.from('published').to('default')
@@ -224,19 +224,19 @@ describe Api::ActionsController do
 
       it 'raises not found if no action is found with that id' do
         expect {
-          put :publish, page_id: 2, id: 9999, publish_status: 'default'
+          put :update, page_id: 2, id: 9999, publish_status: 'default'
         }.to raise_error ActiveRecord::RecordNotFound
       end
 
       it 'returns errors and 422 if given an invalid publish_status' do
-        put :publish, page_id: 2, id: a.id, publish_status: 'invalid'
+        put :update, page_id: 2, id: a.id, publish_status: 'invalid'
         expect(response.code).to eq '422'
         expect(response.body).to eq '{"errors":{"publish_status":"\'invalid\' is not a valid publish_status"}}'
       end
 
       it 'does not update the action when given an invalid publish_status' do
         expect {
-          put :publish, page_id: 2, id: a.id, publish_status: 'invalid'
+          put :update, page_id: 2, id: a.id, publish_status: 'invalid'
         }.not_to change {
           a.reload.publish_status
         }

--- a/spec/controllers/api/actions_controller_spec.rb
+++ b/spec/controllers/api/actions_controller_spec.rb
@@ -152,9 +152,9 @@ describe Api::ActionsController do
 
     describe 'filtering' do
       it 'does not permit params not in the form' do
-        expect do
+        expect {
           post :validate, page_id: 2, form_id: 3, not_permitted: 'no, no!', foo: 'bar'
-        end.to raise_error(
+        }.to raise_error(
           ActionController::UnpermittedParameters,
           'found unpermitted parameter: not_permitted'
         )
@@ -180,6 +180,66 @@ describe Api::ActionsController do
       it 'does not set the cookie' do
         expect(cookies.signed['member_id']).to eq nil
         expect(response.cookies[:member_id]).to eq nil
+      end
+    end
+  end
+
+  describe 'PUT publish' do
+    let!(:a) { create :action }
+
+    describe 'successful' do
+      it 'returns 200' do
+        put :publish, page_id: 2, id: a.id, publish_status: 'published'
+        expect(response).to be_success
+      end
+
+      it 'changes the status to published' do
+        expect {
+          put :publish, page_id: 2, id: a.id, publish_status: 'published'
+        }.to change {
+          a.reload.publish_status
+        }.from('default').to('published')
+      end
+
+      it 'changes the status to hidden' do
+        expect {
+          put :publish, page_id: 2, id: a.id, publish_status: 'hidden'
+        }.to change {
+          a.reload.publish_status
+        }.from('default').to('hidden')
+      end
+
+      it 'changes the status to default' do
+        a.published!
+        expect {
+          put :publish, page_id: 2, id: a.id, publish_status: 'default'
+        }.to change {
+          a.reload.publish_status
+        }.from('published').to('default')
+      end
+    end
+
+    describe 'unsuccessful' do
+      let!(:a) { create :action }
+
+      it 'raises not found if no action is found with that id' do
+        expect {
+          put :publish, page_id: 2, id: 9999, publish_status: 'default'
+        }.to raise_error ActiveRecord::RecordNotFound
+      end
+
+      it 'returns errors and 422 if given an invalid publish_status' do
+        put :publish, page_id: 2, id: a.id, publish_status: 'invalid'
+        expect(response.code).to eq '422'
+        expect(response.body).to eq '{"errors":{"publish_status":"\'invalid\' is not a valid publish_status"}}'
+      end
+
+      it 'does not update the action when given an invalid publish_status' do
+        expect {
+          put :publish, page_id: 2, id: a.id, publish_status: 'invalid'
+        }.not_to change {
+          a.reload.publish_status
+        }
       end
     end
   end

--- a/spec/requests/api/pages_spec.rb
+++ b/spec/requests/api/pages_spec.rb
@@ -30,14 +30,11 @@ describe 'api/pages' do
     end
 
     subject { JSON.parse(response.body) }
-
     before { get('/api/pages.json') }
 
     it 'returns list of pages' do
       expect(subject.size).to eq(1)
-
       expect(subject.first.keys).to match_array(expected)
-
       expect(subject.first.symbolize_keys).to include(title: 'Foo',
                                                       content: 'Bar')
     end
@@ -50,14 +47,11 @@ describe 'api/pages' do
     end
 
     subject { JSON.parse(response.body) }
-
     before { get(featured_api_pages_path(format: :json)) }
 
     it 'returns list of pages' do
       expect(subject.size).to eq(1)
-
       expect(subject.first.keys).to match_array(expected)
-
       expect(subject.first.symbolize_keys).to include(title: 'Foo',
                                                       content: 'Bar')
     end
@@ -85,9 +79,62 @@ describe 'api/pages' do
         campaign_action_count
       )
       expect(subject.keys).to match_array(expected)
-
       expect(subject.symbolize_keys).to include(title: 'Foo',
                                                 id: page.id)
+    end
+  end
+
+  describe 'GET actions' do
+    let(:page) { create :page }
+    let!(:actions) do
+      [:default, :published, :hidden].map do |status|
+        create :action, page: page, publish_status: status, form_data: { action_foo: status }
+      end
+    end
+
+    subject { get api_page_actions_path(page) }
+
+    it 'returns a 403 if the page publish_actions is secure' do
+      page.update!(publish_actions: :secure)
+      subject
+      expect(response.code).to eq '403'
+      expect(response.body).to be_empty
+    end
+
+    it 'returns published and default actions if page publish_actions is default_published' do
+      page.update!(publish_actions: :default_published)
+      subject
+      expect(response.code).to eq '200'
+      expected = [
+        { action_foo: 'published', publish_status: 'published', id: actions[1].id },
+        { action_foo: 'default', publish_status: 'default', id: actions[0].id }
+      ]
+      expect(json.deep_symbolize_keys[:actions]).to match_array(expected)
+    end
+
+    it 'returns only published pages if page publish_actions is default_hidden' do
+      page.update!(publish_actions: :default_hidden)
+      subject
+      expect(response.code).to eq '200'
+      expected = [{ action_foo: 'published', publish_status: 'published', id: actions[1].id }]
+
+      expect(json.deep_symbolize_keys[:actions]).to match_array(expected)
+    end
+
+    it 'returns a hash with the names of the headers' do
+      page.update!(publish_actions: :default_hidden)
+      subject
+      expect(response.code).to eq '200'
+      expected = { action_foo: 'Foo', publish_status: 'Publish Status', id: 'Id' }
+      expect(json.deep_symbolize_keys[:headers]).to eq(expected)
+    end
+
+    it 'will paginate according to parameters that are passed to it' do
+      page.update!(publish_actions: :default_published)
+      get api_page_actions_path(page, page_number: 2, per_page: 1)
+      expect(response.code).to eq '200'
+      expect(json.symbolize_keys[:actions].size).to eq 1
+      expect(json.deep_symbolize_keys[:actions][0][:id]).to eq actions[1].id
     end
   end
 end

--- a/spec/routing/api/actions_routing_spec.rb
+++ b/spec/routing/api/actions_routing_spec.rb
@@ -19,11 +19,11 @@ describe Api::ActionsController do
       )
     end
 
-    it 'does not route to GET#create' do
+    it 'GET#create routes to api/pages' do
       expect(get: '/api/pages/1/actions').to route_to(
-        controller: 'uris',
-        action: 'show',
-        path: 'api/pages/1/actions'
+        controller: 'api/pages',
+        action: 'actions',
+        id: '1'
       )
     end
   end

--- a/spec/services/action_collator_spec.rb
+++ b/spec/services/action_collator_spec.rb
@@ -2,25 +2,25 @@
 require 'rails_helper'
 
 describe ActionCollator do
-  let(:a1) { build :action, form_data: { phone: '12345', name: 'Hocus' } }
-  let(:a2) { build :action, form_data: { name: 'Pocus', postal: '90019', action_foo: 'bar' } }
+  let(:a1) { build :action, form_data: { phone: '12345', name: 'Hocus', id: 1 } }
+  let(:a2) { build :action, form_data: { name: 'Pocus', postal: '90019', action_foo: 'bar', id: 2 } }
 
   describe 'keys' do
     it "includes the keys present on any action's form data" do
-      expect(ActionCollator.new([a1, a2]).keys).to match_array %w(phone name postal action_foo)
+      expect(ActionCollator.new([a1, a2]).keys).to match_array %i(phone name postal action_foo id publish_status)
     end
 
     it "excludes fields that aren't prefixes by action_ or match AK fields" do
       form_data = { form_id: '123', action_foo: 'bar', postal: '12345', commit: 'G', foo: 'bar' }
       a = build :action, form_data: form_data
-      expect(ActionCollator.new([a]).keys).to match_array %w(action_foo postal)
+      expect(ActionCollator.new([a]).keys).to match_array %i(action_foo postal id publish_status)
     end
 
     it 'excludes action_referrer_email and action_express_donation' do
       form_data = { action_referrer_email: 'a', action_express_donation: '1',
                     action_referer: 'blah', country: 'NI' }
       a = build :action, form_data: form_data
-      expect(ActionCollator.new([a]).keys).to match_array ['country']
+      expect(ActionCollator.new([a]).keys).to match_array %i(country id publish_status)
     end
   end
 
@@ -35,25 +35,34 @@ describe ActionCollator do
         postal: '90019'
       }
       a = build :action, form_data: form_data
-      expected = ['Message', 'Tesla Shareholder', 'Bank', 'Marital Status', 'Inspiration', 'Postal']
-      expect(ActionCollator.new([a]).headers).to match_array(expected)
+      expected = {
+        id: 'Id',
+        publish_status: 'Publish Status',
+        action_textentry_message: 'Message',
+        action_box_tesla_shareholder: 'Tesla Shareholder',
+        action_dropdown_bank: 'Bank',
+        action_choice_marital_status: 'Marital Status',
+        action_inspiration: 'Inspiration',
+        postal: 'Postal'
+      }
+      expect(ActionCollator.new([a]).headers).to eq(expected)
     end
   end
 
   describe 'hashes' do
     it 'turns actions into hashes' do
       expect(ActionCollator.new([a1, a2]).hashes).to match_array([
-        { name: 'Pocus', postal: '90019', action_foo: 'bar', phone: nil },
-        { name: 'Hocus', postal: nil, action_foo: nil, phone: '12345' }
-      ].map(&:stringify_keys))
+        { name: 'Pocus', postal: '90019', action_foo: 'bar', phone: nil, id: 2, publish_status: 'default' },
+        { name: 'Hocus', postal: nil, action_foo: nil, phone: '12345', id: 1, publish_status: 'default' }
+      ])
     end
   end
 
   describe 'csv' do
-    let(:content_rows) { [',Pocus,90019,bar', '12345,Hocus,,'] }
+    let(:content_rows) { [',Pocus,90019,bar,default,2', '12345,Hocus,,,default,1'] }
 
     it 'has the headers as the first line' do
-      expect(ActionCollator.csv([a1, a2]).split("\n")[0]).to eq('Phone,Name,Postal,Foo')
+      expect(ActionCollator.csv([a1, a2]).split("\n")[0]).to eq('Phone,Name,Postal,Foo,Publish Status,Id')
     end
 
     it 'has a line for each action, and a header line' do
@@ -67,12 +76,17 @@ describe ActionCollator do
     it 'does not have the headers if skip_headers is passed as true' do
       expect(ActionCollator.csv([a1, a2], skip_headers: true).split("\n")).to match_array(content_rows)
     end
+
+    it 'puts quotes around fields with commas' do
+      a = build :action, form_data: { phone: '12345', name: 'a,b,c', id: 1 }
+      expect(ActionCollator.csv([a]).split("\n").last).to eq('12345,"a,b,c",default,1')
+    end
   end
 
   describe 'run' do
-    it 'returns hashes, keys, and headers' do
+    it 'returns hashes and headers' do
       ac = ActionCollator.new([a1, a2])
-      expect(ActionCollator.run([a1, a2])).to eq([ac.hashes, ac.keys, ac.headers])
+      expect(ActionCollator.run([a1, a2])).to eq([ac.hashes, ac.headers])
     end
   end
 end


### PR DESCRIPTION
This pull request does several things in the service of making actions API readable on Champaign.

- it makes an API endpoint to read actions from a page if the page allows it
- it creates an interface in the pages edit settings pane to allow actions to be read, either with default published or default hidden
- it makes an interface in `/pages/:slug/actions` to hide bad actions from a page that has them default shown, or to show actions from a page that has them default hidden

I started this work for the Shopify employee poaching campaign, but that page has been put on the back burner for the time being. However, I thought it was worth finishing up this work as I foresee it as useful in the near future.