### PR TITLE
Optimise loading of member-facing scripts

### DIFF
--- a/app/assets/javascripts/dependencies.js
+++ b/app/assets/javascripts/dependencies.js
@@ -1,0 +1,2 @@
+//= require jquery
+//= require jquery_ujs

--- a/app/assets/javascripts/member-facing.js.erb
+++ b/app/assets/javascripts/member-facing.js.erb
@@ -1,3 +1,10 @@
+//= require underscore
+//= require backbone
+//= require sticky
+//= require selectize
+//= require i18n
+//= require i18n/translations
+//= require braintree-web
 //= require shared/pub_sub
 //= require shared/show_errors
 //= require member-facing/registration

--- a/app/assets/javascripts/member-facing.js.erb
+++ b/app/assets/javascripts/member-facing.js.erb
@@ -1,17 +1,5 @@
-//= require jquery
-//= require jquery_ujs
-//= require sticky
-//= require underscore
-//= require braintree-web
-//= require backbone
-//= require selectize
-
-//= require i18n
-//= require i18n/translations
-
 //= require shared/pub_sub
 //= require shared/show_errors
-
 //= require member-facing/registration
 
 // external assets

--- a/app/assets/javascripts/member-facing/backbone/fundraiser.js
+++ b/app/assets/javascripts/member-facing/backbone/fundraiser.js
@@ -66,6 +66,11 @@ const Fundraiser = Backbone.View.extend(_.extend(CurrencyMethods, {
 
     GlobalEvents.bindEvents(this);
 
+    this.reveal();
+  },
+
+  reveal() {
+    this.$('.fundraiser-bar__top').removeClass('hidden-closed');
   },
 
   initializeRecurring(recurringDefault) {

--- a/app/assets/javascripts/vendor.js
+++ b/app/assets/javascripts/vendor.js
@@ -1,0 +1,9 @@
+//= require jquery
+//= require jquery_ujs
+//= require underscore
+//= require backbone
+//= require sticky
+//= require braintree-web
+//= require selectize
+//= require i18n
+//= require i18n/translations

--- a/app/assets/javascripts/vendor.js
+++ b/app/assets/javascripts/vendor.js
@@ -1,9 +1,0 @@
-//= require jquery
-//= require jquery_ujs
-//= require underscore
-//= require backbone
-//= require sticky
-//= require braintree-web
-//= require selectize
-//= require i18n
-//= require i18n/translations

--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -6,26 +6,23 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     meta name="description" content=t('branding.description')
     - if Settings.facebook_app_id.present?
       meta property='fb:app_id' content="#{Settings.facebook_app_id}"
-    = stylesheet_link_tag "member-facing"
+    = stylesheet_link_tag 'member-facing'
     = stylesheet_link_tag *webpack_asset_paths('components', extension: 'css') unless Rails.env.test?
-
-    = javascript_include_tag "vendor"
-
-    = render partial: 'shared/optimizely_snippet' unless @page.optimizely_disabled?
-
     = csrf_meta_tags
     = favicon_link_tag 'images/favicon.ico'
     = metamagic
     - canonical_url = @page.canonical_url.blank? ? member_facing_page_url(@page) : @page.canonical_url
     link rel="canonical" href=canonical_url
 
+    = javascript_include_tag 'dependencies'
+    = render partial: 'shared/optimizely_snippet' unless @page.optimizely_disabled?
   body
     = render partial: 'layouts/notification'
     = yield
 
     .mobile-indicator
 
-    = javascript_include_tag "member-facing"
+    = javascript_include_tag 'member-facing'
     = render partial: 'shared/js_locale'
     = render partial: 'shared/page_object'
     = render partial: 'shared/facebook_pixel' unless Rails.env.test?

--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -6,19 +6,12 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     meta name="description" content=t('branding.description')
     - if Settings.facebook_app_id.present?
       meta property='fb:app_id' content="#{Settings.facebook_app_id}"
-    = javascript_include_tag "https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en,Intl.~locale.de,Intl.~locale.es,Intl.~locale.fr"
     = stylesheet_link_tag "member-facing"
-    = javascript_include_tag "member-facing"
-    - if !Rails.env.test?
-      = stylesheet_link_tag *webpack_asset_paths('components', extension: 'css')
-      = javascript_include_tag *webpack_asset_paths('components', extension: 'js')
+    = stylesheet_link_tag *webpack_asset_paths('components', extension: 'css') unless Rails.env.test?
 
-    - unless @page.optimizely_disabled?
-      = render partial: 'shared/optimizely_snippet'
-    = render partial: 'shared/js_locale'
-    = render partial: 'shared/google_analytics_snippet'
-    = render partial: 'shared/page_object'
-    = render partial: 'shared/facebook_pixel' unless Rails.env.test?
+    = javascript_include_tag "vendor"
+
+    = render partial: 'shared/optimizely_snippet' unless @page.optimizely_disabled?
 
     = csrf_meta_tags
     = favicon_link_tag 'images/favicon.ico'
@@ -31,5 +24,13 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     = yield
 
     .mobile-indicator
+
+    = javascript_include_tag "member-facing"
+    = render partial: 'shared/js_locale'
+    = render partial: 'shared/page_object'
+    = render partial: 'shared/facebook_pixel' unless Rails.env.test?
+    = javascript_include_tag "https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en,Intl.~locale.de,Intl.~locale.es,Intl.~locale.fr"
+    = javascript_include_tag *webpack_asset_paths('components', extension: 'js') unless Rails.env.test?
+    = render partial: 'shared/google_analytics_snippet'
 
     script type="text/javascript" charset="utf-8" async=true src="//c.shpg.org/99/sp.js"

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -2,7 +2,7 @@
   <div class="fundraiser-bar sidebar {{ extra_class }} {% if freestanding %} fundraiser-bar--freestanding {% endif %}">
     <div class="{% unless freestanding %}overlay-toggle__mobile-view overlay-toggle__mobile-view--closed{% endunless %}">
       <div class="fundraiser-bar__content">
-        <div class="fundraiser-bar__top script-dependent__for-height">
+        <div class="fundraiser-bar__top script-dependent__for-height hidden-closed">
           <div class="overlay-toggle__mobile-ui">
             <a class="overlay-toggle__close-button">&#x2715;</a>
           </div>
@@ -43,7 +43,7 @@
               {{ 'fundraiser.error_intro' | t }}
             </div>
           </div>
-          <div class="fundraiser-bar__step-panel script-dependent" data-step="1">
+          <div class="fundraiser-bar__step-panel script-dependent hidden-closed" data-step="1">
             <div class="fundraiser-bar__amount-buttons">
             </div>
             <input class="fundraiser-bar__custom-field" placeholder="{{ 'fundraiser.other_amount' | t }}" />
@@ -56,7 +56,7 @@
               {{ 'fundraiser.proceed_to_details' | t }}
             </button>
           </div>
-          <div class="fundraiser-bar__step-panel script-dependent" data-step="2">
+          <div class="fundraiser-bar__step-panel script-dependent hidden-closed" data-step="2">
             {% capture cta %}{{ 'fundraiser.proceed_to_payment' | t }}{% endcapture %}
             {% include 'Form',
               cta: cta,
@@ -68,7 +68,7 @@
               {{ 'petition.fine_print' | t }}
             </div>
           </div>
-          <div class="fundraiser-bar__step-panel form--big script-dependent hosted-fields-view" data-step="3">
+          <div class="fundraiser-bar__step-panel form--big script-dependent hosted-fields-view hidden-closed" data-step="3">
             <div class="action-form__welcome-text hidden-irrelevant">
               <i class="fa fa-check-square-o fundraiser-bar__user-icon"></i>
               <span class="action-form__welcome-name"></span> <br />

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,7 +17,7 @@ end
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
-Rails.application.config.assets.precompile += %w(vendor.js member-facing.css member-facing.js)
+Rails.application.config.assets.precompile += %w(dependencies.js member-facing.css member-facing.js)
 
 # to get browserify to turn everything into es6
 Rails.application.config.browserify_rails.commandline_options = '--transform babelify --extension=".js"'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -17,7 +17,7 @@ end
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
-Rails.application.config.assets.precompile += %w(member-facing.css member-facing.js)
+Rails.application.config.assets.precompile += %w(vendor.js member-facing.css member-facing.js)
 
 # to get browserify to turn everything into es6
 Rails.application.config.browserify_rails.commandline_options = '--transform babelify --extension=".js"'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -432,11 +432,11 @@ ActiveRecord::Schema.define(version: 20170304165947) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "title"
-    t.json     "targets",                 default: [],   array: true
     t.string   "sound_clip_file_name"
     t.string   "sound_clip_content_type"
     t.integer  "sound_clip_file_size"
     t.datetime "sound_clip_updated_at"
+    t.json     "targets",                 default: [],   array: true
     t.text     "description"
     t.boolean  "target_by_country",       default: true
   end


### PR DESCRIPTION
Part 1 of 4 in #902

This moves script tags to the bottom of `<body>`. This change would normally cause a flicker fundraiser form until the plugin's `changeStep` fn runs, so I'm hiding all script dependent panels by default (`changeStep` runs as soon as we initialise the plugin so it will _always_ unhide the right panel on init), and hiding the top bar (where the stepper is) and showing on init. 

There's a new file `app/assets/javascripts/dependencies.js`, that takes care of loading jQuery in `<head>`. The only other script that is loaded in the `head` is optimisely, for pages that have it enabled.

Everything else is loaded _after_ the `= yield`. 