### PR TITLE
Delete home_url from translations

### DIFF
--- a/config/locales/member_facing.de.yml
+++ b/config/locales/member_facing.de.yml
@@ -174,5 +174,3 @@ de:
       failure: 'Leider gab es bei der Einrichtung Ihres Kontos ein Problem. '
       success: 'Sie haben Ihr SumOfUs-Konto erfolgreich bestätigt. Vielen Dank!'
       member_management: "Um Ihre Zahlungsoptionen und -details zu verwalten, können Sie jederzeit die <a href='%{url}'>Seite für SumOfUs-Mitglieder</a> besuchen."
-  footer:
-    home_url: 'http://yourhomepage.org'

--- a/config/locales/member_facing.en.yml
+++ b/config/locales/member_facing.en.yml
@@ -200,5 +200,3 @@ en:
       failure: 'Sorry, there was an issue confirming your account.'
       success: 'You have successfully confirmed your account. Thanks!'
       member_management: "To manage your payment methods and details, you can visit the <a href='%{url}'>members dashboard</a> at any time."
-  footer:
-    home_url: 'http://yourhomepage.org' # replace with your homepage

--- a/config/locales/member_facing.fr.yml
+++ b/config/locales/member_facing.fr.yml
@@ -174,5 +174,3 @@ fr:
       failure: 'Désolé, nous n''avons pas pu confirmer votre compte. Si vous rencontrez des difficultés, contactez-nous ici : donations@sumofus.org.'
       success: 'Félicitations, votre compte SumOfUs a bien été confirmé. Merci !'
       member_management: "Pour gérer vos modalités de paiement, vous pouvez à tout moment visiter le <a href='%{url}'>tableau de bord des membres</a> de SumOfUs."
-  footer:
-    home_url: 'http://yourhomepage.org'


### PR DESCRIPTION
Local translations take precedence over external_assets translations so we have to delete these in order for the other ones to take effect. This fixes the following bug: https://www.pivotaltracker.com/story/show/148286787