### PR TITLE
allow survey auto-advance to be turned off

### DIFF
--- a/app/assets/javascripts/member-facing/backbone/survey.js
+++ b/app/assets/javascripts/member-facing/backbone/survey.js
@@ -21,6 +21,9 @@ const Survey = Backbone.View.extend({
   //    referring_akid: the AK id of the referrer
   //    prefill: an object with fields that will prefill the form
   //    followUpUrl: the url to redirect to after the survey is completed
+  //    autoAdvance: if the page has all the data necessary to complete the first
+  //      form section by the time the page loads (eg from url params) then if this
+  //      param is truthy, the page will automatically scroll.
   //    scrollOffset: the gap to leave between the top of the browser
   //      window and the start of a form when scrolling down. default is 80
   initialize(options={}) {
@@ -30,7 +33,7 @@ const Survey = Backbone.View.extend({
     this.insertHiddenFields(options);
     this.prefill(options.prefill);
     this.revealFirstForm();
-    this.submitFirstFormIfComplete();
+    if (options.autoAdvance) this.submitFirstFormIfComplete();
     this.followUpUrl = options.followUpUrl;
     if (!MobileCheck.isMobile()) {
       this.selectizeDropdowns();

--- a/app/views/plugins/surveys/_form.slim
+++ b/app/views/plugins/surveys/_form.slim
@@ -12,6 +12,14 @@
         .form-group
           = f.submit t('plugins.survey.create_form'), class: 'btn btn-default xhr-feedback'
 
+      - name = "plugins_survey_#{plugin.id}"
+      = form_for plugin, url: plugins_survey_path(plugin), remote: true, as: name, html: {class: 'plugin-settings one-form activation-toggle', data: {type: name }} do |f|
+        = render 'plugins/shared/plugin_metadata', f: f
+        label.edit-page-checkbox
+          = f.check_box :auto_advance
+          = t('plugins.survey.auto_advance')
+        = render 'tooltip', tooltip_text: t('tooltips.auto_advance'), space_left: true
+
     .plugin-form-preview.col-md-5
       h4 Preview
       .content

--- a/app/views/plugins/surveys/_survey.liquid
+++ b/app/views/plugins/surveys/_survey.liquid
@@ -34,6 +34,7 @@
           source:           window.champaign.personalization.urlParams.source,
           akid:             window.champaign.personalization.urlParams.akid,
           referring_akid:   window.champaign.personalization.urlParams.referring_akid,
+          autoAdvance:      ("{{ plugins.survey[ref].auto_advance }}" == "true"),
           followUpUrl:      "{{ follow_up_url }}"
         });
       });

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -76,6 +76,7 @@ en:
     canonical_url: "If a page is accessible through multiple URLs, then pick the best one for SEO. Defaults to https://our.site/a/page-slug"
     optimizely_status: "Optimizely can be slow to load, but we load it on all pages so we can run site-wide experiments. Please only disable for exceptional pages like microsites."
     publish_actions: 'Use this to make member responses to the page accessible through the API.'
+    auto_advance: "Enabling this option allows you to put the first question in the email someone receives, and then to skip to the second question on page load if that response is detected."
     shares:
       link_explanation: "Please keep the {LINK} in your text. Champaign will replace this with the actual link to your page."
       new: "Once you have uploaded the photos you want to test, use this box to create your shares. Champaign will use ShareProgress to serve the best-performing version when there's a winner."
@@ -300,6 +301,7 @@ en:
     survey:
       customise_form: "Edit survey section"
       create_form: "Add a new section to survey"
+      auto_advance: "Automatically skip first section if data is pre-filled"
     fundraiser:
       donation_band: "Default donation band for unknown user"
       title: "Title (eg 'Donate now')"

--- a/db/migrate/20170626194936_add_auto_advance_to_plugins_surveys.rb
+++ b/db/migrate/20170626194936_add_auto_advance_to_plugins_surveys.rb
@@ -1,0 +1,5 @@
+class AddAutoAdvanceToPluginsSurveys < ActiveRecord::Migration
+  def change
+    add_column :plugins_surveys, :auto_advance, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170504213048) do
+ActiveRecord::Schema.define(version: 20170626194936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -500,10 +500,11 @@ ActiveRecord::Schema.define(version: 20170504213048) do
 
   create_table "plugins_surveys", force: :cascade do |t|
     t.integer  "page_id"
-    t.boolean  "active",     default: false
+    t.boolean  "active",       default: false
     t.string   "ref"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "auto_advance", default: true
   end
 
   add_index "plugins_surveys", ["page_id"], name: "index_plugins_surveys_on_page_id", using: :btree


### PR DESCRIPTION
Adds a missing feature to the survey tool (which I need for a survey we're sending tomorrow) to allow the auto-advance feature to be turned off. I've checked it on staging and it looks good.