### PR TITLE
Fix DirectDebit countries showing only DirectDebit

### DIFF
--- a/app/javascript/state/fundraiser/reducer.js
+++ b/app/javascript/state/fundraiser/reducer.js
@@ -60,7 +60,7 @@ export default (state: State = initialState, action: Action): State => {
         return {
           ...state,
           currentPaymentType: 'gocardless',
-          directDebitOnly: true,
+          directDebitOnly: action.payload,
         };
       }
       return state;


### PR DESCRIPTION
I was ignoring the payload value when handling the `set_direct_debit_only` action.