### PR TITLE
Add super basic call count to call tool pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,6 +14,7 @@ class PagesController < ApplicationController
   end
 
   def analytics
+    @calls = Call.where(page_id: @page.id)
   end
 
   def actions

--- a/app/views/pages/analytics.slim
+++ b/app/views/pages/analytics.slim
@@ -39,6 +39,16 @@
         = render variation, page: @page, only_stats: true
       = render 'links_to_share_progress', only_stats: true
 
+  - if @calls.present?
+    - completed_calls = @calls.select { |c| c.log["DialCallStatus"] == 'completed' }
+    - by_day = Hash.new(0)
+    - completed_calls.each { |c| by_day[c.updated_at.to_date] += 1 }
+    = "Members have completed #{completed_calls.size} calls"
+    ul
+    - by_day.to_a.sort_by { |p| p[0] }.each do |date, count|
+      li = "#{count} #{'call'.pluralize(count)} on #{date.strftime('%B %d, %Y')}"
+
+
 javascript:
   $( function() {
     Analytics.makeDashboard("#{@page.id}");


### PR DESCRIPTION
This is just a stand-in for Emma and David to be able to see the call counts for the next few days; Rodrigo is working on a much more fully featured version.