### PR TITLE
Speed up boot time by installing bootnstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem 'turnout'
 gem 'twilio-ruby'
 gem 'uglifier'
 gem 'webpacker', git: 'https://github.com/rails/webpacker.git'
+gem 'bootsnap', require: false
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
     aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     bindex (0.5.0)
+    bootsnap (1.1.2)
+      msgpack (~> 1.0)
     bootstrap-sass (3.3.7)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -312,6 +314,7 @@ GEM
     minitest (5.10.2)
     money (6.9.0)
       i18n (>= 0.6.4, < 0.9)
+    msgpack (1.1.0)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -569,6 +572,7 @@ DEPENDENCIES
   aws-sdk (~> 2)
   aws-sdk-rails
   bcrypt (~> 3.1.7)
+  bootsnap
   bootstrap-sass (~> 3.3.5)
   braintree (~> 2.54.0)
   browser (~> 2.0, >= 2.0.3)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
https://github.com/Shopify/bootsnap

Speeds up rails boot time by 50% per README. My test was even faster:

```
# Before
➜ rod:~/code/sou/champaign(development)% time rails r "puts 'helo'"
helo
rails r "puts 'helo'"  5.02s user 1.98s system 94% cpu 7.369 total
# After
➜ rod:~/code/sou/champaign(development) ✗% time rails r "puts 'helo'"
helo
rails r "puts 'helo'"  2.78s user 0.50s system 120% cpu 2.714 total
```