### PR TITLE
Renamed cloudfront_url  to asset_host for consistency

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = Settings.cloudfront_url
+  config.action_controller.asset_host = Settings.asset_host
   config.assets.prefix = '/assets'
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -95,7 +95,7 @@ Rails.application.configure do
     storage: :s3,
     s3_region: Settings.aws_region,
     s3_host_name: Settings.s3_host_name,
-    s3_host_alias: Settings.cloudfront_url,
+    s3_host_alias: Settings.asset_host,
     s3_protocol: 'https',
     path: '/:class/:attachment/:id_partition/:style/:filename',
     url: ':s3_alias_url',

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,9 +37,7 @@
 #    ak_password: 'Just like ak_username.'
 
 
-# CloudFront config Variables. These variables are used to configure static asset serving via cloudfront, a CDN. Disabled
-# by default in development, they should be overridden in production settings to speed up Champaign's page performance.
-#    cloudfront_url: 'the url of your cloudfront distribution'
+#    asset_host: 'localhost:3000'
 #    s3_asset_bucket: 'your s3 bucket'
 #    rails_serve_static_assets: 'Should Rails serve your static assets?'
 #    compile_static: 'Should Rails compile your static assets on the run if the requested asset is missing?'

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -19,12 +19,10 @@ ak_username: username
 ak_password: password
 
 
-# CloudFront config Variables.
-cloudfront_url: your-cloudfront-url
+# Assets config
 s3_asset_bucket: your-asset-bucket
 rails_serve_static_assets: true
 compile_static: true
-
 asset_host: 'localhost:3000'
 webpack_host: 'localhost'
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -25,9 +25,8 @@ ak_password: <%= ENV['AK_PASSWORD'] %>
 action_kit:
   akid_secret: <%= ENV['AKID_SECRET'] %>
 
-
-# CloudFront config Variables.
-cloudfront_url: <%= ENV['CLOUDFRONT_URL'] %>
+# Assets config
+asset_host: <%= ENV['ASSET_HOST'] %>
 s3_asset_bucket: <%= ENV['S3_ASSET_BUCKET'] %>
 rails_serve_static_assets: <%= ENV['RAILS_SERVE_STATIC_ASSETS'] %>
 compile_static: <%= ENV['COMPILE_STATIC'] %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -39,14 +39,10 @@ ak_api_url: 'https://act.sumofus.org/rest/v1'
 ak_username: 'ak_username'
 ak_password: 'ak_password'
 
-
-# CloudFront config Variables. These variables are used to configure static asset serving via cloudfront, a CDN. Disabled
-# by default in development, they should be overridden in production settings to speed up Champaign's page performance.
-cloudfront_url: 'http://fake-cloudfront.com'
+# Assets config
 s3_asset_bucket: 'fake_s3_asset_bucket'
 rails_serve_static_assets: false
 compile_static: false
-
 
 # NewRelic Connection information. This variable, if set to a valid value, will cause the NewRelic connector to send
 # performance and error information to the NewRelic Dashboard. Disabled by default, except in production.


### PR DESCRIPTION
I updated the `cloudfront_url` settings to `asset_host` for two reasons:

* The cloudfront_url setting is being used to set the asset host url, and it's nothing more than a URL. So, naming it after the service we particularly use to server assets doesn't make sense.
* In production we use `Settings.cloudfront_url` while on dev and test we use `Settings.asset_host`. I think it's a good idea to have all environments use the same option name for consistency

**Important** I also renamed the env var from CLOUDFRONT_URL to ASSET_HOST, so if we merge this we need to remember to rename that env var when deploying.