### PR TITLE
Call tool refactor

### DIFF
--- a/app/controllers/api/calls_controller.rb
+++ b/app/controllers/api/calls_controller.rb
@@ -16,7 +16,7 @@ class Api::CallsController < ApplicationController
 
   def call_params
     params.require(:call)
-      .permit(:member_phone_number, :target_index)
+      .permit(:member_phone_number, :target_id)
       .merge(page_id: params[:page_id],
              member_id: recognized_member&.id)
   end

--- a/app/frontend/containers/CallToolView/CallToolView.js
+++ b/app/frontend/containers/CallToolView/CallToolView.js
@@ -12,6 +12,7 @@ export type Target = {
   countryCode: string;
   name: string;
   title: string;
+  id: string;
 }
 
 export type Country = {
@@ -147,10 +148,6 @@ class CallToolView extends Component {
     return _.sample(candidates);
   }
 
-  selectedTargetIndex() {
-    return _.findIndex(this.props.targets, this.state.selectedTarget);
-  }
-
   submit(event: any) {
     event.preventDefault();
     if(!this.validateForm()) return;
@@ -158,7 +155,7 @@ class CallToolView extends Component {
     ChampaignAPI.calls.create({
       pageId: this.props.pageId,
       memberPhoneNumber: this.state.form.memberPhoneCountryCode + this.state.form.memberPhoneNumber,
-      targetIndex: this.selectedTargetIndex()
+      targetId: this.state.selectedTarget.id
     }).then(this.submitSuccessful.bind(this), this.submitFailed.bind(this));
   }
 

--- a/app/frontend/util/ChampaignAPI.js
+++ b/app/frontend/util/ChampaignAPI.js
@@ -31,7 +31,12 @@ const parseResponse = (response, textStatus, other): OperationResponse => {
   }
 };
 
-const createCall = function(params: {pageId: string|number, memberPhoneNumber?: string, targetIndex: number}): Promise<OperationResponse> {
+type CreateCallParams = {
+  pageId: string | number,
+  memberPhoneNumber?: string,
+  targetId: string,
+};
+const createCall = function(params: CreateCallParams): Promise<OperationResponse> {
   const payload = {
     call: {
       member_phone_number: params.memberPhoneNumber,

--- a/app/frontend/util/ChampaignAPI.js
+++ b/app/frontend/util/ChampaignAPI.js
@@ -35,7 +35,7 @@ const createCall = function(params: {pageId: string|number, memberPhoneNumber?: 
   const payload = {
     call: {
       member_phone_number: params.memberPhoneNumber,
-      target_index: params.targetIndex
+      target_id: params.targetId
     }
   };
 

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -23,7 +23,6 @@ class Call < ActiveRecord::Base
   validates :member_phone_number, presence: true
   validates :target, presence: true
 
-  validate :target_index_is_valid, if: ->(o) { o.target_index.present? }
   validate :member_phone_number_is_valid
 
   delegate :sound_clip, to: :call_tool
@@ -32,9 +31,8 @@ class Call < ActiveRecord::Base
     target.phone_number
   end
 
-  def target_index=(index)
-    write_attribute(:target_index, index)
-    self.target = call_tool.targets[index] 
+  def target_id=(id)
+    self.target = call_tool.find_target(id)
   end
 
   def target=(target_object)
@@ -50,12 +48,6 @@ class Call < ActiveRecord::Base
 
   def call_tool
     @call_tool ||= Plugins::CallTool.find_by_page_id!(page.id)
-  end
-
-  def target_index_is_valid
-    if call_tool.targets[target_index].blank?
-      errors.add(:target_index, 'is invalid')
-    end
   end
 
   def member_phone_number_is_valid

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -21,7 +21,7 @@ class Call < ActiveRecord::Base
 
   validates :page, presence: true
   validates :member_phone_number, presence: true
-  validates :target_index, presence: true
+  validates :target, presence: true
 
   validate :target_index_is_valid, if: ->(o) { o.target_index.present? }
   validate :member_phone_number_is_valid
@@ -32,8 +32,18 @@ class Call < ActiveRecord::Base
     target.phone_number
   end
 
+  def target_index=(index)
+    write_attribute(:target_index, index)
+    self.target = call_tool.targets[index] 
+  end
+
+  def target=(target_object)
+    write_attribute(:target, target_object&.to_hash)
+  end
+
   def target
-    call_tool.targets[target_index]
+    target_json = read_attribute(:target)
+    CallTool::Target.new(target_json) if target_json.present?
   end
 
   private

--- a/app/models/call.rb
+++ b/app/models/call.rb
@@ -7,12 +7,12 @@
 #  page_id             :integer
 #  member_id           :integer
 #  member_phone_number :string
-#  target_index        :integer
 #  created_at          :datetime
 #  updated_at          :datetime
 #  log                 :jsonb            not null
 #  member_call_events  :json             is an Array
 #  twilio_error_code   :integer
+#  target              :json
 #
 
 class Call < ActiveRecord::Base

--- a/app/models/call_tool/target.rb
+++ b/app/models/call_tool/target.rb
@@ -31,6 +31,10 @@ class CallTool::Target
     to_hash == other.to_hash
   end
 
+  def id
+    Digest::SHA1.hexdigest(to_hash.to_s)
+  end
+
   private
 
   def country_is_valid

--- a/app/models/call_tool/target.rb
+++ b/app/models/call_tool/target.rb
@@ -27,6 +27,10 @@ class CallTool::Target
     self.country_code = ISO3166::Country.find_country_by_name(country_name)&.alpha2
   end
 
+  def ==(other)
+    to_hash == other.to_hash
+  end
+
   private
 
   def country_is_valid

--- a/app/models/plugins/call_tool.rb
+++ b/app/models/plugins/call_tool.rb
@@ -57,6 +57,10 @@ class Plugins::CallTool < ActiveRecord::Base
     json_targets.map { |t| ::CallTool::Target.new(t) }
   end
 
+  def find_target(id)
+    targets.find { |t| t.id == id }
+  end
+
   private
 
   def json_targets

--- a/app/models/plugins/call_tool.rb
+++ b/app/models/plugins/call_tool.rb
@@ -36,17 +36,7 @@ class Plugins::CallTool < ActiveRecord::Base
   end
 
   def liquid_data(_supplemental_data = {})
-    {
-      page_id: page_id,
-      locale: page.language_code,
-      active: active,
-      targets: json_targets,
-      target_by_country_enabled: target_by_country,
-      countries: countries,
-      countries_phone_codes: countries_phone_codes,
-      title: title,
-      description: description
-    }
+    Presenter.new(self).to_hash
   end
 
   def targets=(target_objects)
@@ -67,47 +57,6 @@ class Plugins::CallTool < ActiveRecord::Base
     read_attribute(:targets)
   end
 
-  # Returns [{ code: <country-code>, name: <country-name>}, {..} ...]
-  def countries
-    list =
-      if target_by_country
-        targets.map(&:country_code).uniq.compact.map do |country_code|
-          ISO3166::Country[country_code]
-        end
-      else
-        ISO3166::Country.all
-      end
-
-    list.map do |country|
-      {
-        name: country.translation(page.language_code),
-        code: country.alpha2,
-        phoneCode: country.country_code.to_s
-      }
-    end
-  end
-
-  # Temporary ugly solution until we figure out if we want all countries here or
-  # only a subset.
-  def countries_phone_codes
-    list = ISO3166::Country.all.reject do |country|
-      country.country_code.blank?
-    end
-
-    list.map! do |country|
-      {
-        name: country.translation(page.language_code),
-        code: country.country_code.to_s
-      }
-    end
-
-    # Prioritize US
-    us = list.find { |c| c[:name] == ISO3166::Country['US'].translation(page.language_code) }
-    list.delete(us)
-    list.unshift(us)
-    list
-  end
-
   def targets_are_valid
     targets.each_with_index.each do |target, index|
       target.valid?
@@ -120,6 +69,76 @@ class Plugins::CallTool < ActiveRecord::Base
   def target_countries_are_present
     targets.select { |t| t.country_code.blank? }.each_with_index do |_, index|
       errors.add(:targets, "Country can't be blank (row #{index + 1})")
+    end
+  end
+
+  class Presenter
+    attr_reader :obj
+    def initialize(call_tool)
+      @obj = call_tool
+    end
+
+    def to_hash
+      {
+        page_id: obj.page_id,
+        locale: obj.page.language_code,
+        active: obj.active,
+        targets: targets,
+        target_by_country_enabled: obj.target_by_country,
+        countries: countries,
+        countries_phone_codes: countries_phone_codes,
+        title: obj.title,
+        description: obj.description
+      }
+    end
+
+    private
+
+    def targets
+      obj.targets.map { |t| t.to_hash.merge(id: t.id) }
+    end
+
+    # Returns [{ code: <country-code>, name: <country-name>}, {..} ...]
+    def countries
+      list =
+        if obj.target_by_country
+          obj.targets.map(&:country_code).uniq.compact.map do |country_code|
+            ISO3166::Country[country_code]
+          end
+        else
+          ISO3166::Country.all
+        end
+
+      list.map do |country|
+        {
+          name: country.translation(language_code),
+          code: country.alpha2,
+          phoneCode: country.country_code.to_s
+        }
+      end
+    end
+
+    def countries_phone_codes
+      list = ISO3166::Country.all.reject do |country|
+        country.country_code.blank?
+      end
+
+      list.map! do |country|
+        {
+          name: country.translation(language_code),
+          code: country.country_code.to_s
+        }
+      end
+
+      # Prioritize US
+      us = list.find { |c| c[:name] == ISO3166::Country['US'].translation(language_code) }
+      list.delete(us)
+      list.unshift(us)
+      list
+    end
+
+    def language_code
+      obj.page.language_code
     end
   end
 end

--- a/app/services/call_creator.rb
+++ b/app/services/call_creator.rb
@@ -13,7 +13,7 @@ class CallCreator
     @call = Call.new(page: page,
                      member_id: @params[:member_id],
                      member_phone_number: @params[:member_phone_number],
-                     target_index: @params[:target_index])
+                     target_index: target_index)
     Call.transaction do
       place_call if @call.save
     end
@@ -66,5 +66,12 @@ class CallCreator
       @errors[:base] ||= []
       @errors[:base] << I18n.t('call_tool.errors.unknown')
     end
+  end
+
+  def target_index
+    Integer(@params[:target_index])
+  rescue
+    @errors[:base] << I18n.t('call_tool.errors.unknown')
+    0
   end
 end

--- a/app/services/call_creator.rb
+++ b/app/services/call_creator.rb
@@ -13,10 +13,12 @@ class CallCreator
     @call = Call.new(page: page,
                      member_id: @params[:member_id],
                      member_phone_number: @params[:member_phone_number],
-                     target_index: target_index)
+                     target_id: @params[:target_id])
     Call.transaction do
       place_call if @call.save
     end
+    
+    validate_target
 
     errors.blank?
   end
@@ -68,10 +70,13 @@ class CallCreator
     end
   end
 
-  def target_index
-    Integer(@params[:target_index])
-  rescue
-    @errors[:base] << I18n.t('call_tool.errors.unknown')
-    0
+  # If the targets are updated while the user is on the call tool page, the list
+  # of target_ids on the browser are no longer valid. 
+  # This validation checks for this edge case.
+  def validate_target
+    if @call.target.blank? && @params[:target_id].present?
+      @errors[:base] = [I18n.t('call_tool.errors.target.outdated')]
+    end
   end
+
 end

--- a/config/locales/member_facing.en.yml
+++ b/config/locales/member_facing.en.yml
@@ -82,6 +82,8 @@ en:
     select_target: "Just enter your home country and phone number -- and we'll call shortly after."
     errors:
       unknown: "Oops! Something went wrong, please try a different phone number or again in a few minutes."
+      target:
+        outdated: "It seems the number we're trying to connect you to is no longer available. Please reload the page and try again."
       phone_number:
         too_short: "must have at least 6 digits"
         cant_connect: "can't connect to this phone number, please check it's correct or try another one"

--- a/db/migrate/20170301193907_add_target_to_calls.rb
+++ b/db/migrate/20170301193907_add_target_to_calls.rb
@@ -1,0 +1,5 @@
+class AddTargetToCalls < ActiveRecord::Migration
+  def change
+    add_column :calls, :target, :json
+  end
+end

--- a/db/migrate/20170304151306_migrate_call_target_format.rb
+++ b/db/migrate/20170304151306_migrate_call_target_format.rb
@@ -1,0 +1,22 @@
+class MigrateCallTargetFormat < ActiveRecord::Migration
+  class Plugins::CallTool < ActiveRecord::Base
+    def targets
+      super
+    end
+  end
+
+  class Call < ActiveRecord::Base
+    def target
+      super
+    end
+  end
+
+  def up
+    Call.where.not(target_index: nil).each do |call|
+      call_tool = Plugins::CallTool.find_by_page_id(call.page_id)
+      next unless call_tool.present?
+      target = call_tool.targets[call.target_index]
+      call.update!(target: target)
+    end
+  end
+end

--- a/db/migrate/20170304165947_remove_target_index_from_calls.rb
+++ b/db/migrate/20170304165947_remove_target_index_from_calls.rb
@@ -1,0 +1,5 @@
+class RemoveTargetIndexFromCalls < ActiveRecord::Migration
+  def change
+    remove_column :calls, :target_index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170304151306) do
+ActiveRecord::Schema.define(version: 20170304165947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,7 +69,6 @@ ActiveRecord::Schema.define(version: 20170304151306) do
     t.integer  "page_id"
     t.integer  "member_id"
     t.string   "member_phone_number"
-    t.integer  "target_index"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.jsonb    "log",                 default: {}, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170301193907) do
+ActiveRecord::Schema.define(version: 20170304151306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170224140212) do
+ActiveRecord::Schema.define(version: 20170301193907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20170224140212) do
     t.jsonb    "log",                 default: {}, null: false
     t.json     "member_call_events",  default: [],              array: true
     t.integer  "twilio_error_code"
+    t.json     "target"
   end
 
   add_index "calls", ["log"], name: "index_calls_on_log", using: :gin

--- a/spec/factories/calls.rb
+++ b/spec/factories/calls.rb
@@ -7,12 +7,12 @@
 #  page_id             :integer
 #  member_id           :integer
 #  member_phone_number :string
-#  target_index        :integer
 #  created_at          :datetime
 #  updated_at          :datetime
 #  log                 :jsonb            not null
 #  member_call_events  :json             is an Array
 #  twilio_error_code   :integer
+#  target              :json
 #
 
 FactoryGirl.define do

--- a/spec/factories/calls.rb
+++ b/spec/factories/calls.rb
@@ -19,6 +19,6 @@ FactoryGirl.define do
   factory :call do
     association :page, :with_call_tool
     member_phone_number { Faker::PhoneNumber.cell_phone }
-    target_index 0
+    target { build(:call_tool_target) }
   end
 end

--- a/spec/models/call_spec.rb
+++ b/spec/models/call_spec.rb
@@ -7,12 +7,12 @@
 #  page_id             :integer
 #  member_id           :integer
 #  member_phone_number :string
-#  target_index        :integer
 #  created_at          :datetime
 #  updated_at          :datetime
 #  log                 :jsonb            not null
 #  member_call_events  :json             is an Array
 #  twilio_error_code   :integer
+#  target              :json
 #
 
 require 'rails_helper'

--- a/spec/models/call_spec.rb
+++ b/spec/models/call_spec.rb
@@ -37,4 +37,31 @@ describe Call do
       expect(call).to be_valid
     end
   end
+
+  describe '#target' do 
+    let(:call) { Call.new }
+    let(:target) { build(:call_tool_target) }
+
+    it "returns nil if no target is set" do
+      expect(call.target).to be_nil   
+    end
+
+    it "returns the target if it's already set" do
+      call.target = target
+      expect(call.target.name).to eq target.name
+      expect(call.target.phone_number).to eq target.phone_number
+    end
+  end
+
+  describe '#target_index=' do
+    let!(:page) { create(:page) }
+    let!(:targets) { build_list(:call_tool_target, 3, :with_country) }
+    let!(:call_tool) { create(:call_tool, page: page, targets: targets) }
+    let(:call) { build(:call, page: page, target: nil) }
+
+    it "sets the target" do
+      call.target_index = 1
+      expect(call.target).to be == targets[1]
+    end
+  end
 end

--- a/spec/models/call_spec.rb
+++ b/spec/models/call_spec.rb
@@ -53,14 +53,14 @@ describe Call do
     end
   end
 
-  describe '#target_index=' do
+  describe '#target_id=' do
     let!(:page) { create(:page) }
     let!(:targets) { build_list(:call_tool_target, 3, :with_country) }
     let!(:call_tool) { create(:call_tool, page: page, targets: targets) }
     let(:call) { build(:call, page: page, target: nil) }
 
     it "sets the target" do
-      call.target_index = 1
+      call.target_id = targets[1].id
       expect(call.target).to be == targets[1]
     end
   end

--- a/spec/requests/api/calls_spec.rb
+++ b/spec/requests/api/calls_spec.rb
@@ -8,17 +8,18 @@ describe 'API::Calls' do
 
   describe 'POST /api/pages/:id/call' do
     let!(:page) { create(:page, :with_call_tool) }
-
-    let(:params) do
-      {
-        call: {
-          member_phone_number: '+123456789',
-          target_index: 1
-        }
-      }
-    end
+    let(:target) { Plugins::CallTool.find_by_page_id(page.id).targets.sample }
 
     context 'given valid params' do
+      let(:params) do
+        {
+          call: {
+            member_phone_number: '+123456789',
+            target_id: target.id
+          }
+        }
+      end
+
       it 'returns successfully' do
         post "/api/pages/#{page.id}/call", params
         expect(response).to have_http_status(:no_content)
@@ -32,8 +33,7 @@ describe 'API::Calls' do
         call = Call.last
         expect(call.page_id).to eq(page.id)
         expect(call.member_phone_number).to eq('123456789')
-        expect(call.target_index).to eq(1)
-        expect(call.target).to eq(call.send(:call_tool).targets[1])
+        expect(call.target).to eq target
       end
 
       it 'creates a call on Twilio' do
@@ -52,7 +52,7 @@ describe 'API::Calls' do
         {
           call: {
             member_phone_number: 'wrong number',
-            target_index: 1
+            target_id: target.id
           }
         }
       end

--- a/spec/requests/api/calls_spec.rb
+++ b/spec/requests/api/calls_spec.rb
@@ -33,6 +33,7 @@ describe 'API::Calls' do
         expect(call.page_id).to eq(page.id)
         expect(call.member_phone_number).to eq('123456789')
         expect(call.target_index).to eq(1)
+        expect(call.target).to eq(call.send(:call_tool).targets[1])
       end
 
       it 'creates a call on Twilio' do


### PR DESCRIPTION
This refactor solves a couple issues we used to have with how we were managing call tool targets.

* Before this PR, the `Call#target_index` field would store an integer that then would be used in `CallTool.targets[target_index]` in order to know the target of a call. If a new targets CSV was uploaded, then the existing calls `#target_index` field would get outdated. 

* Another issue that was fixed is the following. The front end form used to send a `target_index` field when creating a call. This field was used to find the target for the call using `CallTool.targets[target_index]`, and again, if the targets where updated then the member might be calling a different target than the expected one. 

**To fix those two issues I implemented the following:**

* When a call is created I'm storing the full target info on the `call` object. This way, if the targets on the call tool are updated/removed, the existing calls are not corrupted. 

* I'm no longer using an index to find the targets for a call, I'm using id that's actually a hash of the contents of the target. Using a target guarantees that the id actually refers to the correct target. 

* I also added a rails migration to migrate the targets from the old format using target_index to the new one storing the target json object in the call.  