### PR TITLE
Add location endpoint and specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :test do
   gem 'timecop'
   gem 'coveralls', require: false
   gem 'poltergeist'
+  gem 'rspec-json_expectations'
 end
 
 # Rails Assets - reference any Bower components that you need as gems.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -424,6 +424,7 @@ GEM
     rspec-expectations (3.4.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
+    rspec-json_expectations (2.1.0)
     rspec-mocks (3.4.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
@@ -607,6 +608,7 @@ DEPENDENCIES
   redis (>= 3.2.0)
   remotipart (~> 1.2)
   rmagick
+  rspec-json_expectations
   rspec-rails
   rubocop
   sass-rails (~> 5.0.6)

--- a/app/controllers/api/stateless/location_controller.rb
+++ b/app/controllers/api/stateless/location_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api
+  module Stateless
+    class LocationController < StatelessController
+      def index
+        render json: { location: location_with_currency }
+      rescue Api::Exceptions::LocationNotFound
+        head status: 504
+      end
+
+      private
+
+      def location
+        @location ||= request.location
+        raise Api::Exceptions::LocationNotFound unless @location
+        @location.data
+      end
+
+      def location_with_currency
+        @location_with_currency ||= location.merge(
+          currency: Donations::Utils.currency_from_country_code(location['country_code'])
+        )
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,8 @@ Rails.application.routes.draw do
         post :facebook
         get :test_authentication
       end
+
+      get :location, to: 'location#index'
     end
 
     resources :members

--- a/lib/api/exceptions.rb
+++ b/lib/api/exceptions.rb
@@ -2,6 +2,7 @@
 module Api
   module Exceptions
     class AuthenticationError < StandardError; end
+    class LocationNotFound < StandardError; end
     class UnauthorizedError < AuthenticationError; end
     class InvalidTokenError < AuthenticationError; end
     class ExpiredTokenError < AuthenticationError; end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
+require 'rspec/json_expectations'
 require 'database_cleaner'
 require 'devise'
 require 'support/helper_functions'

--- a/spec/requests/api/stateless/location_spec.rb
+++ b/spec/requests/api/stateless/location_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'API::Stateless Location' do
+  describe 'GET /api/stateless/location' do
+    context 'Geocoder Success' do
+      it 'responds with (at least) a country code and a currency' do
+        get '/api/stateless/location'
+        expect(response.status).to eq(200)
+        expect(response.body).to include_json(
+          location: {
+            country_code: 'RD',
+            currency: 'USD'
+          }
+        )
+      end
+    end
+
+    context 'Geocoder Timeout' do
+      before do
+        allow(Geocoder).to receive(:search) { [] }
+      end
+
+      it 'responds with a 504 Gateway Timeout' do
+        get '/api/stateless/location'
+        expect(response.status).to eq(504)
+      end
+
+      after do
+        allow(Geocoder).to receive(:search).and_call_original
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why?**

We need to run some experiments from other sumofus.org domains (e.g. homepage), but we need to tap into Champaign's logic. In this case, we need location and currency information. Since getting the location blocks the request, it should be used sparingly.

**Details**

`GET /api/stateless/location` responds with `request.location` (Geocoder), extending it
with the currency for that country code, using `Donations::Utils.currency_from_country_code` for consistent behaviour with champaign pages.

When there’s a timeout (or when the location can’t be determined), we return a 504 Gateway Timeout error.