### PR TITLE
Added ak_integration_enabled flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,7 @@ coverage/
 # Ignore uploads
 public/uploads*
 
-env.yml
-config/env.yml
+.env
 
 queue_listeners/config/env.yml
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@
 source 'https://rubygems.org'
 ruby '2.4.1'
 
+gem 'dotenv-rails', groups: [:development, :test]
 gem 'aasm'
 gem 'activeadmin', git: 'https://github.com/activeadmin/activeadmin'
 gem 'bcrypt', '~> 3.1.7'
@@ -51,7 +52,6 @@ gem 'bootstrap-sass', '~> 3.3.5'
 gem 'browser', '~> 2.0', '>= 2.0.3'
 gem 'compass-rails' # was using git master branch before
 gem 'config'
-gem 'envyable', require: 'envyable/rails-now'
 gem 'friendly_id'
 gem 'jwt'
 gem 'logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,8 +196,10 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
-    envyable (1.2.0)
-      thor (>= 0.18.1, < 2.0)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubi (1.6.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
@@ -581,7 +583,7 @@ DEPENDENCIES
   coveralls (~> 0.8.20)
   database_cleaner
   devise
-  envyable
+  dotenv-rails
   factory_girl_rails
   faker
   font-awesome-sass

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,3 @@
 //= require summernote
 
 window.champaign = window.champaign || {};
-window.champaign.configuration = {
-  actionKitEnabled: <%= !!Settings.ak_integration_enabled %>
-};

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -17,3 +17,8 @@
 //= require codemirror/modes/xml
 //= require codemirror/modes/css
 //= require summernote
+
+window.champaign = window.champaign || {};
+window.champaign.configuration = {
+  actionKitEnabled: <%= !!Settings.ak_integration_enabled %>
+};

--- a/app/javascript/campaigner_facing/page.js
+++ b/app/javascript/campaigner_facing/page.js
@@ -21,6 +21,8 @@ const slugView = Backbone.View.extend({
     submit: 'submit',
   },
 
+  slugCheckEnabled: window.champaign.configuration.actionKitEnabled,
+
   initialize() {
     this.slugChecker = new slugChecker();
     this.slugChecker.on('change:valid', _.bind(this.updateViewWithValid, this));
@@ -108,7 +110,7 @@ const slugView = Backbone.View.extend({
 
     this.$checkButton.text('Checking...').addClass('disabled');
 
-    if (!this.slugChecker.get('valid')) {
+    if (this.slugCheckEnabled && !this.slugChecker.get('valid')) {
       this.checkSlugAvailable(e, () => {
         if (this.slugChecker.get('valid')) {
           this.$el.unbind();

--- a/app/javascript/campaigner_facing/page.js
+++ b/app/javascript/campaigner_facing/page.js
@@ -21,8 +21,6 @@ const slugView = Backbone.View.extend({
     submit: 'submit',
   },
 
-  slugCheckEnabled: window.champaign.configuration.actionKitEnabled,
-
   initialize() {
     this.slugChecker = new slugChecker();
     this.slugChecker.on('change:valid', _.bind(this.updateViewWithValid, this));
@@ -110,7 +108,7 @@ const slugView = Backbone.View.extend({
 
     this.$checkButton.text('Checking...').addClass('disabled');
 
-    if (this.slugCheckEnabled && !this.slugChecker.get('valid')) {
+    if (process.env.AK_API_URL && !this.slugChecker.get('valid')) {
       this.checkSlugAvailable(e, () => {
         if (this.slugChecker.get('valid')) {
           this.$el.unbind();

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -14,6 +14,7 @@ action_kit:
   akid_secret: secret-sauce
 
 # Direct ActionKit Connection variables.
+ak_integration_enabled: false
 ak_api_url: 'http://actionkit_api_url.com'
 ak_username: username
 ak_password: password

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -14,10 +14,9 @@ action_kit:
   akid_secret: secret-sauce
 
 # Direct ActionKit Connection variables.
-ak_integration_enabled: false
-ak_api_url: 'http://actionkit_api_url.com'
-ak_username: username
-ak_password: password
+ak_api_url: <%= ENV['AK_API_URL'] %>
+ak_username: <%= ENV['AK_USERNAME'] %>
+ak_password: <%= ENV['AK_PASSWORD'] %>
 
 
 # Assets config

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -16,6 +16,7 @@ ak_processor_url: <%= ENV['AK_PROCESSOR_URL'] %>
 
 
 # Direct ActionKit Connection variables.
+ak_integration_enabled: <%= ENV['AK_INTEGRATION_ENABLED'] %>
 ak_api_url: <%= ENV['AK_API_URL'] %>
 ak_ui_url: <%= ENV['AK_UI_URL'] %>
 ak_username: <%= ENV['AK_USERNAME'] %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -35,6 +35,7 @@ ak_processor_url: 'http://example.com'
 
 
 # Direct ActionKit Connection variables.
+ak_integration_enabled: true
 ak_api_url: 'https://act.sumofus.org/rest/v1'
 ak_username: 'ak_username'
 ak_password: 'ak_password'

--- a/config/webpack/app-config.js
+++ b/config/webpack/app-config.js
@@ -1,4 +1,4 @@
-require('dotenv').config({ path: 'env.yml' });
+require('dotenv').config();
 const webpack = require('webpack');
 
 module.exports = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ web:
     PG_USERNAME: postgres
     PG_HOST: db
   env_file:
-    - env.yml
+    - .env
 
 db:
   image: postgres
@@ -25,4 +25,3 @@ redis:
   image: redis
   ports:
     - "6379"
-


### PR DESCRIPTION
* Checking slug on page creation only if the flag is enabled

**Notes**

* I added a global `champaign.configuration` object to store the setting that says whether the ak integration is enabled or not. This value comes from an ENV var set via the `Settings` object. I don't like the idea of using a global object, and thought of doing this through webpack, but then the ENV var should be in .env instead of Settings. What I don't like about this is that the configuration for champaign is starting to live in two different places: `Settings` and .env. I'd be a great idea to unify this.

* Also, I think I found a bug with the slug checker. If I create a page with title "Rodri test", action kit creates two pages: 'rodri-test-petition' and 'rodri-test-donation', but the slug that actually get's checked is 'rodri-test', which is never actually created. 


