### PR TITLE
Omit Call Tool filters with empty values

### DIFF
--- a/app/javascript/components/CallTool/CallToolDrillDown.js
+++ b/app/javascript/components/CallTool/CallToolDrillDown.js
@@ -4,7 +4,7 @@ import {
   compact,
   flatten,
   get,
-  omit,
+  isEmpty,
   omitBy,
   sample,
   startCase,
@@ -37,7 +37,8 @@ export default class CallToolDrillDown extends Component {
   constructor(props: Props) {
     super(props);
 
-    const filters = Object.assign({}, props.filters);
+    // omit filters with empty values
+    const filters = omitBy(Object.assign({}, props.filters), isEmpty);
     this.state = {
       filters,
       targets: filterTargets(props.targets, filters),
@@ -45,7 +46,7 @@ export default class CallToolDrillDown extends Component {
   }
 
   componentDidMount() {
-    this.fn();
+    this.updateSelection();
   }
 
   sampleTarget(targets: TargetWithFields[]): TargetWithFields {
@@ -73,11 +74,11 @@ export default class CallToolDrillDown extends Component {
         filters,
         targets: filterTargets(this.props.targets, filters),
       }),
-      () => this.fn()
+      () => this.updateSelection()
     );
   }
 
-  fn() {
+  updateSelection() {
     if (
       Object.keys(this.state.filters).length ===
       this.props.targetByAttributes.length

--- a/app/javascript/components/CallTool/CallToolDrillDown.test.js
+++ b/app/javascript/components/CallTool/CallToolDrillDown.test.js
@@ -39,3 +39,15 @@ describe('CallToolDrillDown Snapshots', () => {
     expect(toJSON(wrapper)).toMatchSnapshot('CallToolDrillDownWithFilters');
   });
 });
+
+it('ignores empty filters', () => {
+  const props = {
+    ...baseProps,
+    filters: { country: 'United States', state: '' },
+  };
+
+  const wrapper = shallow(<CallToolDrillDown {...props} />);
+
+  expect(wrapper.state('filters')).not.toHaveProperty('state');
+  expect(wrapper.state('filters')).toHaveProperty('country');
+});


### PR DESCRIPTION
Fixes a bug where empty filters don't match any targets and the result is an empty array of "matching" targets.