### PR TITLE
Slug better

### DIFF
--- a/app/controllers/action_kit_controller.rb
+++ b/app/controllers/action_kit_controller.rb
@@ -5,7 +5,7 @@ class ActionKitController < ApplicationController
 
   def check_slug
     ak_valid = ActionKit::Helper.check_petition_name_is_available(params[:slug])
-    chmp_valid = Page.where(slug: params[:slug]).empty?
+    chmp_valid = !Page.exists?(slug: params[:slug])
 
     respond_to do |format|
       format.json { render json: { valid: (ak_valid && chmp_valid) } }

--- a/app/controllers/action_kit_controller.rb
+++ b/app/controllers/action_kit_controller.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
+
 class ActionKitController < ApplicationController
   before_action :authenticate_user!
 
   def check_slug
-    valid = ActionKit::Helper.check_petition_name_is_available(params[:slug])
+    ak_valid = ActionKit::Helper.check_petition_name_is_available(params[:slug])
+    chmp_valid = Page.where(slug: params[:slug]).empty?
 
     respond_to do |format|
-      format.json { render json: { valid: valid } }
+      format.json { render json: { valid: (ak_valid && chmp_valid) } }
     end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
+
 require 'champaign_queue'
 require 'browser'
 
 class PagesController < ApplicationController
-  before_action :authenticate_user!, except: [:show, :follow_up]
-  before_action :get_page, only: [:edit, :update, :destroy, :follow_up, :analytics, :actions]
+  before_action :authenticate_user!, except: %i[show follow_up]
+  before_action :get_page, only: %i[edit update destroy follow_up analytics actions]
   before_action :get_page_or_homepage, only: [:show]
-  before_action :redirect_unless_published, only: [:show, :follow_up]
-  before_action :localize, only: [:show, :follow_up]
+  before_action :redirect_unless_published, only: %i[show follow_up]
+  before_action :localize, only: %i[show follow_up]
 
   def index
     @pages = Search::PageSearcher.search(search_params)
@@ -39,7 +40,7 @@ class PagesController < ApplicationController
     @page = PageBuilder.create(page_params)
 
     if @page.valid?
-      redirect_to edit_page_path(@page.id)
+      redirect_to edit_page_path(@page)
     else
       render :new
     end
@@ -134,7 +135,7 @@ class PagesController < ApplicationController
     default_params = {
       publish_status: Page.publish_statuses.values_at(:published, :unpublished),
       limit: 500,
-      order_by: [:updated_at, :desc]
+      order_by: %i[updated_at desc]
     }
     @search_params = default_params.merge(params.to_unsafe_hash.symbolize_keys)
   end

--- a/app/javascript/campaigner_facing/page.js
+++ b/app/javascript/campaigner_facing/page.js
@@ -39,7 +39,7 @@ const slugView = Backbone.View.extend({
   updateViewWithValid() {
     const valid = this.slugChecker.get('valid');
 
-    this.$submit.removeClass('disabled');
+    this.enableButton(this.$submit);
 
     this.$('.loading').hide();
 
@@ -49,11 +49,13 @@ const slugView = Backbone.View.extend({
 
     this.$('.form-group.slug .glyphicon').hide();
 
+    console.log('valid is', valid);
     if (valid) {
       this.$('.form-group.slug').addClass('has-success has-feedback');
       this.$('.form-group.slug .glyphicon-ok').show();
     } else {
       this.$('.slug-field').show();
+      console.log(this.$('.form-group.slug'));
 
       this.$('.form-group.slug').addClass('has-error has-feedback');
       this.$('.form-group.slug .glyphicon-remove').show();
@@ -75,7 +77,7 @@ const slugView = Backbone.View.extend({
 
     this.checking = true;
 
-    this.$submit.addClass('disabled');
+    this.disableButton(this.$submit);
 
     this.$('.loading').show();
 
@@ -83,9 +85,7 @@ const slugView = Backbone.View.extend({
 
     this.slugChecker.save().done(() => {
       this.checking = false;
-      this.$checkButton
-        .text('Check if name is available')
-        .removeClass('disabled');
+      this.enableButton(this.$checkButton.text('Check if name is available'));
 
       if (cb) {
         cb.call(this);
@@ -103,10 +103,20 @@ const slugView = Backbone.View.extend({
     this.$feedback.removeClass('has-error has-success has-feedback');
   },
 
+  disableButton($btn) {
+    $btn.prop('disabled', true);
+    $btn.addClass('disabled');
+  },
+
+  enableButton($btn) {
+    $btn.prop('disabled', false);
+    $btn.removeClass('disabled');
+  },
+
   submit(e) {
     e.preventDefault();
 
-    this.$checkButton.text('Checking...').addClass('disabled');
+    this.disableButton(this.$checkButton.text('Checking...'));
 
     if (!this.slugChecker.get('valid')) {
       this.checkSlugAvailable(e, () => {

--- a/app/lib/action_kit/client.rb
+++ b/app/lib/action_kit/client.rb
@@ -4,8 +4,6 @@ require 'httparty'
 
 module ActionKit
   module Client
-    module_function :client, :get, :configured?, :auth
-
     def client(verb, path, params)
       HTTParty.send(
         verb,
@@ -33,5 +31,7 @@ module ActionKit
         password: Settings.ak_password
       }
     end
+
+    module_function :client, :get, :configured?, :auth
   end
 end

--- a/app/lib/action_kit/client.rb
+++ b/app/lib/action_kit/client.rb
@@ -4,7 +4,7 @@ require 'httparty'
 
 module ActionKit
   module Client
-    extend self
+    module_function :client, :get, :configured?, :auth
 
     def client(verb, path, params)
       HTTParty.send(
@@ -17,6 +17,12 @@ module ActionKit
 
     def get(path, params)
       client('get', path, params)
+    end
+
+    def configured?
+      Settings.ak_api_url.present? &&
+        Settings.ak_username.present? &&
+        Settings.ak_password.present?
     end
 
     private

--- a/app/lib/action_kit/helper.rb
+++ b/app/lib/action_kit/helper.rb
@@ -2,9 +2,10 @@
 
 module ActionKit
   module Helper
-    extend self
+    module_function :check_petition_name_is_available
 
     def check_petition_name_is_available(name)
+      return true unless ActionKit::Client.configured?
       resp = ActionKit::Client.get('petitionpage', params: { _limit: 1, name: name })
       if resp.code == 200
         (JSON.parse(resp.body)['meta']['total_count']).zero?

--- a/app/lib/action_kit/helper.rb
+++ b/app/lib/action_kit/helper.rb
@@ -2,8 +2,6 @@
 
 module ActionKit
   module Helper
-    module_function :check_petition_name_is_available
-
     def check_petition_name_is_available(name)
       return true unless ActionKit::Client.configured?
       resp = ActionKit::Client.get('petitionpage', params: { _limit: 1, name: name })
@@ -13,5 +11,7 @@ module ActionKit
         false
       end
     end
+
+    module_function :check_petition_name_is_available
   end
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -15,8 +15,8 @@ action_kit:
 
 # Direct ActionKit Connection variables.
 ak_api_url: 'http://actionkit_api_url.com'
-ak_username: username
-ak_password: password
+# ak_username: username
+# ak_password: password
 
 
 # Assets config

--- a/spec/controllers/action_kit_controller_spec.rb
+++ b/spec/controllers/action_kit_controller_spec.rb
@@ -21,9 +21,15 @@ describe ActionKitController do
       post :check_slug, params: { slug: 'foo-bar', format: :json }
     end
 
+    it 'checks if name is available on Champaign' do
+      allow(Page).to receive(:exists?)
+      expect(Page).to receive(:exists?).with(slug: 'foo-bar')
+      subject
+    end
+
     it 'returns true if there is no matching page on AK or Champaign' do
       allow(ActionKit::Helper).to receive(:check_petition_name_is_available) { true }
-      allow(Page).to receive(:where) { [] }
+      allow(Page).to receive(:exists?) { false }
 
       subject
       expect(response.body).to eq '{"valid":true}'
@@ -31,7 +37,7 @@ describe ActionKitController do
 
     it 'returns false if there is a matching page on AK but not Champaign' do
       allow(ActionKit::Helper).to receive(:check_petition_name_is_available) { false }
-      allow(Page).to receive(:where) { [] }
+      allow(Page).to receive(:exists?) { false }
 
       subject
       expect(response.body).to eq '{"valid":false}'
@@ -39,7 +45,7 @@ describe ActionKitController do
 
     it 'returns false if there is a matching page on Champaign but not AK' do
       allow(ActionKit::Helper).to receive(:check_petition_name_is_available) { true }
-      allow(Page).to receive(:where) { [double(Page)] }
+      allow(Page).to receive(:exists?) { true }
 
       subject
       expect(response.body).to eq '{"valid":false}'
@@ -47,7 +53,7 @@ describe ActionKitController do
 
     it 'returns false if there is a matching page on AK and Champaign' do
       allow(ActionKit::Helper).to receive(:check_petition_name_is_available) { false }
-      allow(Page).to receive(:where) { [double(Page)] }
+      allow(Page).to receive(:exists?) { true }
 
       subject
       expect(response.body).to eq '{"valid":false}'

--- a/spec/controllers/action_kit_controller_spec.rb
+++ b/spec/controllers/action_kit_controller_spec.rb
@@ -11,12 +11,46 @@ describe ActionKitController do
                    [{ post: [:check_slug, params: { slug: 'foo-bar', format: :json }] }]
 
   describe 'POST#check_slug' do
-    it 'checks if name is available' do
+    subject { post :check_slug, params: { slug: 'foo-bar', format: :json } }
+
+    it 'checks if name is available on AK' do
       expect(ActionKit::Helper)
         .to receive(:check_petition_name_is_available)
         .with('foo-bar')
 
       post :check_slug, params: { slug: 'foo-bar', format: :json }
+    end
+
+    it 'returns true if there is no matching page on AK or Champaign' do
+      allow(ActionKit::Helper).to receive(:check_petition_name_is_available) { true }
+      allow(Page).to receive(:where) { [] }
+
+      subject
+      expect(response.body).to eq '{"valid":true}'
+    end
+
+    it 'returns false if there is a matching page on AK but not Champaign' do
+      allow(ActionKit::Helper).to receive(:check_petition_name_is_available) { false }
+      allow(Page).to receive(:where) { [] }
+
+      subject
+      expect(response.body).to eq '{"valid":false}'
+    end
+
+    it 'returns false if there is a matching page on Champaign but not AK' do
+      allow(ActionKit::Helper).to receive(:check_petition_name_is_available) { true }
+      allow(Page).to receive(:where) { [double(Page)] }
+
+      subject
+      expect(response.body).to eq '{"valid":false}'
+    end
+
+    it 'returns false if there is a matching page on AK and Champaign' do
+      allow(ActionKit::Helper).to receive(:check_petition_name_is_available) { false }
+      allow(Page).to receive(:where) { [double(Page)] }
+
+      subject
+      expect(response.body).to eq '{"valid":false}'
     end
   end
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -60,7 +60,7 @@ describe PagesController do
 
     context 'successfully created' do
       it 'redirects to edit_page' do
-        expect(response).to redirect_to(edit_page_path(page.id))
+        expect(response).to redirect_to(edit_page_path(page))
       end
     end
 

--- a/spec/lib/action_kit/client.rb
+++ b/spec/lib/action_kit/client.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ActionKit::Client do
+  describe '.configured?' do
+    before :each do
+      allow(Settings).to receive(:ak_api_url) { 'not blank' }
+      allow(Settings).to receive(:ak_username) { 'not blank' }
+      allow(Settings).to receive(:ak_password) { 'not blank' }
+    end
+
+    it 'returns true if ak_api_url, ak_password, and ak_username are all present' do
+      expect(ActionKit::Client.configured?).to be true
+    end
+
+    it 'returns false if ak_api_url is blank' do
+      allow(Settings).to receive(:ak_api_url) { nil }
+      expect(ActionKit::Client.configured?).to be false
+    end
+
+    it 'returns false if ak_username is blank' do
+      allow(Settings).to receive(:ak_username) { nil }
+      expect(ActionKit::Client.configured?).to be false
+    end
+
+    it 'returns false if ak_password is blank' do
+      allow(Settings).to receive(:ak_password) { nil }
+      expect(ActionKit::Client.configured?).to be false
+    end
+  end
+end

--- a/spec/lib/action_kit/helper_spec.rb
+++ b/spec/lib/action_kit/helper_spec.rb
@@ -19,5 +19,10 @@ describe ActionKit::Helper do
         ).to be false
       end
     end
+
+    it 'returns true when no AK config is available' do
+      allow(ActionKit::Client).to receive(:configured?).and_return(false)
+      expect(ActionKit::Helper.check_petition_name_is_available('foo-bar')).to be true
+    end
   end
 end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: pages
@@ -423,6 +424,15 @@ describe Page do
         expect(page.slug).to eq('oela')
       end
     end
+
+    context 'duplicate slug' do
+      it 'is invalid' do
+        page_with_dup = build(:page, title: 'new title!', slug: 'simple-slug', liquid_layout: liquid_layout)
+        expect { page_with_dup.save! }.to raise_error(
+          ActiveRecord::RecordInvalid, /Slug has already been taken/
+        )
+      end
+    end
   end
 
   describe 'follow_up_plan' do
@@ -436,7 +446,7 @@ describe Page do
     it 'correctly lists the names of plugins' do
       page = create :page
       [create(:plugins_petition, page: page), create(:plugins_fundraiser, page: page), create(:plugins_thermometer, page: page)]
-      plugin_names = %w(petition fundraiser thermometer)
+      plugin_names = %w[petition fundraiser thermometer]
       expect(page.plugin_names).to match_array(plugin_names)
     end
   end


### PR DESCRIPTION
This PR addresses several long-standing issues with Champaign, some serious, some cosmetic, all of them related to slugs.

- We never had an actual validation of unique slugs on the Page model, instead relying on friendly_id. Unfortunately, that has proven inadequate, leading to a couple very confused campaigners trying to understand how their page suddenly had no content or actions. This adds that model validation
- When new pages were created, we did a pre-check against ActionKit that the slug was unique. This check no passes only if the page is unique on both ActionKit AND Champaign.
- That same ActionKit check previously required AK credentials, and made it impossible to make pages without AK credentials. This PR removes that requirement, skipping the AK check if no AK credentials are configured.
- When someone attempted to make a page with a slug that was already taken, the button to try again at the bottom of the new page page was never re-enabled. This fixes that.
- Upon creation of a new page, the URL showed the numeric page id, not the slug. It now shows the slug.