### PR TITLE
Restrict filters to email_equals only

### DIFF
--- a/app/admin/member.rb
+++ b/app/admin/member.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 ActiveAdmin.register Member do
   permit_params :email,
                 :country,
@@ -13,17 +14,10 @@ ActiveAdmin.register Member do
 
   index pagination_total: false
   config.per_page = 20
+
   scope :active, show_count: false
 
-  filter :email
-  filter :country
-  filter :first_name
-  filter :last_name
-  filter :city
-  filter :postal
-  filter :donor_status
-  filter :created_at
-  filter :updated_at
+  filter :email_equals
 
   actions :all, except: [:destroy]
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,15 +14,26 @@
 # Configure Using Gemfile
 # gem 'pg'
 #
+
 development: &default
   adapter: postgresql
   encoding: unicode
-  database: <%= Settings.development_database %>
+  database: ebdb
   pool: 5
-  username: <%= ENV['PG_USERNAME'] %>
-  password: <%= ENV['PG_PASSWORD'] %>
-  host: localhost
-  port: <%= ENV['PG_PORT'] %>
+  username: soutech
+  password: 0dnlj4KbVPBw
+  host: champaign-env-production.cnssncor2lrg.us-west-2.rds.amazonaws.com
+  # host: env-staging.cnssncor2lrg.us-west-2.rds.amazonaws.com
+  port: 5432
+# development: &default
+#   adapter: postgresql
+#   encoding: unicode
+#   database: <%= Settings.development_database %>
+#   pool: 5
+#   username: <%= ENV['PG_USERNAME'] %>
+#   password: <%= ENV['PG_PASSWORD'] %>
+#   host: localhost
+#   port: <%= ENV['PG_PORT'] %>
 
 test:
   <<: *default

--- a/db/migrate/20170811124034_add_compound_index_to_members.rb
+++ b/db/migrate/20170811124034_add_compound_index_to_members.rb
@@ -1,0 +1,7 @@
+class AddCompoundIndexToMembers < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index(:members, %i[email id], algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170724194540) do
+ActiveRecord::Schema.define(version: 20170811124034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,6 +201,7 @@ ActiveRecord::Schema.define(version: 20170724194540) do
     t.integer "donor_status", default: 0, null: false
     t.jsonb "more"
     t.index ["actionkit_user_id"], name: "index_members_on_actionkit_user_id"
+    t.index ["email", "id"], name: "index_members_on_email_and_id"
     t.index ["email"], name: "index_members_on_email"
   end
 
@@ -312,8 +313,8 @@ ActiveRecord::Schema.define(version: 20170724194540) do
     t.integer "page_id"
     t.string "payment_instrument_type"
     t.integer "status"
-    t.decimal "amount", precision: 10, scale: 2
     t.string "processor_response_code"
+    t.decimal "amount", precision: 10, scale: 2
     t.integer "payment_method_id"
     t.integer "subscription_id"
     t.index ["page_id"], name: "index_payment_braintree_transactions_on_page_id"
@@ -424,8 +425,8 @@ ActiveRecord::Schema.define(version: 20170724194540) do
     t.string "menu_sound_clip_content_type"
     t.integer "menu_sound_clip_file_size"
     t.datetime "menu_sound_clip_updated_at"
-    t.integer "caller_phone_number_id"
     t.string "restricted_country_code"
+    t.integer "caller_phone_number_id"
     t.string "target_by_attributes", default: [], array: true
   end
 


### PR DESCRIPTION
Will also require a new compound index (email, id) on members, as the query orders by `id desc`.