### PR TITLE
Updated EmailTool templating and documentation

### DIFF
--- a/app/javascript/components/EmailEditor/EmailEditor.js
+++ b/app/javascript/components/EmailEditor/EmailEditor.js
@@ -30,8 +30,8 @@ export default class EmailEditor extends PureComponent {
   constructor(props: Props) {
     super(props);
     this.state = {
-      subject: this.props.subject,
-      body: this.props.body,
+      subject: this.parse(this.props.subject),
+      body: this.parse(this.props.body),
     };
   }
 
@@ -48,6 +48,9 @@ export default class EmailEditor extends PureComponent {
   }
 
   parse(templateString?: string = ''): string {
+    if (!templateString) {
+      return '';
+    }
     templateString = templateString.replace(/(?:\r\n|\r|\n)/g, '<br />');
     return template(templateString)(this.props.templateVars);
   }

--- a/app/javascript/email_tool/EmailToolView.js
+++ b/app/javascript/email_tool/EmailToolView.js
@@ -34,6 +34,7 @@ type Props = {
   country: string,
   email: string,
   name: string,
+  postal: string,
   isSubmitting: boolean,
   page: string,
   pageId: number,
@@ -152,6 +153,7 @@ export default class EmailToolView extends Component {
   templateVars() {
     return {
       name: this.state.name,
+      postal: this.props.postal,
       target: this.state.target,
     };
   }

--- a/app/javascript/packs/email_tool.js
+++ b/app/javascript/packs/email_tool.js
@@ -17,6 +17,7 @@ type Props = {
   isSubmitting: boolean,
   locale: string,
   name?: string,
+  postal?: string,
   page: string,
   pageId: number,
   targets: EmailTarget[],

--- a/app/views/plugins/email_pensions/_email_pension.liquid
+++ b/app/views/plugins/email_pensions/_email_pension.liquid
@@ -9,6 +9,7 @@
         name: member.full_name,
         email: member.email,
         country: member.country,
+        postal: member.postal,
         formValues: window.champaign.personalization.formValues
       });
 

--- a/app/views/plugins/email_tools/_email_tool.liquid
+++ b/app/views/plugins/email_tools/_email_tool.liquid
@@ -12,6 +12,7 @@
       _.merge(data, {
         name: personalization.member.full_name,
         email: personalization.member.email,
+        postal: personalization.member.postal,
         country: personalization.member.country || personalization.location.country,
         trackingParams: trackingParams,
         onSuccess: function (target) {

--- a/app/views/plugins/email_tools/_form.slim
+++ b/app/views/plugins/email_tools/_form.slim
@@ -3,7 +3,7 @@
     - name = "plugins_email_tool_#{plugin.id}"
     = form_for plugin, url: '#', remote: true, as: name, html: { class: 'form-element one-form' }, data: {type: name }  do |f|
       = render 'plugins/shared/plugin_metadata', f: f
-      .form-group 
+      .form-group
         = label_with_tooltip(f, :title, t('plugins.email_tool.title'), t('plugins.email_tool.tooltips.title'))
         = f.text_field :title, class: 'form-control'
       .form-group
@@ -28,15 +28,15 @@
       = render 'plugins/shared/subject_editor', name: name, f: f, plugin: plugin
 
       .form-group
-        = f.label(:email_body_header, t('plugins.email_tool.email_header'))
+        = label_with_tooltip f, :email_body_header, t('plugins.email_tool.email_header'), t('plugins.email_tool.tooltips.email_content')
         = f.text_area :email_body_header, class: 'form-control height-short'
 
       .form-group
-        = f.label(:email_body, t('plugins.email_tool.email_body'))
+        = label_with_tooltip f, :email_body, t('plugins.email_tool.email_body'), t('plugins.email_tool.tooltips.email_content')
         = f.text_area :email_body, class: 'form-control height-large'
 
       .form-group
-        = f.label(:email_body_footer, t('plugins.email_tool.email_footer'))
+        = label_with_tooltip f, :email_body_footer, t('plugins.email_tool.email_footer'), t('plugins.email_tool.tooltips.email_content')
         = f.text_area :email_body_footer, class: 'form-control height-short'
 
       .form-group

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -339,6 +339,10 @@ en:
         use_member_email: "Emails sent to targets will use the member's email address in the `from` field"
         from_address: "Email will be sent from this email address if \"Send from member's email address\" is unchecked. In any case, this address will also be used as a reply-to address."
         email_address_for_testing: 'ALL emails will be delivered to this address - use when you want to test a campaign before publishing.'
+        email_content: "To use the member's name include a tag with the following format: ${name}. \
+         The available variables are: ${name}, ${postal}, ${target.email} and ${target.name}. Target's custom fields included in the CSV such as country \
+         and state, can be access with ${target.fields.country} and ${target.fields.state}."
+
     call_tool:
       title: 'Title'
       click_to_play: 'Click to play'


### PR DESCRIPTION
* Added new postal variable to mail templates
* Adding ability to include variables both in the subjects and body.

I tried doing the same for EmailPension, but I found it's broken. The props are not being populated correctly, probably because of some issue with the Redux setup. 