### PR TITLE
fix the favicon loading in rails 5

### DIFF
--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -11,7 +11,7 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     = stylesheet_pack_tag 'email_target'
 
     = csrf_meta_tags
-    = favicon_link_tag 'images/favicon.ico'
+    = favicon_link_tag 'images/org-favicon.ico'
     = metamagic
     - canonical_url = @page.canonical_url.blank? ? member_facing_page_url(@page) : @page.canonical_url
     link rel="canonical" href=canonical_url


### PR DESCRIPTION
The favicon hasn't been showing up on member-facing pages since the Rails 5 upgrade. I found it only doesn't find it if it's called `favicon.ico`, otherwise it finds it fine. I've subsequently changed it. Accompanied by a PR on sou-assets.