### PR TITLE
Correctly set currency in Fundraiser Component

### DIFF
--- a/app/javascript/components/ExpressDonation/ExpressDonation.js
+++ b/app/javascript/components/ExpressDonation/ExpressDonation.js
@@ -11,14 +11,14 @@ import PaymentMethodItem from './PaymentMethod';
 import { setRecurring } from '../../state/fundraiser/actions';
 
 import type { Dispatch } from 'redux';
-import type { AppState, PaymentMethod, Fundraiser, Page } from '../../state';
+import type { AppState, PaymentMethod, Fundraiser } from '../../state';
 
 import './ExpressDonation.scss';
 
 type OwnProps = {
   hidden: boolean,
   fundraiser: Fundraiser,
-  page: Page,
+  page: ChampaignPage,
   paymentMethods: PaymentMethod[],
   formData: { member: any, storeInVault: boolean },
   setRecurring: (value: boolean) => void,

--- a/app/javascript/components/Payment/Payment.js
+++ b/app/javascript/components/Payment/Payment.js
@@ -25,13 +25,7 @@ import ExpressDonation from '../ExpressDonation/ExpressDonation';
 
 import type { Dispatch } from 'redux';
 import type { Client } from 'braintree-web';
-import type {
-  AppState,
-  Member,
-  Fundraiser,
-  Page,
-  PaymentMethod,
-} from '../../state';
+import type { AppState, Member, Fundraiser, PaymentMethod } from '../../state';
 
 // Styles
 import './Payment.css';
@@ -44,7 +38,7 @@ type OwnProps = {
   member: Member,
   fundraiser: Fundraiser,
   paymentMethods: PaymentMethod[],
-  page: Page,
+  page: ChampaignPage,
   hideRecurring: boolean,
   disableFormReveal: boolean,
   formData: { member: any, storeInVault: boolean },
@@ -338,7 +332,9 @@ export class Payment extends Component {
             </div>
             {this.state.errors.map((e, i) => {
               return (
-                <div key={i} className="fundraiser-bar__error-detail">{e}</div>
+                <div key={i} className="fundraiser-bar__error-detail">
+                  {e}
+                </div>
               );
             })}
           </div>

--- a/app/javascript/fundraiser/FundraiserView.js
+++ b/app/javascript/fundraiser/FundraiserView.js
@@ -18,12 +18,12 @@ import {
 
 import type { Dispatch } from 'redux';
 import type { AppState } from '../state';
-import type { Member, Fundraiser, Page } from '../state';
+import type { Member, Fundraiser } from '../state';
 
 type OwnProps = {
   fundraiser: Fundraiser,
   member: Member,
-  page: Page,
+  page: ChampaignPage,
   changeStep: number => void,
   selectAmount: (?number) => void,
   selectCurrency: string => void,

--- a/app/javascript/packs/email_target.js
+++ b/app/javascript/packs/email_target.js
@@ -19,7 +19,7 @@ type emailTargetInitialState = {
   isSubmitting: boolean,
 };
 
-const store: Store<AppState, *> = window.champaignStore;
+const store: Store<AppState, *> = window.champaign.store;
 
 window.mountEmailTarget = (root: string, props: emailTargetInitialState) => {
   props = camelizeKeys(props);

--- a/app/javascript/packs/fundraiser_plugin.js
+++ b/app/javascript/packs/fundraiser_plugin.js
@@ -6,7 +6,7 @@ import ComponentWrapper from '../components/ComponentWrapper';
 import FundraiserView from '../fundraiser/FundraiserView';
 import configureStore from '../state';
 
-const store = window.champaignStore;
+const store = window.champaign.store;
 
 window.mountFundraiser = function(root, data) {
   store.dispatch({ type: 'initialize_page', payload: window.champaign.page });

--- a/app/javascript/packs/member_facing.js
+++ b/app/javascript/packs/member_facing.js
@@ -47,4 +47,5 @@ const initializeApp = () => {
 };
 
 initializeApp();
-window.champaignStore = configureStore({});
+
+window.champaign.store = configureStore({});

--- a/app/javascript/state/fundraiser/actions.js
+++ b/app/javascript/state/fundraiser/actions.js
@@ -1,16 +1,38 @@
 // @flow
 import $ from 'jquery';
-import type { GlobalActions } from '../reducers';
+import type { FormField, InitialAction } from '../reducers';
+import type { DonationBands, EnumRecurringDefault } from './helpers';
+
+export type FundraiserInitializationOptions = {
+  pageId: string,
+  currency: string,
+  amount: string,
+  donationBands: { [key: string]: number[] },
+  showDirectDebit: boolean,
+  formValues: { [key: string]: string },
+  formId: string,
+  outstandingFields: string[],
+  title: string,
+  preselectAmount: boolean,
+  fields: FormField[],
+  recurringDefault: EnumRecurringDefault,
+  freestanding: boolean,
+};
 
 export type FundraiserAction =
-  | GlobalActions
-  | { type: 'change_currency', payload: string }
+  | InitialAction
+  | { type: 'initialize_fundraiser', payload: FundraiserInitializationOptions }
   | { type: 'change_amount', payload: ?number }
+  | { type: 'change_currency', payload: string }
+  | { type: 'change_step', payload: number }
+  | { type: 'preselect_amount', payload: boolean }
+  | { type: 'set_donation_bands', payload: DonationBands }
+  | { type: 'set_payment_type', payload: ?string }
   | { type: 'set_recurring', payload: boolean }
+  | { type: 'set_recurring_defaults', payload?: string }
   | { type: 'set_submitting', payload: boolean }
   | { type: 'set_store_in_vault', payload: boolean }
-  | { type: 'set_payment_type', payload: ?string }
-  | { type: 'change_step', payload: number }
+  | { type: 'toggle_direct_debit', payload: boolean }
   | { type: 'update_form', payload: { [key: string]: any } };
 
 export function changeAmount(payload: ?number): FundraiserAction {
@@ -29,9 +51,7 @@ export function setSubmitting(payload: boolean): FundraiserAction {
 
 export function changeStep(payload: number): FundraiserAction {
   // we put it in a timeout because otherwise the event is fired before the step has switched
-  window.setTimeout(() => {
-    $.publish('fundraiser:change_step', [payload]);
-  }, 100);
+  setTimeout(() => $.publish('fundraiser:change_step', [payload]), 100);
   return { type: 'change_step', payload };
 }
 

--- a/app/javascript/state/fundraiser/helpers.js
+++ b/app/javascript/state/fundraiser/helpers.js
@@ -6,6 +6,11 @@ type RecurringState = {
   recurringDefault: EnumRecurringDefault,
 };
 
+type FeaturedAmountState = {
+  preselectAmount: boolean,
+  donationFeaturedAmount?: number,
+};
+
 export type EnumRecurringDefault = 'one_off' | 'recurring' | 'only_recurring';
 
 export type DonationBands = { [id: string]: number[] };
@@ -96,21 +101,21 @@ export function pickMedianAmount(
   return amounts[Math.floor(amounts.length / 2)] || 0;
 }
 
-type FeaturedAmountState = {
-  preselectAmount: boolean,
-  donationFeaturedAmount?: number,
-};
 export function featuredAmountState(
-  state: Fundraiser,
-  currency: string,
-  preselect?: string
+  preselectAmount: boolean,
+  state?: { donationBands: DonationBands, currency: string }
 ): FeaturedAmountState {
-  const preselectAmount =
-    (preselect && preselect === '1') || state.preselectAmount;
+  if (preselectAmount && state) {
+    return {
+      preselectAmount,
+      donationFeaturedAmount: pickMedianAmount(
+        state.donationBands,
+        state.currency
+      ),
+    };
+  }
+
   return {
     preselectAmount,
-    donationFeaturedAmount: preselectAmount
-      ? pickMedianAmount(state.donationBands, currency)
-      : undefined,
   };
 }

--- a/app/javascript/state/index.js
+++ b/app/javascript/state/index.js
@@ -9,7 +9,6 @@ export type { AppState } from './reducers';
 export type { Fundraiser } from './fundraiser/helpers';
 export type { Member } from './member/reducer';
 export type { PaymentMethod } from './paymentMethods/reducer';
-export type { Page } from './page/reducer';
 
 export default function configureStore(initialState: any): any {
   const composeEnhancers =

--- a/app/javascript/state/page/reducer.js
+++ b/app/javascript/state/page/reducer.js
@@ -1,29 +1,6 @@
 // @flow
 
-export type Page = {
-  action_count: number;
-  allow_duplicate_actions: boolean;
-  canonical_url: string;
-  created_at: string;
-  featured: boolean;
-  follow_up_page_id: number;
-  follow_up_plan: 'with_liquid' | 'with_page';
-  id: number;
-  language_id: number;
-  optimizely_status: 'optimizely_disabled' | 'optimizely_enabled';
-  primary_image_id: number;
-  publish_status: string;
-  slug: string;
-  status: string;
-  title: string;
-  updated_at: string;
-  ak_donation_resource_uri?: string;
-  ak_petition_resource_uri?: string;
-  campaign_id?: number;
-  follow_up_liquid_layout_id?: number;
-};
-
-const initialState: Page = {
+const initialState: ChampaignPage = {
   action_count: 0,
   allow_duplicate_actions: false,
   canonical_url: '',
@@ -44,12 +21,15 @@ const initialState: Page = {
 
 export type PageAction = {
   type: 'initialize_page',
-  payload: Page
+  payload: ChampaignPage,
 };
 
-export default function pageReducer(state: Page = initialState, action: PageAction) {
+export default function pageReducer(
+  state: ChampaignPage = initialState,
+  action: PageAction
+) {
   if (action.type === 'initialize_page') {
-      return action.payload;
+    return action.payload;
   }
   return state;
 }

--- a/app/javascript/state/reducers.js
+++ b/app/javascript/state/reducers.js
@@ -20,43 +20,16 @@ export default combineReducers(reducers);
 import type { Member } from './member/reducer';
 import type { Fundraiser, EnumRecurringDefault } from './fundraiser/helpers';
 import type { PaymentMethod } from './paymentMethods/reducer';
-import type { Page } from './page/reducer';
+import type { PageAction } from './page/reducer';
 
 export type AppState = {
   member: Member,
   fundraiser: Fundraiser,
   paymentMethods: PaymentMethod[],
-  page: Page,
+  page: ChampaignPage,
 };
 
 type ChampaignPaymentMethod = any;
-
-type ChampaignMember = {
-  id: number,
-  email: string,
-  country: string,
-  name: string,
-  first_name: string,
-  last_name: string,
-  full_name: string,
-  welcome_name: string,
-  postal: string,
-  actionkit_user_id: ?string,
-  donor_status: 'donor' | 'non_donor' | 'recurring_donor',
-  registered: boolean,
-  created_at: string,
-  updated_at: string,
-};
-
-declare type ChampaignLocation = {
-  country: string,
-  country_code: string,
-  country_name: string,
-  currency: string,
-  ip: string,
-  latitude: string,
-  longitude: string,
-};
 
 export type FormField = {
   id: number,
@@ -73,46 +46,9 @@ export type FormField = {
   choices: any[],
 };
 
-type FundraiserPageOptions = {
-  pageId: string,
-  currency: string,
-  amount: string,
-  donationBands: { [key: string]: number[] },
-  showDirectDebit: boolean,
-  formValues: { [key: string]: string },
-  formId: string,
-  outstandingFields: string[],
-  title: string,
-  preselectAmount: boolean,
-  fields: FormField[],
-  recurringDefault: EnumRecurringDefault,
-  freestanding: false,
-};
-declare type ChampaignPersonalizationData = {
-  fundraiser: FundraiserPageOptions,
-  locale: string,
-  location: ChampaignLocation,
-  member: ?ChampaignMember,
-  paymentMethods: ChampaignPaymentMethod[],
-  showDirectDebit: boolean,
-  urlParams: { [key: string]: string },
-};
-
 export type InitialAction = {
   type: 'parse_champaign_data',
   payload: ChampaignPersonalizationData,
 };
-
-export type GlobalActions =
-  | InitialAction
-  | {
-      type: 'querystring_parameters',
-      payload: {
-        recurring_default?: string,
-        amount?: string,
-        currency?: string,
-        preselect?: string,
-      },
-    };
 
 export const INITIAL_ACTION = 'parse_champaign_data';

--- a/app/javascript/types.js
+++ b/app/javascript/types.js
@@ -1,15 +1,72 @@
 /* eslint-disable */
 // @flow
+import type { AppState } from './state/reducers';
 
-declare type WebpackModuleHot = {
-  accept: (path: string, callback: () => void) => void,
+declare type ChampaignMember = {
+  id: number,
+  email: string,
+  country: string,
+  name: string,
+  first_name: string,
+  last_name: string,
+  full_name: string,
+  welcome_name: string,
+  postal: string,
+  actionkit_user_id: ?string,
+  donor_status: 'donor' | 'non_donor' | 'recurring_donor',
+  registered: boolean,
+  created_at: string,
+  updated_at: string,
 };
 
-declare type WebpackModule = {
-  hot: WebpackModuleHot,
+declare type ChampaignLocation = {
+  country: string,
+  country_code: string,
+  country_name: string,
+  currency: string,
+  ip: string,
+  latitude: string,
+  longitude: string,
 };
 
-declare var module: WebpackModule;
+declare type ChampaignPage = {
+  action_count: number,
+  allow_duplicate_actions: boolean,
+  canonical_url: string,
+  created_at: string,
+  featured: boolean,
+  follow_up_page_id: number,
+  follow_up_plan: 'with_liquid' | 'with_page',
+  id: number,
+  language_id: number,
+  optimizely_status: 'optimizely_disabled' | 'optimizely_enabled',
+  primary_image_id: number,
+  publish_status: string,
+  slug: string,
+  status: string,
+  title: string,
+  updated_at: string,
+  ak_donation_resource_uri?: string,
+  ak_petition_resource_uri?: string,
+  campaign_id?: number,
+  follow_up_liquid_layout_id?: number,
+};
+
+declare type ChampaignPersonalizationData = {
+  locale: string,
+  location: ChampaignLocation,
+  member: ?ChampaignMember,
+  paymentMethods: ChampaignPaymentMethod[],
+  urlParams: { [key: string]: string },
+};
+
+declare type ChampaignGlobalObject = {
+  personalization: ChampaignPersonalizationData,
+  page: ChampaignPage,
+  store: Store<AppState, *>,
+};
+
+declare var champaign: ChampaignGlobalObject;
 
 declare type FBStandardEvent =
   | 'ViewContent'
@@ -37,3 +94,13 @@ declare function fbq(
   eventName: FBStandardEvent,
   data?: FBEventParams
 ): void;
+
+declare var module: WebpackModule;
+
+declare type WebpackModule = {
+  hot: WebpackModuleHot,
+};
+
+declare type WebpackModuleHot = {
+  accept: (path: string, callback: () => void) => void,
+};

--- a/flow-typed/npm/query-string_v4.x.x.js
+++ b/flow-typed/npm/query-string_v4.x.x.js
@@ -1,0 +1,22 @@
+// flow-typed signature: d7aa81f9489bb4260dfbb73717f500b0
+// flow-typed version: <<STUB>>/query-string_v4.3/flow_v0.48.0
+
+declare module 'query-string' {
+  declare type ParseOptions = {
+    arrayFormat?: 'bracket' | 'index' | 'none',
+  };
+
+  declare type StringifyOptions = {
+    strict?: boolean,
+    encode?: boolean,
+    arrayFormat?: 'bracket' | 'index' | 'none',
+  };
+
+  declare function parse(
+    str: string,
+    opts?: ParseOptions
+  ): { [key: string]: string };
+
+  declare function stringify(obj: Object, opts?: StringifyOptions): string;
+  declare function extract(str: string): string;
+}


### PR DESCRIPTION
With the last query string parameters bugfix, I introduced a new bug that always overrode the member's currency (set by location) if there was no currency parameter in the query string. This re-introduces the fallback mechanism, as well as it simplifies the fundraiser reducer. 

I've eliminated the `parse_champaign_data` from the reducer to be more explicit (now using individual actions for each group of properties). Currency is now always set via the `change_currency` action. This also introduces a new action: `initialize_fundraiser`, which initializes the component's store with a select number of properties instead of _all_ properties passed as payload. Grabbing all properties isn't declarative enough and can lead to a situation (like the one which caused this bug) where a developer isn't aware of what properties are updated by an action.