### PR TITLE
Allow only displaying direct debit as a payment method

### DIFF
--- a/app/javascript/components/Payment/PaymentTypeSelection.js
+++ b/app/javascript/components/Payment/PaymentTypeSelection.js
@@ -16,23 +16,21 @@ type Props = {
 export class PaymentTypeSelection extends Component {
   props: Props;
 
-  constructor(props: Props) {
-    super(props);
+  showCardAndPaypal() {
+    if (this.props.directDebitOnly && !this.props.showDirectDebit) return true;
+    if (this.props.directDebitOnly) return false;
+    return true;
   }
 
   paymentTypes(): PaymentType[] {
     const paymentTypes = [];
 
-    if (
-      !this.props.directDebitOnly ||
-      (this.props.directDebitOnly && !this.props.showDirectDebit)
-    ) {
-      paymentTypes.push('paypal');
-      paymentTypes.push('card');
-    }
-
     if (this.props.showDirectDebit) {
       paymentTypes.push('gocardless');
+    }
+
+    if (this.showCardAndPaypal()) {
+      paymentTypes.push('paypal', 'card');
     }
 
     return paymentTypes;

--- a/app/javascript/components/Payment/PaymentTypeSelection.js
+++ b/app/javascript/components/Payment/PaymentTypeSelection.js
@@ -1,39 +1,70 @@
 // @flow
 import React, { Component } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { connect } from 'react-redux';
 import PaymentMethodWrapper from '../ExpressDonation/PaymentMethodWrapper';
+import type { AppState } from '../../state';
+import type { PaymentType } from '../../state/fundraiser/types';
 
-export default class PaymentTypeSelection extends Component {
-  props: {
-    disabled?: boolean;
-    currentPaymentType?: string;
-    onChange: (paymentType: string) => void;
-    showDirectDebit: ?boolean;
-  };
+type Props = {
+  disabled?: boolean,
+  currentPaymentType?: string,
+  onChange: (paymentType: string) => void,
+  showDirectDebit: boolean,
+  directDebitOnly: boolean,
+};
+export class PaymentTypeSelection extends Component {
+  props: Props;
+
+  constructor(props: Props) {
+    super(props);
+  }
+
+  paymentTypes(): PaymentType[] {
+    const paymentTypes = [];
+
+    if (
+      !this.props.directDebitOnly ||
+      (this.props.directDebitOnly && !this.props.showDirectDebit)
+    ) {
+      paymentTypes.push('paypal');
+      paymentTypes.push('card');
+    }
+
+    if (this.props.showDirectDebit) {
+      paymentTypes.push('gocardless');
+    }
+
+    return paymentTypes;
+  }
 
   render() {
     const { disabled, currentPaymentType, onChange } = this.props;
-    const methods = ['card', 'paypal'];
-    if (this.props.showDirectDebit) methods.push('gocardless');
 
     return (
-      <div className='PaymentTypeSelection__payment-methods'>
+      <div className="PaymentTypeSelection__payment-methods">
         <PaymentMethodWrapper>
           <span className="PaymentTypeSelection__prompt">
-            <FormattedMessage id="fundraiser.payment_type_prompt" defaultMessage="Payment Method" />
+            <FormattedMessage
+              id="fundraiser.payment_type_prompt"
+              defaultMessage="Payment Method"
+            />
           </span>
 
-          {methods.map((method, i) => {
+          {this.paymentTypes().map((paymentType, i) => {
             return (
               <div className="PaymentMethod" key={i}>
                 <label>
-                    <input
-                      disabled={disabled}
-                      type="radio"
-                      checked={currentPaymentType === method}
-                      onChange={(e) => onChange(method)}
-                    />
-                  <FormattedMessage id={`fundraiser.payment_methods.${method}`} defaultMessage="Unknown payment method" />
+                  <input
+                    disabled={disabled}
+                    type="radio"
+                    checked={currentPaymentType === paymentType}
+                    onChange={e => onChange(paymentType)}
+                  />
+                  <FormattedMessage
+                    id={`fundraiser.payment_methods.${paymentType}`}
+                    defaultMessage="Unknown payment method"
+                  />
                 </label>
               </div>
             );
@@ -43,3 +74,8 @@ export default class PaymentTypeSelection extends Component {
     );
   }
 }
+
+export default connect((state: AppState) => ({
+  showDirectDebit: state.fundraiser.showDirectDebit,
+  directDebitOnly: state.fundraiser.directDebitOnly,
+}))(PaymentTypeSelection);

--- a/app/javascript/fundraiser/FundraiserView.test.js
+++ b/app/javascript/fundraiser/FundraiserView.test.js
@@ -9,7 +9,7 @@ import { mountWithIntl } from '../../../spec/jest/intl-enzyme-test-helpers';
 import type {
   FundraiserAction,
   FundraiserInitializationOptions,
-} from '../state/fundraiser/actions';
+} from '../state/fundraiser/types';
 
 global.fbq = () => null;
 
@@ -347,6 +347,11 @@ describe('Donation Amount Tab', function() {
 
 describe('Payment Panel', function() {
   describe('Initial state', () => {
+    describe('when directDebitOnly = true', () => {
+      it('[pending] gocardless is the default if showDirectDebit is true');
+      it('[pending] has no effect if showDirectDebit is false');
+    });
+
     it("displays the user's name if they are logged in", () => {
       initialize({
         member: { email: 'asdf@gmail.com', name: 'As Df', country: 'US' },

--- a/app/javascript/packs/fundraiser.js
+++ b/app/javascript/packs/fundraiser.js
@@ -1,5 +1,4 @@
 // @flow
-import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 import queryString from 'query-string';
@@ -8,21 +7,23 @@ import FundraiserView from '../fundraiser/FundraiserView';
 import configureStore from '../state';
 
 import type { AppState } from '../state/reducers';
-import type { DonationBands } from '../state/fundraiser/helpers';
+import type { DonationBands } from '../state/fundraiser/types.js';
 import type { PageAction } from '../state/page/reducer';
+import type { InitialAction } from '../state/reducers';
 import type {
   FundraiserAction,
   FundraiserInitializationOptions,
-} from '../state/fundraiser/actions';
+} from '../state/fundraiser/types';
 
 type SearchParams = {
-  recurring_default?: string,
   amount?: string,
   currency?: string,
+  dd_only?: string,
+  recurring_default?: string,
   preselect?: string,
 };
 
-type Action = FundraiserAction | PageAction;
+type Action = FundraiserAction | PageAction | InitialAction;
 const store: Store<AppState, FundraiserAction> = window.champaign.store;
 const dispatch = (a: Action): Action => store.dispatch(a);
 
@@ -72,6 +73,8 @@ window.mountFundraiser = function(root: string, data: MountFundraiserOptions) {
 
   const rDefault = search.recurring_default || data.fundraiser.recurringDefault;
   dispatch({ type: 'set_recurring_defaults', payload: rDefault });
+
+  dispatch({ type: 'set_direct_debit_only', payload: search.dd_only === '1' });
 
   const options = { store, locale: data.locale };
 

--- a/app/javascript/packs/member_facing.js
+++ b/app/javascript/packs/member_facing.js
@@ -5,7 +5,6 @@ import '../member-facing/registration';
 import '../member-facing/track_shares';
 import 'whatwg-fetch';
 
-import airbrake from 'airbrake-js';
 import URI from 'urijs';
 import configureStore from '../state';
 import Petition from '../member-facing/backbone/petition';

--- a/app/javascript/state/fundraiser/actions.js
+++ b/app/javascript/state/fundraiser/actions.js
@@ -1,39 +1,6 @@
 // @flow
 import $ from 'jquery';
-import type { FormField, InitialAction } from '../reducers';
-import type { DonationBands, EnumRecurringDefault } from './helpers';
-
-export type FundraiserInitializationOptions = {
-  pageId: string,
-  currency: string,
-  amount: string,
-  donationBands: { [key: string]: number[] },
-  showDirectDebit: boolean,
-  formValues: { [key: string]: string },
-  formId: string,
-  outstandingFields: string[],
-  title: string,
-  preselectAmount: boolean,
-  fields: FormField[],
-  recurringDefault: EnumRecurringDefault,
-  freestanding: boolean,
-};
-
-export type FundraiserAction =
-  | InitialAction
-  | { type: 'initialize_fundraiser', payload: FundraiserInitializationOptions }
-  | { type: 'change_amount', payload: ?number }
-  | { type: 'change_currency', payload: string }
-  | { type: 'change_step', payload: number }
-  | { type: 'preselect_amount', payload: boolean }
-  | { type: 'set_donation_bands', payload: DonationBands }
-  | { type: 'set_payment_type', payload: ?string }
-  | { type: 'set_recurring', payload: boolean }
-  | { type: 'set_recurring_defaults', payload?: string }
-  | { type: 'set_submitting', payload: boolean }
-  | { type: 'set_store_in_vault', payload: boolean }
-  | { type: 'toggle_direct_debit', payload: boolean }
-  | { type: 'update_form', payload: { [key: string]: any } };
+import type { FundraiserAction, PaymentType } from './types';
 
 export function changeAmount(payload: ?number): FundraiserAction {
   $.publish('fundraiser:change_amount', [payload]);
@@ -67,6 +34,6 @@ export function setStoreInVault(payload: boolean = false): FundraiserAction {
   return { type: 'set_store_in_vault', payload };
 }
 
-export function setPaymentType(payload: ?string = null): FundraiserAction {
+export function setPaymentType(payload: PaymentType): FundraiserAction {
   return { type: 'set_payment_type', payload };
 }

--- a/app/javascript/state/fundraiser/helpers.js
+++ b/app/javascript/state/fundraiser/helpers.js
@@ -1,43 +1,13 @@
 // @flow
-import type { FormField } from '../reducers';
+import type {
+  DonationBands,
+  EnumRecurringDefault,
+  FeaturedAmountState,
+  Fundraiser,
+  PaymentType,
+  RecurringState,
+} from './types';
 
-type RecurringState = {
-  recurring: boolean,
-  recurringDefault: EnumRecurringDefault,
-};
-
-type FeaturedAmountState = {
-  preselectAmount: boolean,
-  donationFeaturedAmount?: number,
-};
-
-export type EnumRecurringDefault = 'one_off' | 'recurring' | 'only_recurring';
-
-export type DonationBands = { [id: string]: number[] };
-export type FeaturedAmounts = { [id: string]: number };
-
-export type Fundraiser = {
-  title: string,
-  currency: string,
-  donationBands: DonationBands,
-  donationFeaturedAmount?: number,
-  donationAmount?: number,
-  currentStep: number,
-  recurring: boolean,
-  recurringDefault: EnumRecurringDefault,
-  storeInVault: boolean,
-  paymentMethods: any[],
-  formId: string,
-  fields: FormField[],
-  form: Object,
-  formValues: Object,
-  currentPaymentType: ?string,
-  showDirectDebit?: boolean,
-  freestanding?: boolean,
-  submitting: boolean,
-  preselectAmount: boolean,
-  outstandingFields: string[],
-};
 export const initialState: Fundraiser = {
   currency: 'USD',
   donationBands: {
@@ -53,8 +23,9 @@ export const initialState: Fundraiser = {
   recurringDefault: 'one_off',
   recurring: false,
   storeInVault: true,
-  currentPaymentType: null,
+  currentPaymentType: 'card',
   showDirectDebit: false,
+  directDebitOnly: false,
   paymentMethods: [],
   title: '',
   fields: [],

--- a/app/javascript/state/fundraiser/reducer.js
+++ b/app/javascript/state/fundraiser/reducer.js
@@ -7,8 +7,12 @@ import {
   pickMedianAmount,
   featuredAmountState,
 } from './helpers';
-import type { FundraiserAction as Action } from './actions';
-import type { Fundraiser as State, DonationBands } from './helpers';
+
+import type {
+  Fundraiser as State,
+  FundraiserAction as Action,
+  DonationBands,
+} from './types';
 
 export default (state: State = initialState, action: Action): State => {
   switch (action.type) {
@@ -51,6 +55,15 @@ export default (state: State = initialState, action: Action): State => {
       return { ...state, currentStep };
     case 'update_form':
       return { ...state, form: action.payload };
+    case 'set_direct_debit_only':
+      if (state.showDirectDebit) {
+        return {
+          ...state,
+          currentPaymentType: 'gocardless',
+          directDebitOnly: true,
+        };
+      }
+      return state;
     case 'set_donation_bands':
       const payload: DonationBands = action.payload;
       const donationBands: DonationBands = isEmpty(payload)

--- a/app/javascript/state/fundraiser/types.js
+++ b/app/javascript/state/fundraiser/types.js
@@ -1,0 +1,77 @@
+// @flow
+
+import type { FormField } from '../reducers';
+
+export type DonationBands = { [id: string]: number[] };
+
+export type EnumRecurringDefault = 'one_off' | 'recurring' | 'only_recurring';
+
+export type FeaturedAmounts = { [id: string]: number };
+
+export type FeaturedAmountState = {
+  donationFeaturedAmount?: number,
+  preselectAmount: boolean,
+};
+
+export type Fundraiser = {
+  currency: string,
+  currentPaymentType: PaymentType,
+  currentStep: number,
+  directDebitOnly: boolean,
+  donationAmount?: number,
+  donationBands: DonationBands,
+  donationFeaturedAmount?: number,
+  fields: FormField[],
+  form: Object,
+  formId: string,
+  formValues: Object,
+  freestanding?: boolean,
+  outstandingFields: string[],
+  paymentMethods: any[],
+  preselectAmount: boolean,
+  recurring: boolean,
+  recurringDefault: EnumRecurringDefault,
+  showDirectDebit?: boolean,
+  storeInVault: boolean,
+  submitting: boolean,
+  title: string,
+};
+
+export type FundraiserAction =
+  | { type: 'initialize_fundraiser', payload: FundraiserInitializationOptions }
+  | { type: 'change_amount', payload: ?number }
+  | { type: 'change_currency', payload: string }
+  | { type: 'change_step', payload: number }
+  | { type: 'preselect_amount', payload: boolean }
+  | { type: 'set_direct_debit_only', payload: boolean }
+  | { type: 'set_donation_bands', payload: DonationBands }
+  | { type: 'set_payment_type', payload: PaymentType }
+  | { type: 'set_recurring', payload: boolean }
+  | { type: 'set_recurring_defaults', payload?: string }
+  | { type: 'set_submitting', payload: boolean }
+  | { type: 'set_store_in_vault', payload: boolean }
+  | { type: 'toggle_direct_debit', payload: boolean }
+  | { type: 'update_form', payload: { [key: string]: any } };
+
+export type FundraiserInitializationOptions = {
+  amount: string,
+  currency: string,
+  donationBands: DonationBands,
+  fields: FormField[],
+  formValues: { [key: string]: string },
+  formId: string,
+  freestanding: boolean,
+  outstandingFields: string[],
+  pageId: string,
+  preselectAmount: boolean,
+  recurringDefault: EnumRecurringDefault,
+  showDirectDebit: boolean,
+  title: string,
+};
+
+export type PaymentType = 'card' | 'paypal' | 'gocardless';
+
+export type RecurringState = {
+  recurring: boolean,
+  recurringDefault: EnumRecurringDefault,
+};

--- a/app/javascript/state/index.js
+++ b/app/javascript/state/index.js
@@ -6,7 +6,7 @@ import reducers from './reducers';
 // flow types
 export type { Store } from 'redux';
 export type { AppState } from './reducers';
-export type { Fundraiser } from './fundraiser/helpers';
+export type { Fundraiser } from './fundraiser/types';
 export type { Member } from './member/reducer';
 export type { PaymentMethod } from './paymentMethods/reducer';
 

--- a/app/javascript/state/reducers.js
+++ b/app/javascript/state/reducers.js
@@ -18,7 +18,7 @@ export default combineReducers(reducers);
 
 // import types
 import type { Member } from './member/reducer';
-import type { Fundraiser, EnumRecurringDefault } from './fundraiser/helpers';
+import type { Fundraiser, EnumRecurringDefault } from './fundraiser/types';
 import type { PaymentMethod } from './paymentMethods/reducer';
 import type { PageAction } from './page/reducer';
 


### PR DESCRIPTION
This is for a fundraising experiment. We want to be able to pass a `dd_only=1` query parameter in a test that will disable paypal / card payment methods. This simply adds some functionality with some fallback logic (e.g. when the member is not in a direct debit country). The rest of this experiment will be done via `optimizelyHook()`.

I've also moved flow types to their own file around to make fundraiser related `app/javascript/state/*` files easier to read.