### PR TITLE
Performance boost for mobile

### DIFF
--- a/app/assets/javascripts/member-facing.js.erb
+++ b/app/assets/javascripts/member-facing.js.erb
@@ -8,6 +8,7 @@
 //= require shared/pub_sub
 //= require shared/show_errors
 //= require member-facing/registration
+//= require member-facing/image_display
 
 // external assets
 <% if Settings.external_js_path.present? %>

--- a/app/assets/javascripts/member-facing/image_display.js
+++ b/app/assets/javascripts/member-facing/image_display.js
@@ -1,0 +1,18 @@
+$(() => {
+  const $banner = $('.cover-photo');
+  const width = $(window).width();
+  const mobile_breakpoint = 480;
+  const data = $banner.data();
+  const tempImage = new Image();
+
+  tempImage.onload = () => {
+    $banner.css('backgroundImage', `url("${tempImage.src}")`);
+    $banner.addClass('visible');
+  };
+
+  if (width <= mobile_breakpoint) {
+    tempImage.src = data.mobileImage;
+  } else {
+    tempImage.src = data.desktopImage;
+  }
+});

--- a/app/assets/javascripts/member-facing/image_display.js
+++ b/app/assets/javascripts/member-facing/image_display.js
@@ -1,12 +1,12 @@
-$(() => {
-  const $banner = $('.cover-photo');
-  const width = $(window).width();
-  const mobile_breakpoint = 480;
-  const data = $banner.data();
-  const tempImage = new Image();
+$(function() {
+  var $banner = $('.cover-photo'),
+      width = $(window).width(),
+      mobile_breakpoint = 480,
+      data = $banner.data(),
+      tempImage = new Image();
 
-  tempImage.onload = () => {
-    $banner.css('backgroundImage', `url("${tempImage.src}")`);
+  tempImage.onload = function() {
+    $banner.css('backgroundImage', "url('" + tempImage.src + "')");
     $banner.addClass('visible');
   };
 

--- a/app/assets/stylesheets/member-facing/images.scss
+++ b/app/assets/stylesheets/member-facing/images.scss
@@ -1,0 +1,10 @@
+.cover-photo {
+  visibility: hidden;
+  opacity: 0;
+
+  &.visible {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.5s linear;
+  }
+}

--- a/app/assets/stylesheets/member-facing/images.scss
+++ b/app/assets/stylesheets/member-facing/images.scss
@@ -5,6 +5,6 @@
   &.visible {
     visibility: visible;
     opacity: 1;
-    transition: opacity 0.5s linear;
+    transition: opacity 0.2s linear;
   }
 }

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -137,7 +137,7 @@ class LiquidRenderer
 
   def image_urls(img)
     return { urls: { large: '', small: '', original: '' } } if img.blank? || img.content.blank?
-    { urls: { large: img.content.url(:large), small: img.content.url(:thumb), original: img.content.url(:original) } }
+    { urls: { large: img.content.url(:large), small: img.content.url(:thumb), mobile: img.content.url(:mobile), original: img.content.url(:original) } }
   end
 
   def follow_up_url

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -26,12 +26,14 @@ class Image < ActiveRecord::Base
                         thumb: '100x100#',
                         medium_square: ['700x500#', attachment.instance.decide_format],
                         facebook: ['1200x630>', attachment.instance.decide_format],
-                        large: ['1920x', attachment.instance.decide_format]
+                        large: ['1920x', attachment.instance.decide_format],
+                        mobile: ['480x', attachment.instance.decide_format],
                       }
                     },
                     convert_options: {
                       all: '-strip -interlace Plane',
-                      large: '-quality 80'
+                      large: '-quality 80',
+                      mobile: '-quality 60'
                     },
                     default_url: '/images/:style/missing.png'
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -27,7 +27,7 @@ class Image < ActiveRecord::Base
                         medium_square: ['700x500#', attachment.instance.decide_format],
                         facebook: ['1200x630>', attachment.instance.decide_format],
                         large: ['1920x', attachment.instance.decide_format],
-                        mobile: ['480x', attachment.instance.decide_format],
+                        mobile: ['480x', attachment.instance.decide_format]
                       }
                     },
                     convert_options: {

--- a/circle.yml
+++ b/circle.yml
@@ -50,7 +50,7 @@ deployment:
       - ./bin/build.sh
       - ./bin/deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch: development
+    branch: 'fix.mobile_performance'
     commands:
       - ./bin/build.sh
       - ./bin/deploy.sh $CIRCLE_SHA1 'champaign' 'champaign-staging' 'champaign-assets-staging' 'logs3.papertrailapp.com:34848' 'action-staging.sumofus.org'


### PR DESCRIPTION
- Adds new image size for mobile.
- Loads screen size dependent image asynchronously

@NealJMD our mobile performance score according to google is still really poor, and our banner image is the primary blocker. Here's my hack at fixing this. Please can you look it over and tell me what you think? It makes a massive difference to our score (from ~%55 to ~%95).

There's work to be done on sou-assets that I can wrap up on Monday. https://github.com/SumOfUs/sou-assets/pull/28 covers the full width header.

I think this is urgent and want to get something on production Monday.

![dfa101e1a2c14fd2f65b8cf6f152177b](https://cloud.githubusercontent.com/assets/12949/24058853/91eadcc8-0b44-11e7-85e0-7057fc08b7bb.gif)
