### PR TITLE
Allow referring_id to be passed as rid

### DIFF
--- a/app/assets/javascripts/member-facing/backbone/action_form.js
+++ b/app/assets/javascripts/member-facing/backbone/action_form.js
@@ -5,7 +5,7 @@ const GlobalEvents = require('shared/global_events');
 const ActionForm = Backbone.View.extend({
 
   el: 'form.action-form',
-  HIDDEN_FIELDS: ['source', 'akid', 'referrer_id', 'bucket', 'referring_akid'],
+  HIDDEN_FIELDS: ['source', 'akid', 'referrer_id', 'rid', 'bucket', 'referring_akid'],
 
   events: {
     'click .action-form__clear-form': 'clearForm',

--- a/app/assets/javascripts/member-facing/backbone/survey.js
+++ b/app/assets/javascripts/member-facing/backbone/survey.js
@@ -5,7 +5,7 @@ const GlobalEvents = require('shared/global_events');
 const Survey = Backbone.View.extend({
 
   el: '.survey',
-  HIDDEN_FIELDS: ['source', 'referrer_id', 'akid', 'referring_akid'],
+  HIDDEN_FIELDS: ['source', 'referrer_id', 'rid', 'akid', 'referring_akid'],
   DEFAULT_SCROLL_OFFSET: 80,
 
   events: {

--- a/app/controllers/api/actions_controller.rb
+++ b/app/controllers/api/actions_controller.rb
@@ -42,7 +42,7 @@ class Api::ActionsController < ApplicationController
   end
 
   def base_params
-    %w(page_id form_id name source akid referring_akid referrer_id bucket)
+    %w(page_id form_id name source akid referring_akid referrer_id rid bucket)
   end
 
   def fields

--- a/app/controllers/api/email_targets_controller.rb
+++ b/app/controllers/api/email_targets_controller.rb
@@ -37,6 +37,7 @@ class Api::EmailTargetsController < ApplicationController
       akid: params[:akid],
       referring_akid: params[:referring_akid],
       referrer_id: params[:referrer_id],
+      rid: params[:rid],
       source: params[:source]
     }
   end

--- a/app/controllers/api/survey_responses_controller.rb
+++ b/app/controllers/api/survey_responses_controller.rb
@@ -23,7 +23,7 @@ class Api::SurveyResponsesController < ApplicationController
   end
 
   def survey_response_params
-    params.slice(*form.form_elements.map(&:name), 'akid', 'source', 'referring_akid', 'referrer_id')
+    params.slice(*form.form_elements.map(&:name), 'akid', 'source', 'referring_akid', 'rid', 'referrer_id')
   end
 
   def form

--- a/app/frontend/components/MemberDetailsForm/MemberDetailsForm.js
+++ b/app/frontend/components/MemberDetailsForm/MemberDetailsForm.js
@@ -36,7 +36,7 @@ export class MemberDetailsForm extends Component {
 
   static title = <FormattedMessage id="details" defaultMessage="details" />;
 
-  HIDDEN_FIELDS = ['source', 'akid', 'referrer_id', 'bucket', 'referring_akid'];
+  HIDDEN_FIELDS = ['source', 'akid', 'referrer_id', 'rid', 'bucket', 'referring_akid'];
 
   constructor(props: OwnProps) {
     super(props);

--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -2,7 +2,7 @@
 class LiquidRenderer
   include Rails.application.routes.url_helpers
 
-  HIDDEN_FIELDS = %w(source bucket referrer_id akid referring_akid).freeze
+  HIDDEN_FIELDS = %w(source bucket referrer_id rid akid referring_akid).freeze
 
   def initialize(page, location: nil, member: nil, url_params: {}, payment_methods: [])
     @page = page

--- a/app/services/action_builder.rb
+++ b/app/services/action_builder.rb
@@ -74,6 +74,7 @@ module ActionBuilder
     @params.tap do |params|
       member = nil
       member = Member.find_by_akid(params[:referring_akid]) if params[:referring_akid].present?
+      member = Member.find_by(id: params[:rid]) if params[:rid].present?
       member = Member.find_by(id: params[:referrer_id]) if params[:referrer_id].present?
       params[:action_referrer_email] = member.email if member.try(:email).present?
     end

--- a/app/views/plugins/fundraisers/_fundraiser.liquid
+++ b/app/views/plugins/fundraisers/_fundraiser.liquid
@@ -137,6 +137,7 @@
           location:          chmp.personalization.location,
           akid:              chmp.personalization.urlParams.akid,
           referring_akid:    chmp.personalization.urlParams.referring_akid,
+          rid:               chmp.personalization.urlParams.rid,
           source:            chmp.personalization.urlParams.source,
           referrer_id:       chmp.personalization.urlParams.referrer_id,
           bucket:            chmp.personalization.urlParams.bucket,

--- a/app/views/plugins/petitions/_petition.liquid
+++ b/app/views/plugins/petitions/_petition.liquid
@@ -32,6 +32,7 @@
           referring_akid:   chmp.personalization.urlParams.referring_akid,
           source:           chmp.personalization.urlParams.source,
           referrer_id:      chmp.personalization.urlParams.referrer_id,
+          rid:              chmp.personalization.urlParams.rid,
           bucket:           chmp.personalization.urlParams.bucket,
           prefill:          true
         });

--- a/spec/liquid/liquid_renderer_spec.rb
+++ b/spec/liquid/liquid_renderer_spec.rb
@@ -372,7 +372,7 @@ describe LiquidRenderer do
 
       it 'allows all the hidden field params' do
         fundraiser # lazy eval
-        hiddens = { akid: 'a', bucket: 'b', source: 'c', referrer_id: 'd', referring_akid: 'e' }
+        hiddens = { akid: 'a', bucket: 'b', source: 'c', referrer_id: 'd', referring_akid: 'e', rid: 'f' }
         url_params.merge!(hiddens)
         renderer = LiquidRenderer.new(page, member: member, url_params: url_params)
         expected = { country: 'NI', email: 'sup@dude.com' }.merge(hiddens)

--- a/spec/services/action_builder_spec.rb
+++ b/spec/services/action_builder_spec.rb
@@ -223,32 +223,32 @@ describe ActionBuilder do
     let(:akid) { '1234.5678.tKK7gX' }
     let(:ak_user_id) { akid.split('.')[1] }
 
-    describe 'is not added if referrer_id' do
+    describe 'is not added if rid' do
       it 'is not included' do
         action = MockActionBuilder.new(base_params).build_action
         expect(action.form_data.keys).not_to include('action_referrer_email')
       end
 
       it 'is blank' do
-        action = MockActionBuilder.new(base_params.merge(referrer_id: '')).build_action
+        action = MockActionBuilder.new(base_params.merge(rid: '')).build_action
         expect(action.form_data.keys).not_to include('action_referrer_email')
       end
 
       it "is an id of a member that doesn't exist" do
-        action = MockActionBuilder.new(base_params.merge(referrer_id: 1_234_567_890)).build_action
+        action = MockActionBuilder.new(base_params.merge(rid: 1_234_567_890)).build_action
         expect(action.form_data.keys).not_to include('action_referrer_email')
       end
 
       it 'is an id of a member with no email' do
         m2 = create :member, email: ''
-        action = MockActionBuilder.new(base_params.merge(referrer_id: m2.id)).build_action
+        action = MockActionBuilder.new(base_params.merge(rid: m2.id)).build_action
         expect(action.form_data.keys).not_to include('action_referrer_email')
       end
     end
 
-    it 'is added to form_data if referrer_id is the id of a member' do
+    it 'is added to form_data if rid is the id of a member' do
       m2 = create :member, email: 'asdf@hjkl.com'
-      action = MockActionBuilder.new(base_params.merge(referrer_id: m2.id)).build_action
+      action = MockActionBuilder.new(base_params.merge(rid: m2.id)).build_action
       expect(action.form_data['action_referrer_email']).to eq 'asdf@hjkl.com'
     end
 
@@ -258,13 +258,22 @@ describe ActionBuilder do
       expect(action.form_data['action_referrer_email']).to eq 'qwer@hjkl.com'
     end
 
-    it 'adds the email of a matching referrer_id if both referrer_id and referring_akid are present' do
+    it 'adds the email of a matching rid if both rid and referring_akid are present' do
       m2 = create :member, email: 'asdf@hjkl.com'
       m3 = create :member, email: 'qwer@hjkl.com', actionkit_user_id: ak_user_id
       action = MockActionBuilder.new(base_params.merge(
-        referrer_id: m2.id, referring_akid: akid
+        rid: m2.id, referring_akid: akid
       )).build_action
-      expect(action.form_data['action_referrer_email']).to eq 'asdf@hjkl.com'
+      expect(action.form_data['action_referrer_email']).to eq m2.email
+    end
+
+    it 'adds the email of a matching referring_id if both rid and referrer_id are present' do
+      m2 = create :member, email: 'asdf@hjkl.com'
+      m3 = create :member, email: 'qwer@hjkl.com'
+      action = MockActionBuilder.new(base_params.merge(
+        rid: m2.id, referrer_id: m3.id
+      )).build_action
+      expect(action.form_data['action_referrer_email']).to eq m3.email
     end
   end
 end


### PR DESCRIPTION
Currently, when someone shares one of our pages with a ShareProgress button, the URL they share is of the form `http://sumof.us/309191623t?referrer_id=14282164`. This is fine for facebook, but uses excessive characters on twitter and the `referrer_id` looks weird. This PR will make it work with referrer_id or rid so that the URLs can have the form `http://sumof.us/309191623t?rid=14282164`.

I'm looking to get this live on prod by tomorrow :D