### PR TITLE
Updated the SQS client to use FIFO queues

### DIFF
--- a/app/controllers/api/stateless/members_controller.rb
+++ b/app/controllers/api/stateless/members_controller.rb
@@ -51,7 +51,7 @@ module Api
       end
 
       def update_on_ak(member)
-        ChampaignQueue.push(
+        ChampaignQueue.push({
           type: 'update_member',
           params: {
             akid: member.actionkit_user_id,
@@ -64,7 +64,7 @@ module Api
             address1: member.address1,
             address2: member.address2
           }
-        )
+        }, { group_id: "member:#{member.id}" })
       end
     end
   end

--- a/app/lib/champaign_queue/clients/sqs.rb
+++ b/app/lib/champaign_queue/clients/sqs.rb
@@ -6,14 +6,15 @@ module ChampaignQueue
       class << self
         # +params+ - The message to send. String maximum 256 KB in size.
         # +delay+  - The number of seconds (0 to 900 - 15 minutes) to delay a specific message.
-        def push(params, delay: 0)
-          new(params, delay).push
+        def push(params, group_id:, delay: 0)
+          new(params, group_id, delay).push
         end
       end
 
-      def initialize(params, delay)
+      def initialize(params, group_id, delay)
         @params = params
         @delay = delay
+        @group_id = group_id
       end
 
       def push
@@ -21,7 +22,8 @@ module ChampaignQueue
 
         client.send_message(queue_url:    queue_url,
                             message_body: @params.to_json,
-                            delay_seconds: @delay)
+                            delay_seconds: @delay,
+                            message_group_id: @group_id)
       end
 
       private

--- a/app/models/payment/braintree/subscription.rb
+++ b/app/models/payment/braintree/subscription.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: payment_braintree_subscriptions
@@ -32,18 +33,24 @@ class Payment::Braintree::Subscription < ApplicationRecord
 
   def publish_cancellation(reason)
     # reason can be "user", "admin", "processor", "failure", "expired"
-    ChampaignQueue.push(type: 'cancel_subscription',
-                        params: {
-                          recurring_id: subscription_id,
-                          canceled_by: reason
-                        })
+    ChampaignQueue.push(
+      { type: 'cancel_subscription',
+        params: {
+          recurring_id: subscription_id,
+          canceled_by: reason
+        } },
+      { group_id: "braintree-subscription:#{id}" }
+    )
   end
 
   def publish_amount_update
-    ChampaignQueue.push(type: 'recurring_payment_update',
-                        params: {
-                          recurring_id: subscription_id,
-                          amount: amount.to_s
-                        })
+    ChampaignQueue.push(
+      { type: 'recurring_payment_update',
+        params: {
+          recurring_id: subscription_id,
+          amount: amount.to_s
+        } },
+      { group_id: "braintree-subscription:#{id}" }
+    )
   end
 end

--- a/app/models/payment/braintree/transaction.rb
+++ b/app/models/payment/braintree/transaction.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: payment_braintree_transactions
@@ -27,7 +28,7 @@ class Payment::Braintree::Transaction < ApplicationRecord
   belongs_to :payment_method, class_name: 'Payment::Braintree::PaymentMethod'
   belongs_to :customer,       class_name: 'Payment::Braintree::Customer', primary_key: 'customer_id'
   belongs_to :subscription,   class_name: 'Payment::Braintree::Subscription'
-  enum status: [:success, :failure]
+  enum status: %i[success failure]
 
   scope :one_off, -> { where(subscription_id: nil) }
 
@@ -41,6 +42,8 @@ class Payment::Braintree::Transaction < ApplicationRecord
         status: status == 'success' ? 'completed' : 'failed',
         amount: amount.to_s
       }
-    }, { delay: 120 })
+    },
+                        { delay: 120,
+                          group_id: "braintree-subscription:#{subscription.id}" })
   end
 end

--- a/app/models/payment/go_cardless/transaction.rb
+++ b/app/models/payment/go_cardless/transaction.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: payment_go_cardless_transactions
@@ -56,11 +57,11 @@ class Payment::GoCardless::Transaction < ApplicationRecord
     end
 
     event :run_confirm do
-      transitions from: [:created, :submitted], to: :confirmed
+      transitions from: %i[created submitted], to: :confirmed
     end
 
     event :run_payout do
-      transitions from: [:created, :submitted, :confirmed], to: :paid_out
+      transitions from: %i[created submitted confirmed], to: :paid_out
     end
 
     event :run_cancel do
@@ -86,6 +87,8 @@ class Payment::GoCardless::Transaction < ApplicationRecord
         success: 0,
         status: 'failed'
       }
-    }, { delay: 120 })
+    },
+                        { delay: 120,
+                          group_id: "gocardless-subscription:#{id}" })
   end
 end

--- a/app/services/action_queue.rb
+++ b/app/services/action_queue.rb
@@ -11,7 +11,7 @@ module ActionQueue
     end
 
     def push
-      ChampaignQueue.push(payload.merge(meta))
+      ChampaignQueue.push(payload.merge(meta), group_id: "action:#{@action.id}")
     end
 
     def page

--- a/app/services/call_event.rb
+++ b/app/services/call_event.rb
@@ -11,7 +11,7 @@ module CallEvent
     end
 
     def publish
-      ChampaignQueue.push(payload)
+      ChampaignQueue.push(payload, group_id: "call:#{@call.id}")
     end
 
     private

--- a/app/services/campaign_creator.rb
+++ b/app/services/campaign_creator.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CampaignCreator
   def self.run(params)
     new(params).run
@@ -17,8 +18,11 @@ class CampaignCreator
   private
 
   def publish_event
-    ChampaignQueue.push(type: 'create_campaign',
-                        name: @campaign.name,
-                        campaign_id: @campaign.id)
+    ChampaignQueue.push(
+      { type: 'create_campaign',
+        name: @campaign.name,
+        campaign_id: @campaign.id },
+      { group_id: "campaign:#{@campaign.id}" }
+    )
   end
 end

--- a/app/services/campaign_updater.rb
+++ b/app/services/campaign_updater.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class CampaignUpdater
   def self.run(campaign, params)
     new(campaign, params).run
@@ -18,8 +19,11 @@ class CampaignUpdater
   private
 
   def publish_event
-    ChampaignQueue.push(type: 'update_campaign',
-                        name: @campaign.name,
-                        campaign_id: @campaign.id)
+    ChampaignQueue.push(
+      { type: 'update_campaign',
+        name: @campaign.name,
+        campaign_id: @campaign.id },
+      { group_id: "campaign:#{@campaign.id}" }
+    )
   end
 end

--- a/app/services/queue_manager.rb
+++ b/app/services/queue_manager.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class QueueManager
   include Rails.application.routes.url_helpers
 
@@ -31,7 +32,8 @@ class QueueManager
 
   def to_queue(additions = {})
     ChampaignQueue.push(
-      data_for_queue.merge(additions)
+      data_for_queue.merge(additions),
+      group_id: "page:#{@page.id}"
     )
   end
 

--- a/spec/features/express_donations/email_one_click_spec.rb
+++ b/spec/features/express_donations/email_one_click_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 require_relative 'shared_methods'
 
@@ -71,7 +72,8 @@ feature 'Express From Mailing Link' do
     expect(customer.transactions.count).to eq(1)
 
     @is_authenticated = 1
-    expect(ChampaignQueue).to receive(:push).with(queue_payload)
+    expect(ChampaignQueue).to receive(:push)
+      .with(queue_payload, group_id: /action:\d+/)
 
     VCR.use_cassette('feature_member_email_donation') do
       visit page_path(donation_page, amount: '2.10', currency: 'GBP', akid: valid_akid, one_click: true)
@@ -91,7 +93,8 @@ feature 'Express From Mailing Link' do
     expect(Action.count).to eq(1)
 
     @is_authenticated = 0
-    expect(ChampaignQueue).to receive(:push).with(queue_payload)
+    expect(ChampaignQueue).to receive(:push)
+      .with(queue_payload, group_id: /action:\d+/)
 
     VCR.use_cassette('feature_one_click_cookie') do
       visit page_path(donation_page, amount: '2.10', currency: 'GBP', akid: valid_akid, one_click: true)

--- a/spec/lib/champaign_queue/clients/sqs_spec.rb
+++ b/spec/lib/champaign_queue/clients/sqs_spec.rb
@@ -17,7 +17,7 @@ describe ChampaignQueue::Clients::Sqs do
         </SendMessageResponse>)
     end
 
-    let(:request_body) { 'Action=SendMessage&DelaySeconds=0&MessageBody=%7B%22foo%22%3A%22bar%22%7D&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F679051310897%2Fdemo&Version=2012-11-05' }
+    let(:request_body) { 'Action=SendMessage&DelaySeconds=0&MessageBody=%7B%22foo%22%3A%22bar%22%7D&MessageGroupId=abc&QueueUrl=https%3A%2F%2Fsqs.us-east-1.amazonaws.com%2F679051310897%2Fdemo&Version=2012-11-05' }
     let(:request_uri)  { 'https://sqs.us-east-1.amazonaws.com/679051310897/demo' }
 
     before do
@@ -33,7 +33,7 @@ describe ChampaignQueue::Clients::Sqs do
 
     it 'delivers payload to AWS SQS Queue' do
       Timecop.freeze('2015/01/01') do
-        resp = ChampaignQueue::Clients::Sqs.push(foo: :bar)
+        resp = ChampaignQueue::Clients::Sqs.push({ foo: :bar }, { group_id: 'abc' })
 
         expect(resp.message_id).to eq('918aba5a-b70f-4e31-9905-ba02000fcdaa')
       end
@@ -47,7 +47,7 @@ describe ChampaignQueue::Clients::Sqs do
 
     it 'does not deliver payload to AWS SQS Queue' do
       expect_any_instance_of(Aws::SQS::Client).to_not receive(:send_message)
-      ChampaignQueue::Clients::Sqs.push(foo: :bar)
+      ChampaignQueue::Clients::Sqs.push({ foo: :bar }, { group_id: 'abc' })
     end
   end
 end

--- a/spec/lib/champaign_queue_spec.rb
+++ b/spec/lib/champaign_queue_spec.rb
@@ -11,9 +11,9 @@ describe ChampaignQueue do
 
       it 'delegates to Client::Sqs' do
         expect(ChampaignQueue::Clients::Sqs)
-          .to receive(:push).with({ foo: 'bar' }, {})
+          .to receive(:push).with({ foo: 'bar' }, { group_id: 'bla' })
 
-        ChampaignQueue.push(foo: 'bar')
+        ChampaignQueue.push({ foo: 'bar' }, { group_id: 'bla' })
       end
     end
 
@@ -22,7 +22,7 @@ describe ChampaignQueue do
         expect(ChampaignQueue::Clients::Sqs)
           .to_not receive(:push)
 
-        ChampaignQueue.push(foo: 'bar')
+        ChampaignQueue.push(foo: 'bar', group_id: 'bla')
       end
     end
   end

--- a/spec/lib/payment_processor/go_cardless/webhook_handler_spec.rb
+++ b/spec/lib/payment_processor/go_cardless/webhook_handler_spec.rb
@@ -359,11 +359,13 @@ module PaymentProcessor::GoCardless
 
         context 'first created payment' do
           it 'posts to queue' do
-            expect(ChampaignQueue).to have_received(:push)
-              .with(type: 'subscription-payment',
-                    params: {
-                      recurring_id: 'index_ID_123'
-                    }).once
+            expect(ChampaignQueue).to have_received(:push).with(
+              { type: 'subscription-payment',
+                params: {
+                  recurring_id: 'index_ID_123'
+                } },
+              { group_id: "gocardless-subscription:#{subscription.id}" }
+            ).once
           end
         end
 
@@ -373,11 +375,13 @@ module PaymentProcessor::GoCardless
           end
 
           it 'posts to queue' do
-            expect(ChampaignQueue).to have_received(:push)
-              .with(type: 'subscription-payment',
-                    params: {
-                      recurring_id: 'index_ID_123'
-                    }).twice
+            expect(ChampaignQueue).to have_received(:push).with(
+              { type: 'subscription-payment',
+                params: {
+                  recurring_id: 'index_ID_123'
+                } },
+              { group_id: "gocardless-subscription:#{subscription.id}" }
+            ).twice
           end
         end
       end

--- a/spec/models/payment/braintree/subscription_spec.rb
+++ b/spec/models/payment/braintree/subscription_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: payment_braintree_subscriptions
@@ -58,11 +59,14 @@ describe Payment::Braintree::Subscription do
   describe 'publish cancellation event' do
     let(:subscription) { create(:payment_braintree_subscription, subscription_id: 'asd123') }
     it 'pushes to the event queue with correct parameters' do
-      expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
-                                                    params: {
-                                                      recurring_id: 'asd123',
-                                                      canceled_by: 'user'
-                                                    })
+      expect(ChampaignQueue).to receive(:push).with(
+        { type: 'cancel_subscription',
+          params: {
+            recurring_id: 'asd123',
+            canceled_by: 'user'
+          } },
+        { group_id: "braintree-subscription:#{subscription.id}" }
+      )
       subscription.publish_cancellation('user')
     end
   end
@@ -70,11 +74,14 @@ describe Payment::Braintree::Subscription do
   describe 'publish amount update event' do
     let(:subscription) { create(:payment_braintree_subscription, subscription_id: 'asd123', amount: 100) }
     it 'pushes to the event queue with correct parameters' do
-      expect(ChampaignQueue).to receive(:push).with(type: 'recurring_payment_update',
-                                                    params: {
-                                                      recurring_id: 'asd123',
-                                                      amount: '100.0'
-                                                    })
+      expect(ChampaignQueue).to receive(:push).with(
+        { type: 'recurring_payment_update',
+          params: {
+            recurring_id: 'asd123',
+            amount: '100.0'
+          } },
+        { group_id: "braintree-subscription:#{subscription.id}" }
+      )
       subscription.publish_amount_update
     end
   end

--- a/spec/models/payment/braintree/transaction_spec.rb
+++ b/spec/models/payment/braintree/transaction_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: payment_braintree_transactions
@@ -118,7 +119,11 @@ describe Payment::Braintree::Transaction do
           amount: '123.0'
         }
       }
-      expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)
+      expect(ChampaignQueue).to receive(:push).with(
+        expected_payload,
+        delay: 120,
+        group_id: "braintree-subscription:#{subscription.id}"
+      )
       transaction.publish_subscription_charge
     end
   end

--- a/spec/models/payment/go_cardless/subscription_spec.rb
+++ b/spec/models/payment/go_cardless/subscription_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: payment_go_cardless_subscriptions
@@ -163,11 +164,14 @@ describe Payment::GoCardless::Subscription do
   describe 'publish cancellation event' do
     let(:subscription) { create(:payment_go_cardless_subscription, go_cardless_id: 'adklwe') }
     it 'pushes to the event queue with correct parameters' do
-      expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
-                                                    params: {
-                                                      recurring_id: 'adklwe',
-                                                      canceled_by: 'user'
-                                                    })
+      expect(ChampaignQueue).to receive(:push).with(
+        { type: 'cancel_subscription',
+          params: {
+            recurring_id: 'adklwe',
+            canceled_by: 'user'
+          } },
+        { group_id: "gocardless-subscription:#{subscription.id}" }
+      )
       subscription.publish_cancellation('user')
     end
   end

--- a/spec/requests/api/actions_spec.rb
+++ b/spec/requests/api/actions_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Api Actions' do
@@ -66,11 +67,11 @@ describe 'Api Actions' do
 
     describe 'queue' do
       before do
-        post "/api/pages/#{page.id}/actions", params: params,  headers: headers
+        post "/api/pages/#{page.id}/actions", params: params, headers: headers
       end
 
       it 'pushes action to queue' do
-        expect(ChampaignQueue).to have_received(:push).with(message_body)
+        expect(ChampaignQueue).to have_received(:push).with(message_body, group_id: /action:\d+/)
       end
     end
 
@@ -87,7 +88,8 @@ describe 'Api Actions' do
               params: hash_including(
                 country: name
               )
-            )
+            ),
+            group_id: /action:\d+/
           )
         end
       end
@@ -216,7 +218,8 @@ describe 'Api Actions' do
             }
           )
 
-          expect(ChampaignQueue).to have_received(:push).with(expected_params)
+          expect(ChampaignQueue).to have_received(:push)
+            .with(expected_params, group_id: /action:\d+/)
         end
       end
     end

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Braintree API' do
@@ -108,7 +109,11 @@ describe 'Braintree API' do
               }
             }
 
-            expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)
+            expect(ChampaignQueue).to receive(:push).with(
+              expected_payload,
+              delay: 120,
+              group_id: "braintree-subscription:#{@subscription.id}"
+            )
 
             subject
           end
@@ -173,7 +178,11 @@ describe 'Braintree API' do
               }
             }
 
-            expect(ChampaignQueue).to receive(:push).with(expected_payload, delay: 120)
+            expect(ChampaignQueue).to receive(:push).with(
+              expected_payload,
+              delay: 120,
+              group_id: "braintree-subscription:#{subscription.id}"
+            )
             subject
           end
         end
@@ -227,11 +236,14 @@ describe 'Braintree API' do
           end
 
           it 'posts a cancellation event to the ChampaignQueue' do
-            expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
-                                                          params: {
-                                                            recurring_id: subscription.subscription_id,
-                                                            canceled_by: 'processor'
-                                                          })
+            expect(ChampaignQueue).to receive(:push).with(
+              { type: 'cancel_subscription',
+                params: {
+                  recurring_id: subscription.subscription_id,
+                  canceled_by: 'processor'
+                } },
+              { group_id: "braintree-subscription:#{subscription.id}" }
+            )
             subject
           end
 

--- a/spec/requests/api/email_targets_spec.rb
+++ b/spec/requests/api/email_targets_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Emailing Targets', type: :request do
@@ -68,7 +69,7 @@ describe 'Emailing Targets', type: :request do
     end
 
     it 'posts action to queue' do
-      expected_options = hash_including(
+      payload = hash_including(
         type: 'action',
         params: hash_including(page: 'foo-bar-petition',
                                name: "Sender's Name",
@@ -78,7 +79,10 @@ describe 'Emailing Targets', type: :request do
                                akid: akid)
       )
 
-      expect(ChampaignQueue).to have_received(:push).with(expected_options)
+      expect(ChampaignQueue).to have_received(:push).with(
+        payload,
+        group_id: /action:\d+/
+      )
     end
   end
 end

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -1,5 +1,6 @@
 # coding: utf-8
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'GoCardless API' do
@@ -300,7 +301,9 @@ describe 'GoCardless API' do
 
           it 'posts donation action to queue with correct data' do
             allow(ChampaignQueue).to receive(:push)
-            expect(ChampaignQueue).to receive(:push).with(donation_push_params)
+            expect(ChampaignQueue).to receive(:push).with(
+              donation_push_params, group_id: /action:\d+/
+            )
             subject
           end
 
@@ -453,7 +456,8 @@ describe 'GoCardless API' do
             allow(ChampaignQueue).to receive(:push)
 
             subject
-            expect(ChampaignQueue).to have_received(:push).with(donation_push_params)
+            expect(ChampaignQueue).to have_received(:push)
+              .with(donation_push_params, group_id: /action:\d+/)
           end
 
           it 'stores amount, currency, is_subscription, and subscription_id in form_data on the Action' do
@@ -560,7 +564,6 @@ describe 'GoCardless API' do
         end
 
         it 'does not push to the queue' do
-          allow(ChampaignQueue).to receive(:push)
           expect(ChampaignQueue).not_to receive(:push)
           subject
         end

--- a/spec/requests/api/go_cardless/webhooks_spec.rb
+++ b/spec/requests/api/go_cardless/webhooks_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'subscriptions' do
@@ -83,7 +84,10 @@ describe 'subscriptions' do
       describe 'Posting to queue' do
         context 'with existing transaction' do
           it 'posts to queue' do
-            expect(ChampaignQueue).to have_received(:push).with(type: 'subscription-payment', params: { recurring_id: 'index_ID_123' })
+            expect(ChampaignQueue).to have_received(:push).with(
+              { type: 'subscription-payment', params: { recurring_id: 'index_ID_123' } },
+              { group_id: /gocardless-subscription:\d+/ }
+            )
           end
         end
       end
@@ -137,7 +141,9 @@ describe 'subscriptions' do
             success: 0,
             status: 'failed'
           }
-        }, { delay: 120 })
+        },
+                                                      { delay: 120,
+                                                        group_id: /gocardless-subscription:\d+/ })
         post('/api/go_cardless/webhook', params: events, headers: headers)
       end
     end

--- a/spec/requests/api/members_spec.rb
+++ b/spec/requests/api/members_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'api/members' do
@@ -29,14 +30,15 @@ describe 'api/members' do
       allow(ChampaignQueue).to receive :push
       subject
       expect(ChampaignQueue).to have_received(:push).with(
-        type: 'subscribe_member',
-        params: {
-          email: params[:email],
-          name: params[:name],
-          country: params[:country],
-          locale: params[:locale],
-          postal: params[:postal]
-        }
+        { type: 'subscribe_member',
+          params: {
+            email: params[:email],
+            name: params[:name],
+            country: params[:country],
+            locale: params[:locale],
+            postal: params[:postal]
+          } },
+        { group_id: /member:\d+/ }
       )
     end
 

--- a/spec/requests/api/stateless/braintree/subscriptions_spec.rb
+++ b/spec/requests/api/stateless/braintree/subscriptions_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'API::Stateless Braintree Subscriptions' do
@@ -124,11 +125,14 @@ describe 'API::Stateless Braintree Subscriptions' do
 
     it 'pushes a cancelled subscription event to the event queue' do
       VCR.use_cassette('stateless api cancel subscription') do
-        expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
-                                                      params: {
-                                                        recurring_id: '4ts4r2',
-                                                        canceled_by: 'user'
-                                                      })
+        expect(ChampaignQueue).to receive(:push).with(
+          { type: 'cancel_subscription',
+            params: {
+              recurring_id: '4ts4r2',
+              canceled_by: 'user'
+            } },
+          { group_id: /braintree-subscription:\d+/ }
+        )
 
         delete "/api/stateless/braintree/subscriptions/#{cancel_this_subscription.id}", headers: auth_headers
       end

--- a/spec/requests/api/stateless/go_cardless/subscriptions_spec.rb
+++ b/spec/requests/api/stateless/go_cardless/subscriptions_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'API::Stateless GoCardless Subscriptions' do
@@ -142,11 +143,14 @@ describe 'API::Stateless GoCardless Subscriptions' do
 
     it 'pushes a cancelled subscription event to the event queue' do
       VCR.use_cassette('stateless api cancel go_cardless subscription') do
-        expect(ChampaignQueue).to receive(:push).with(type: 'cancel_subscription',
-                                                      params: {
-                                                        recurring_id: 'SB00003GHBQ3YF',
-                                                        canceled_by: 'user'
-                                                      })
+        expect(ChampaignQueue).to receive(:push).with(
+          { type: 'cancel_subscription',
+            params: {
+              recurring_id: 'SB00003GHBQ3YF',
+              canceled_by: 'user'
+            } },
+          { group_id: "gocardless-subscription:#{delete_subscription.id}" }
+        )
 
         delete "/api/stateless/go_cardless/subscriptions/#{delete_subscription.id}", headers: auth_headers
       end

--- a/spec/requests/api/stateless/members_spec.rb
+++ b/spec/requests/api/stateless/members_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'API::Stateless Members' do
@@ -109,18 +110,19 @@ describe 'API::Stateless Members' do
         allow(ChampaignQueue).to receive(:push)
 
         expect(ChampaignQueue).to receive(:push).with(
-          type: 'update_member',
-          params: {
-            akid: member.actionkit_user_id,
-            email: 'test+1@example.com',
-            first_name: 'Harry',
-            last_name: 'Tubman',
-            country: 'United Kingdom',
-            city: 'London',
-            postal: '12345',
-            address1: 'Jam Factory 123',
-            address2: nil
-          }
+          { type: 'update_member',
+            params: {
+              akid: member.actionkit_user_id,
+              email: 'test+1@example.com',
+              first_name: 'Harry',
+              last_name: 'Tubman',
+              country: 'United Kingdom',
+              city: 'London',
+              postal: '12345',
+              address1: 'Jam Factory 123',
+              address2: nil
+            } },
+          { group_id: "member:#{member.id}" }
         )
         subject
       end

--- a/spec/requests/campaigns_spec.rb
+++ b/spec/requests/campaigns_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Campaigns', type: :request do
@@ -24,9 +25,12 @@ describe 'Campaigns', type: :request do
       end
 
       it 'publishes the event' do
-        expect(ChampaignQueue).to receive(:push).with(name: 'Super Campaign',
-                                                      type: 'create_campaign',
-                                                      campaign_id: be_a(Integer))
+        expect(ChampaignQueue).to receive(:push).with(
+          { name: 'Super Campaign',
+            type: 'create_campaign',
+            campaign_id: be_a(Integer) },
+          { group_id: /campaign:\d+/ }
+        )
         post '/campaigns', params
       end
     end
@@ -67,9 +71,10 @@ describe 'Campaigns', type: :request do
 
       it 'publishes the event' do
         expect(ChampaignQueue).to receive(:push).with(
-          type: 'update_campaign',
-          name: 'Updated Campaign',
-          campaign_id: campaign.id
+          { type: 'update_campaign',
+            name: 'Updated Campaign',
+            campaign_id: campaign.id },
+          { group_id: /campaign:\d+/ }
         )
         put "/campaigns/#{campaign.id}", params
       end

--- a/spec/services/manage_action_spec.rb
+++ b/spec/services/manage_action_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe ManageAction do
@@ -24,7 +25,7 @@ describe ManageAction do
     end
 
     it 'posts action to queue' do
-      expected = {
+      payload = {
         type: 'action',
         meta: hash_including(
           title: 'Foo Bar'
@@ -38,7 +39,8 @@ describe ManageAction do
         }
       }
 
-      expect(ChampaignQueue).to receive(:push).with(expected)
+      expect(ChampaignQueue).to receive(:push)
+        .with(payload, group_id: /action:\d+/)
       subject
     end
 

--- a/spec/services/manage_braintree_donation_spec.rb
+++ b/spec/services/manage_braintree_donation_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 describe ManageBraintreeDonation do
   let(:braintree_arguments) do
@@ -92,7 +93,8 @@ describe ManageBraintreeDonation do
         expected = {
           type: 'donation'
         }
-        expect(ChampaignQueue).to have_received(:push).with(hash_including(expected))
+        expect(ChampaignQueue).to have_received(:push)
+          .with(hash_including(expected), group_id: /action:\d+/)
       end
 
       it 'is marked as a donation' do

--- a/spec/services/queue_manager_spec.rb
+++ b/spec/services/queue_manager_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe QueueManager do
@@ -28,7 +29,8 @@ describe QueueManager do
       it 'posts to queue' do
         expect(ChampaignQueue).to receive(:push)
           .with(expected_params.merge(donation_uri: 'http://example.com/donation',
-                                      petition_uri: 'http://example.com/petition'))
+                                      petition_uri: 'http://example.com/petition'),
+                group_id: "page:#{page.id}")
 
         subject
       end
@@ -38,7 +40,9 @@ describe QueueManager do
       subject { QueueManager.push(page, job_type: :create) }
 
       it 'posts to queue' do
-        expect(ChampaignQueue).to receive(:push).with(expected_params.merge(type: :create))
+        expect(ChampaignQueue).to receive(:push).with(
+          expected_params.merge(type: :create), group_id: "page:#{page.id}"
+        )
         subject
       end
     end


### PR DESCRIPTION
FIFO queues need an extra param called `MessageGroupId`. This params identify a group of messages that need to be delivered in order. Messages with different group ids may be delivered in any order. 