### PR TITLE
[Call tool] Allow manual target selection

### DIFF
--- a/app/frontend/containers/EmailTargetView/EmailTargetView.js
+++ b/app/frontend/containers/EmailTargetView/EmailTargetView.js
@@ -3,11 +3,11 @@ import _ from 'lodash';
 import $ from 'jquery';
 import { connect } from 'react-redux';
 import Select from '../../components/SweetSelect/SweetSelect';
-import './EmailTargetView.scss';
 import Input from '../../components/SweetInput/SweetInput';
 import Button from '../../components/Button/Button';
 import SelectCountry from '../../components/SelectCountry/SelectCountry';
 import { FormattedMessage } from 'react-intl';
+import './EmailTargetView.scss';
 
 import {
   changeCountry,
@@ -36,12 +36,12 @@ class EmailTargetView extends Component {
   }
 
   getPensionFunds(country: string) {
-    if(!country) return;
+    if (!country) return;
 
     const url = `/api/pension_funds?country=${country.toLowerCase()}`;
 
-    const handleSuccess = (data) => {
-      data.forEach((fund) => {
+    const handleSuccess = data => {
+      data.forEach(fund => {
         fund.value = fund._id;
         fund.label = fund.fund;
       });
@@ -60,59 +60,53 @@ class EmailTargetView extends Component {
   validateForm() {
     const errors = {};
 
-    const fields = [
-      'country',
-      'subject',
-      'name',
-      'email',
-      'fund'
-    ];
+    const fields = ['country', 'subject', 'name', 'email', 'fund'];
 
-    fields.forEach((field) => {
-      if(_.isEmpty(this.props[field])) {
+    fields.forEach(field => {
+      if (_.isEmpty(this.props[field])) {
         const location = `email_target.form.errors.${field}`;
         const message = <FormattedMessage id={location} />;
         errors[field] = message;
       }
     });
 
-    this.setState({errors: errors});
+    this.setState({ errors: errors });
     return _.isEmpty(errors);
   }
 
   render() {
     const errorNotice = () => {
-      if (!_.isEmpty(this.state.errors)){
+      if (!_.isEmpty(this.state.errors)) {
         return (
           <span className="error-msg left-align">
-            <FormattedMessage id='email_target.form.errors.message' />
+            <FormattedMessage id="email_target.form.errors.message" />
           </span>
         );
       }
     };
 
-    const parse = (template) => {
+    const parse = template => {
       template = template.replace(/(?:\r\n|\r|\n)/g, '<br />');
-      template= _.template(template);
+      template = _.template(template);
       return template(this.props);
     };
 
     const parseHeader = () => {
-      return {__html: parse(this.props.header)};
+      return { __html: parse(this.props.header) };
     };
 
     const parseFooter = () => {
-      return {__html: parse(this.props.footer)};
+      return { __html: parse(this.props.footer) };
     };
 
-    const changeFund = (value) => {
-      const contact = _.find(this.props.pensionFunds, {_id: value});
+    const changeFund = value => {
+      const contact = _.find(this.props.pensionFunds, { _id: value });
       this.props.changeFund(contact);
     };
 
     const showFundSuggestion = () => {
-      if (this.state.shouldShowFundSuggestion){
-        return(
+      if (this.state.shouldShowFundSuggestion) {
+        return (
           <p>
             <FormattedMessage id="email_target.suggest_fund" />
           </p>
@@ -120,9 +114,10 @@ class EmailTargetView extends Component {
       }
     };
 
-    const prepBody = () => `${parseHeader().__html}\n\n${this.props.body}\n\n${parseFooter().__html}`;
+    const prepBody = () =>
+      `${parseHeader().__html}\n\n${this.props.body}\n\n${parseFooter().__html}`;
 
-    const onSubmit = (e) => {
+    const onSubmit = e => {
       e.preventDefault();
 
       const valid = this.validateForm();
@@ -143,94 +138,170 @@ class EmailTargetView extends Component {
 
       this.props.changeSubmitting(true);
 
-      $.post('/api/email_targets', payload).done((a,b,c) => {});
+      $.post('/api/email_targets', payload).done((a, b, c) => {});
     };
 
-    return(
-      <div className='email-target'>
-        <div className='email-target-form'>
-        <form onSubmit={onSubmit} className='action-form form--big'>
-          <div className='email-target-action'>
-            <div className='form__group'>
-              <SelectCountry
-                value={this.props.country}
-                name='country'
-                filter={["AU", "BE", "CA", "CH", "DE", "DK", "ES", "FI", "FR", "GB", "IE", "IS", "IT", "NL", "NO", "PT", "SE", "US"]}
-                label={<FormattedMessage id="email_target.form.select_country" defaultMessage="Select country (default)" />}
-                className='form-control'
-                errorMessage={this.state.errors.country}
-                onChange={this.changeCountry.bind(this)} />
+    return (
+      <div className="email-target">
+        <div className="email-target-form">
+          <form onSubmit={onSubmit} className="action-form form--big">
+            <div className="email-target-action">
+              <div className="form__group">
+                <SelectCountry
+                  value={this.props.country}
+                  name="country"
+                  filter={[
+                    'AU',
+                    'BE',
+                    'CA',
+                    'CH',
+                    'DE',
+                    'DK',
+                    'ES',
+                    'FI',
+                    'FR',
+                    'GB',
+                    'IE',
+                    'IS',
+                    'IT',
+                    'NL',
+                    'NO',
+                    'PT',
+                    'SE',
+                    'US',
+                  ]}
+                  label={
+                    <FormattedMessage
+                      id="email_target.form.select_country"
+                      defaultMessage="Select country (default)"
+                    />
+                  }
+                  className="form-control"
+                  errorMessage={this.state.errors.country}
+                  onChange={this.changeCountry.bind(this)}
+                />
+              </div>
+
+              <div className="form__group">
+                <Select
+                  className="form-control"
+                  value={this.props.fundId}
+                  onChange={changeFund}
+                  errorMessage={this.state.errors.fund}
+                  label={
+                    <FormattedMessage
+                      id="email_target.form.select_target"
+                      defaultMessage="Select a fund (default)"
+                    />
+                  }
+                  name="select-fund"
+                  options={this.props.pensionFunds}
+                />
+              </div>
+              <div className="email__target-suggest-fund">
+                <p>
+                  <a
+                    onClick={() =>
+                      this.setState({
+                        shouldShowFundSuggestion: !this.state.shouldShowFundSuggestion,
+                      })}
+                  >
+                    Can't find your pension fund?
+                  </a>
+                </p>
+                {showFundSuggestion()}
+              </div>
+            </div>
+            <div className="email-target-action">
+              <h3>
+                <FormattedMessage
+                  id="email_target.section.compose"
+                  defaultMessage="Compose Your Email"
+                />
+              </h3>
+
+              <div className="form__group">
+                <Input
+                  name="email_subject"
+                  errorMessage={this.state.errors.subject}
+                  value={this.props.subject}
+                  label={
+                    <FormattedMessage
+                      id="email_target.form.subject"
+                      defaultMessage="Subejct (default)"
+                    />
+                  }
+                  onChange={value => this.props.changeSubject(value)}
+                />
+              </div>
+
+              <div className="form__group">
+                <Input
+                  name="name"
+                  label={
+                    <FormattedMessage
+                      id="email_target.form.your_name"
+                      defaultMessage="Your name (default)"
+                    />
+                  }
+                  value={this.props.name}
+                  errorMessage={this.state.errors.name}
+                  onChange={value => this.props.changeName(value)}
+                />
+              </div>
+
+              <div className="form__group">
+                <Input
+                  name="email"
+                  label={
+                    <FormattedMessage
+                      id="email_target.form.your_email"
+                      defaultMessage="Your email (default)"
+                    />
+                  }
+                  value={this.props.email}
+                  errorMessage={this.state.errors.country}
+                  onChange={value => this.props.changeEmail(value)}
+                />
+              </div>
+
+              <div className="form__group">
+                <div className="email__target-body">
+                  <div
+                    className="email__target-header"
+                    dangerouslySetInnerHTML={parseHeader()}
+                  />
+                  <textarea
+                    name="email_body"
+                    value={this.props.body}
+                    onChange={event =>
+                      this.props.changeBody(event.currentTarget.value)}
+                    maxLength="9999"
+                  />
+                  <div
+                    className="email__target-footer"
+                    dangerouslySetInnerHTML={parseFooter()}
+                  />
+                </div>
+              </div>
             </div>
 
-            <div className='form__group'>
-              <Select className='form-control'
-                value={this.props.fundId}
-                onChange={changeFund}
-                errorMessage={this.state.errors.fund}
-                label={<FormattedMessage id="email_target.form.select_target" defaultMessage="Select a fund (default)" />}
-                name='select-fund' options={this.props.pensionFunds} />
+            <div className="form__group">
+              <Button
+                disabled={this.props.isSubmitting}
+                className="button action-form__submit-button"
+              >
+                <FormattedMessage
+                  id="email_target.form.send_email"
+                  defaultMessage="Send email (default)"
+                />
+              </Button>
+              {errorNotice()}
             </div>
-            <div className='email__target-suggest-fund'>
-              <p><a onClick={() => this.setState({shouldShowFundSuggestion: !this.state.shouldShowFundSuggestion})} >Can't find your pension fund?</a></p>
-              { showFundSuggestion() }
-            </div>
-          </div>
-          <div className='email-target-action'>
-            <h3>
-              <FormattedMessage id="email_target.section.compose" defaultMessage="Compose Your Email" />
-            </h3>
-
-            <div className='form__group'>
-              <Input
-                name='email_subject'
-                errorMessage={this.state.errors.subject}
-                value={this.props.subject}
-                label={<FormattedMessage id="email_target.form.subject" defaultMessage="Subejct (default)" />}
-                onChange={(value) => this.props.changeSubject(value)} />
-            </div>
-
-          <div className='form__group'>
-            <Input
-              name='name'
-              label={<FormattedMessage id="email_target.form.your_name" defaultMessage="Your name (default)" />}
-              value={this.props.name}
-              errorMessage={this.state.errors.name}
-              onChange={(value) => this.props.changeName(value)} />
-          </div>
-
-          <div className='form__group'>
-            <Input
-              name='email'
-              label={<FormattedMessage id="email_target.form.your_email" defaultMessage="Your email (default)" />}
-              value={this.props.email}
-              errorMessage={this.state.errors.country}
-              onChange={(value) => this.props.changeEmail(value) } />
-          </div>
-
-          <div className='form__group'>
-            <div className='email__target-body'>
-            <div className='email__target-header' dangerouslySetInnerHTML={parseHeader()}></div>
-            <textarea
-              name='email_body'
-              value={this.props.body}
-              onChange={(event) => this.props.changeBody(event.currentTarget.value)}
-              maxLength="9999">
-            </textarea>
-            <div className='email__target-footer' dangerouslySetInnerHTML={parseFooter()}></div>
-          </div>
-          </div>
+          </form>
         </div>
 
-        <div className='form__group'>
-          <Button disabled={this.props.isSubmitting} className='button action-form__submit-button'>
-            <FormattedMessage id="email_target.form.send_email" defaultMessage="Send email (default)" />
-          </Button>
-          {errorNotice()}
-        </div>
-      </form>
       </div>
-
-    </div>
     );
   }
 }
@@ -251,11 +322,11 @@ type EmailTargetType = {
   fundContact: string,
   fundEmail: string,
   page: string,
-}
+};
 
 type OwnState = {
   emailTarget: EmailTargetType,
-}
+};
 
 export const mapStateToProps = (state: OwnState) => ({
   body: state.emailTarget.emailBody,
@@ -284,7 +355,8 @@ export const mapDispatchToProps = (dispatch: Dispatch<*>) => ({
 
   changeSubmitting: (value: boolean) => dispatch(changeSubmitting(true)),
   changeSubject: (subject: string) => dispatch(changeSubject(subject)),
-  changePensionFunds: (pensionFunds: Array<string>) => dispatch(changePensionFunds(pensionFunds)),
+  changePensionFunds: (pensionFunds: Array<string>) =>
+    dispatch(changePensionFunds(pensionFunds)),
 
   changeName: (name: string) => {
     dispatch(changeName(name));

--- a/app/models/plugins/call_tool.rb
+++ b/app/models/plugins/call_tool.rb
@@ -22,6 +22,7 @@
 #  menu_sound_clip_file_size    :integer
 #  menu_sound_clip_updated_at   :datetime
 #  restricted_country_code      :string
+#  allow_manual_target_selection :boolean         default(FALSE)
 #
 
 class Plugins::CallTool < ActiveRecord::Base
@@ -109,7 +110,8 @@ class Plugins::CallTool < ActiveRecord::Base
         countries: countries,
         countries_phone_codes: countries_phone_codes,
         title: obj.title,
-        description: obj.description
+        description: obj.description,
+        allow_manual_target_selection: obj.allow_manual_target_selection
       }
     end
 

--- a/app/views/plugins/call_tools/_form.slim
+++ b/app/views/plugins/call_tools/_form.slim
@@ -15,6 +15,11 @@
       .form-group
         = label_with_tooltip(f, :restricted_country_code, t('plugins.call_tool.restricted_country_code'), t('tooltips.call_tool.restricted_country_code'))
         = f.select :restricted_country_code, ISO3166::Country.all.map {|c| [c.name, c.alpha2]}, { include_blank: true }, class: 'form-control restricted_country_code'
+      .form-group
+        label
+          = t('plugins.call_tool.allow_manual_target_selection')
+          | &nbsp;
+          = f.check_box :allow_manual_target_selection
 
     .well.targets-section
       = render partial: 'plugins/call_tools/target_form.slim', locals: { plugin: plugin }

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -327,6 +327,7 @@ en:
       show_targets: 'Show Targets'
       restricted_country_code: 'Restrict calls to'
       target_by_country: 'Target by country'
+      allow_manual_target_selection: "Allow manual target selection"
       targets:
         country: 'Country'
         postal: 'Postal Code'
@@ -370,5 +371,3 @@ en:
     domain: 'Domain'
     path: 'Path'
     page: 'Page'
-
-

--- a/db/migrate/20170419205020_add_allow_manual_target_selection_to_plugins_call_tool.rb
+++ b/db/migrate/20170419205020_add_allow_manual_target_selection_to_plugins_call_tool.rb
@@ -1,0 +1,5 @@
+class AddAllowManualTargetSelectionToPluginsCallTool < ActiveRecord::Migration
+  def change
+    add_column :plugins_call_tools, :allow_manual_target_selection, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170406200345) do
+ActiveRecord::Schema.define(version: 20170419205020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -428,18 +428,19 @@ ActiveRecord::Schema.define(version: 20170406200345) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "title"
-    t.json     "targets",                      default: [],   array: true
     t.string   "sound_clip_file_name"
     t.string   "sound_clip_content_type"
     t.integer  "sound_clip_file_size"
     t.datetime "sound_clip_updated_at"
+    t.json     "targets",                       default: [],    array: true
     t.text     "description"
-    t.boolean  "target_by_country",            default: true
+    t.boolean  "target_by_country",             default: true
     t.string   "menu_sound_clip_file_name"
     t.string   "menu_sound_clip_content_type"
     t.integer  "menu_sound_clip_file_size"
     t.datetime "menu_sound_clip_updated_at"
     t.string   "restricted_country_code"
+    t.boolean  "allow_manual_target_selection", default: false
   end
 
   create_table "plugins_email_targets", force: :cascade do |t|


### PR DESCRIPTION
When the feature is enabled in a page with the Caller template, it displays a dropdown with the list of targets for the selected country. The user must select a country and the page must also be configured to target by country.