### PR TITLE
fix terrible load time on CallTool::Target

### DIFF
--- a/app/models/call_tool/target.rb
+++ b/app/models/call_tool/target.rb
@@ -28,19 +28,12 @@ class CallTool::Target
     Hash[MAIN_ATTRS.collect { |attr| [attr, send(attr)] }].merge(fields: fields)
   end
 
-  def country_name
-    @country_name ||= ISO3166::Country[country_code]&.name
-  end
-
-  def country_name=(country_name)
-    @country_name = country_name
-    self.country_code = ISO3166::Country.find_country_by_name(country_name)&.alpha2
-  end
-
   def country=(country)
     if ISO3166::Country[country].present?
       self.country_code = country
-    else
+      self.country_name = ISO3166::Country[country].name
+    elsif ISO3166::Country.find_country_by_name(country)
+      self.country_code = ISO3166::Country.find_country_by_name(country)&.alpha2
       self.country_name = country
     end
   end

--- a/app/models/plugins/call_tool.rb
+++ b/app/models/plugins/call_tool.rb
@@ -59,7 +59,7 @@ class Plugins::CallTool < ApplicationRecord
   end
 
   def empty_cols
-    CallTool::Target::MAIN_ATTRS.select do |field|
+    ::CallTool::Target::MAIN_ATTRS.select do |field|
       targets.map { |t| t.try(field) }.compact.empty?
     end
   end

--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ deployment:
       - BRAINTREE_TOKEN_URL=$PRODUCTION_BRAINTREE_TOKEN_URL ./bin/build.sh
       - ./bin/deploy.sh $CIRCLE_SHA1 'champaign' 'env-production' 'champaign-assets-production' 'logs3.papertrailapp.com:44107' 'actions.sumofus.org'
   staging:
-    branch:  'feature/call-tool-dynamic-target-parser'
+    branch:  'fix-call-edit-load'
     commands:
       - BRAINTREE_TOKEN_URL=$STAGING_BRAINTREE_TOKEN_URL ./bin/build.sh
       - ./bin/deploy.sh $CIRCLE_SHA1 'champaign' 'env-staging' 'champaign-assets-staging' 'logs3.papertrailapp.com:34848' 'action-staging.sumofus.org'

--- a/spec/factories/plugins_call_tools.rb
+++ b/spec/factories/plugins_call_tools.rb
@@ -41,7 +41,7 @@ FactoryGirl.define do
     }
 
     trait :with_country do
-      country_name {
+      country {
         ISO3166::Country.find_country_by_alpha2(Faker::Address.country_code).name
       }
     end

--- a/spec/fixtures/call_tool_data.csv
+++ b/spec/fixtures/call_tool_data.csv
@@ -1,4 +1,4 @@
-country name,phone number,name,title,caller id
+country,phone number,name,title,caller id
 Germany,+448008085429,Abe Ben,MEP for Germany,+448008085400
 United Kingdom,+448000119712,Claire Do,MEP South East England,
 United Kingdom,+61261885481,Emily Fred,MEP for South West England,

--- a/spec/models/call_tool/target_spec.rb
+++ b/spec/models/call_tool/target_spec.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe CallTool::Target do
   let(:target) { CallTool::Target.new }
 
-  describe '#country_name=' do
+  describe '#country=' do
     it 'assigns the country code if code is valid' do
-      target.country_name = 'United states'
+      target.country = 'US'
       expect(target.country_code).to eq 'US'
+      expect(target.country_name).to eq 'United States of America'
+    end
+
+    it 'assigns the country code if name is valid' do
+      target.country = 'United states'
+      expect(target.country_code).to eq 'US'
+      expect(target.country_name).to eq 'United states'
     end
 
     it 'sets country_code to nil if name is invalid' do
-      target.country_name = 'Magic Country'
+      target.country = 'Magic Country'
       expect(target.country_code).to be_nil
-    end
-  end
-
-  describe '#country_name' do
-    it 'returns the name of the country matching the country_code' do
-      target.country_code = 'AR'
-      expect(target.country_name).to eq('Argentina')
+      expect(target.country_name).to be_nil
     end
   end
 

--- a/spec/services/targets_parser_spec.rb
+++ b/spec/services/targets_parser_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe CallTool::TargetsParser do
   let(:csv_string) do
     <<-EOS
-      Country name, State, phone number, Phone Extension, NAME, title, caller id, dynamic column
+      Country, State, phone number, Phone Extension, NAME, title, caller id, dynamic column
       united kingdom, Greater London, 4410000000, 123, Claire Do, MEP South East England, 1234567, Dynamic
       united kingdom, Greater London, 4411111111,, Emily Fred, MEP for South West England, 123
       united kingdom, Brighton and Hove, 442222222,, George Harris, MEP for South West England, 123
@@ -34,22 +34,12 @@ describe CallTool::TargetsParser do
     expect(t.fields[:dynamic_column]).to eq('Dynamic')
   end
 
-  it 'detects a `country_name` field and sets the country code' do
-    t = targets.first
-    expect(t.country_code).to eq('GB')
-  end
-
   it 'detects a `country` field with a name and sets the country code' do
-    different_csv = csv_string.gsub(/Country name/i, 'country')
-    expect(different_csv.include?('ountry name')).to eq false
-    different_targets = CallTool::TargetsParser.parse_csv(different_csv)
-    t = different_targets.first
-    expect(t.country_code).to eq('GB')
+    expect(targets.first.country_code).to eq('GB')
   end
 
   it 'detects a `country` field with a code and sets it to country code' do
-    different_csv = csv_string.gsub(/Country name/i, 'country').gsub(/united kingdom/i, 'DE')
-    expect(different_csv.include?('ountry name')).to eq false
+    different_csv = csv_string.gsub(/united kingdom/i, 'DE')
     different_targets = CallTool::TargetsParser.parse_csv(different_csv)
     t = different_targets.first
     expect(t.country_code).to eq('DE')


### PR DESCRIPTION
`country_name=` was being called on every instantiation, and no matter the value of `country_name` or `country_code`, it was calling `ISO3166::Country.find_country_by_name`. Now that method is only called on CSV upload.