### PR TITLE
Locked airbrake-ruby to 1.7.1 to remove warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'rmagick' # rmagick for image processing
 # AWS SDK for Rails - makes SES integration easy
 gem 'actionkit_connector', git: 'https://github.com/SumOfUs/actionkit_connector', branch: 'master'
 gem 'airbrake', '~> 5.7.1'
+gem 'airbrake-ruby', '1.7.1'
 gem 'aws-sdk-rails'
 gem 'bootstrap-sass', '~> 3.3.5'
 gem 'browser', '~> 2.0', '>= 2.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     airbrake (5.7.1)
       airbrake-ruby (~> 1.7)
-    airbrake-ruby (1.8.0)
+    airbrake-ruby (1.7.1)
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
@@ -536,6 +536,7 @@ DEPENDENCIES
   actionkit_connector!
   activeadmin!
   airbrake (~> 5.7.1)
+  airbrake-ruby (= 1.7.1)
   annotate
   aws-sdk (~> 2)
   aws-sdk-rails


### PR DESCRIPTION
Context: 
https://github.com/airbrake/airbrake/issues/679#issuecomment-282472603