### PR TITLE
Fix one-click from URI error

### DIFF
--- a/lib/payment_processor/braintree/one_click_from_uri.rb
+++ b/lib/payment_processor/braintree/one_click_from_uri.rb
@@ -48,14 +48,15 @@ module PaymentProcessor::Braintree
     end
 
     def payment_method_id
-      cookied_payment_methods.split(',').each do |token|
-        pm = member.customer.payment_methods.find_by(token: token, cancelled_at: nil, store_in_vault: true)
-        if pm && pm.expiration_date.to_date > Date.today
-          return pm.id
-        end
-      end
-
-      false
+      member
+        .customer
+        .payment_methods
+        .stored
+        .active
+        .where(token: cookied_payment_methods.split(','))
+        .order('created_at DESC')
+        .first
+        &.id
     end
 
     def token_from_cookie

--- a/lib/payment_processor/braintree/one_click_from_uri.rb
+++ b/lib/payment_processor/braintree/one_click_from_uri.rb
@@ -48,6 +48,8 @@ module PaymentProcessor::Braintree
     end
 
     def payment_method_id
+      return nil unless member
+
       member
         .customer
         .payment_methods


### PR DESCRIPTION
OneClickFromUri was checking expiration date on all payment methods but
only credit / debit cards will have one (in the form of MM/YYYY).

We're now picking the most recently created "stored" and "active"
payment method, or returning nil.

The following error was triggered when trying to use expiration dates on
paypal payment methods:

```
[2017-04-11T16:34:29.450332 #6]  INFO -- : method=GET path=/a/beekeepers-bayer format=html controller=pages action=show status=500 error='NoMethodError: undefined method `to_date' for nil:NilClass' duration=15.12 view=0.00 db=9.44 params={"akid"=>"29405.7350357.ineo4F", "amount"=>"5", "currency"=>"GBP", "one_click"=>"true", "rd"=>"1", "source"=>"fwd", "t"=>"67", "id"=>"beekeepers-bayer"} time=2017-04-11 16:34:29 +0000 exception=["NoMethodError", "undefined method `to_date' for nil:NilClass"]
```

See: https://papertrailapp.com/groups/3855683/events?focus=788506320159563825&q=%28%22production.log%22+%28status%3D500+OR+status%3D504%29%29+-%22Braintree%3A%3AValidationsFailed%22&selected=788506320159563825