### PR TITLE
Improving the docker-compose / docker experience

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,11 @@
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 .gitignore
-.git
-log
+.git/*
+log/*
+tmp/*
+public/packs
+public/packs-test
+Dockerfile
 node_modules
 vendor/bundle

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,0 +1,18 @@
+FROM starefossen/ruby-node:2-8
+
+ENV APP_ROOT /champaign
+
+RUN mkdir $APP_ROOT
+WORKDIR $APP_ROOT
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs 20 --retry 3
+
+COPY package.json yarn.lock $APP_ROOT/
+RUN yarn
+
+COPY . $APP_ROOT/
+
+EXPOSE 3000 8080
+
+CMD bundle exec foreman start

--- a/app/javascript/components/ComponentWrapper.js
+++ b/app/javascript/components/ComponentWrapper.js
@@ -13,14 +13,17 @@ function WrapInStore({ store, children }) {
 
 export default class ComponentWrapper extends Component {
   props: {
-    store?: Store;
-    children?: any;
-    locale: string;
+    store?: Store,
+    children?: any,
+    locale: string,
   };
 
   render() {
     return (
-      <IntlProvider locale={this.props.locale} messages={ loadTranslations(this.props.locale) }>
+      <IntlProvider
+        locale={this.props.locale}
+        messages={loadTranslations(this.props.locale)}
+      >
         <WrapInStore store={this.props.store}>
           <div className="App">
             {this.props.children}

--- a/app/javascript/util/TranslationsLoader.js
+++ b/app/javascript/util/TranslationsLoader.js
@@ -3,7 +3,7 @@ import translations from './locales/translations';
 
 export default function loadTranslations(locale: string) {
   if (!translations[locale]) {
-    throw new Error(`Unsuported locale: ${locale}`);
+    throw new Error(`Unsupported locale: ${locale}`);
   }
   return translations[locale];
 }

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,7 @@ development: &default
   pool: 5
   username: <%= ENV['PG_USERNAME'] %>
   password: <%= ENV['PG_PASSWORD'] %>
-  host: localhost
+  host: <%= ENV.fetch('PG_HOST') { 'localhost' } %>
   port: <%= ENV['PG_PORT'] %>
 
 test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,22 @@
 web:
   build: .
+  dockerfile: Dockerfile.development
   volumes:
     - .:/champaign
     - ../sou-assets:/sou-assets
   ports:
     - "3000:3000"
+    - "8080:8080"
   links:
     - db
     - redis
   environment:
     PG_USERNAME: postgres
     PG_HOST: db
+    PG_PORT: 5432
+
   env_file:
-    - env.yml
+    - env-docker.yml
 
 db:
   image: postgres
@@ -25,4 +29,3 @@ redis:
   image: redis
   ports:
     - "6379"
-


### PR DESCRIPTION
## Installing
I've created `Dockerfile.development` from scratch so there's not much in common with our production Dockerfile. Since we need nodejs / yarn, build-tools, and a ruby stack, I've gone for a different base docker image to inherit from: [starefossen/ruby-node:2-8](https://hub.docker.com/r/starefossen/ruby-node/). I would've gone for the `2-8-alpine` variant for smaller size, but it isn't available when I try to run docker build with it. Strange, because it's definitely there and on github. Anyway, I digress... You can use `docker` to build the image:

```sh
# This won't fully work, but it's useful to know...
# The following command builds the docker image, using the file specified
# by -f, and -t tags the image as "champaign" in this case.
$ docker build -f Dockerfile.development -t champaign ./
# This runs the container in interactive mode, attaches a tty session,
# and maps the ports exposed. The -v flag maps volumes, so we're mapping
# our current directory to `/champaign` in the container
$ docker run -itP -v $(pwd):/champaign champaign
```

However, you'll want to use `docker-compose` since you'll need the other dependencies, Redis and PostgreSQL. A few things to consider before you build:

* You might need to modify `docker-compose.yml` to point to the right folder for `sou-assets`. As it is, it assumes that, it sits in the same folder as our  `project_root`, so we're pointing at `../sou-assets`. This might not be true.
* That being said, `sou-assets` should not be necessary to build Champaign,   especially by third parties. Therefore, before you run the `docker-compose`   commands below be sure to:
  
  * Remove any references to `external_asset_paths`, `external_css_path`, etc.     from `config/settings/*.yml`.
  * Remove `EXTERNAL_JS_PATH` env var from `env.yml`.

  That way we don't need sou-assets and we have a vanilla Champaign install. Our  default installation instructions should document how to do install Champaign  on its own without any external assets. We should then have separate   documentation on how to configure Champaign for pulling in external assets.

* If you *do* want to run it in development mode and reference external assets  you have to remember that **you need to point to the right folder inside the  docker container**, so instead of using the path in your filesystem, use the  expected path inside the container (obviously) since that's what the app will  attempt to load. So, for example, these are the changes I made:
  
  ```diff
  # config/settings/development.local.yml
  - external_asset_paths: '/Users/me/projects/sou-assets'
  + external_asset_paths: '/sou-assets'

  # env.yml
  - EXTERNAL_JS_PATH=/Users/me/projects/sou-assets/javascripts/champaign
  + EXTERNAL_JS_PATH=/sou-assets/javascripts/champaign
  ```

Okay, so with that out of the way, if you've removed any references to `sou-assets` or updated your env vars to build and run it in development mode, you can simply do:

```sh
$ docker-compose build
$ docker-compose up
```

That will build all images in `docker-compose.yml` and run the containers. If you need to run any rake tasks or any commands, you'll need to override the default `CMD`:

```sh
$ docker-compose run web bundle exec rake db:migrate
$ docker-compose run web bundle install
$ docker-compose run web <your-command>
```

If you simply want to attach your session into the container, use `bash`:

```sh
$ docker-compose run web bash
Starting champaign_db_1 ... done
Starting champaign_redis_1 ... done
root@de0828dbc468:/champaign#
```

## Issues
After I got it up and running, I did come across a few issues. Here's a short list of the main things that stood out:

### General 
* Perhaps we should create a default admin user in `db:seed` in development mode   and document it. That way the user doesn't need to run a rails console and create a user which might be unintuitive since I don't necessarily know the schema or what fields are required. Creating a default admin account would be less friction for people just trying this out. Basically I want to get this to a point where running `docker-compose build` and `docker-compose up` will be a fully functioning environment to play around, poke, and then maybe develop.
* Does the Google sign in only work with sumofus email addresses? I didn't see anything about that in the documentation.
* The `sou-assets` volume needs to be mounted in `/sou-assets`, as mentioned in the previous section.
* The `db:seed` task doesn't create languages, so when creating a page, there are no pages in the dropdown.
* User can't access `/admin` to create languages, but it's not really documented
* `actionkit_uri` is not optional for languages. AK should be optional?
* [minor] When creating a language, language code can't be uppercase. Perhaps downcase before saving? If you create a language with an uppercase code, e.g. `EN`, champaign dies.

### Creating a page
* As mentioned above, no languages available by default it seems.
* User needs to click on "Show all layouts" in order to show generic layouts on default installation. It's not clear if a layout is needed, or what layout would be the default layout.

### Templates
* User needs to click on "Show all layouts" in order to show generic layouts on default installation
* Generic fundraiser:
  * template doesn't use React component so it will break if we phase out the backbone one.
  * template sidebar layout is broken / wonky, gets chopped off at the top
  * template tries to be responsive but fails drastically.
* Generic Petition:
  * Background is white, the input boxes don't have a border.
* Generic Call Tool: 
  * Broken? Unsupported locale: undefined
* Generic survey template
  * There is no generic survey template (should there be?)

#### Other observations
I think it would appeal more if we had nicer default layouts. I can make a couple over the weekend. Nothing fancy, but something neat and responsive. E.g. the generic templates but with a bit more consideration.
