### PR TITLE
Add a liquid_layout meta tag to page#show

### DIFF
--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -6,7 +6,7 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     meta name="description" content=t('branding.description')
     - if Settings.facebook_app_id.present?
       meta property='fb:app_id' content="#{Settings.facebook_app_id}"
-      
+
     - if Settings.mixpanel_token
       = render 'layouts/mixpanel'
     = stylesheet_link_tag 'member-facing'
@@ -35,7 +35,6 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     = render partial: 'shared/facebook_pixel' unless Rails.env.test?
 
     = yield
-
 
     = render partial: 'shared/google_analytics_snippet'
 

--- a/app/views/pages/_show.slim
+++ b/app/views/pages/_show.slim
@@ -3,7 +3,7 @@
 - meta og: facebook_meta(@page, share_card)
 
 - meta optimization_tags: @page.meta_tags
-
+- meta liquid_layout: @page.liquid_layout.title
 = @rendered
 = render 'pages/personalization', data: @data
 = render 'pages/campaigner_overlay', page: @page

--- a/app/views/pages/_show.slim
+++ b/app/views/pages/_show.slim
@@ -3,7 +3,7 @@
 - meta og: facebook_meta(@page, share_card)
 
 - meta optimization_tags: @page.meta_tags
-- meta liquid_layout: @page.liquid_layout.title
+- meta liquid_layout: @page.liquid_layout.title.downcase
 = @rendered
 = render 'pages/personalization', data: @data
 = render 'pages/campaigner_overlay', page: @page

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,8 +45,8 @@ ActiveRecord::Schema.define(version: 20171023193604) do
     t.text "body"
     t.string "resource_id", null: false
     t.string "resource_type", null: false
-    t.integer "author_id"
     t.string "author_type"
+    t.integer "author_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id"
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 20171023193604) do
     t.string "member_phone_number"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.jsonb "target_call_info", default: {}, null: false
+    t.jsonb "target_call_info", default: "{}", null: false
     t.json "member_call_events", default: [], array: true
     t.integer "twilio_error_code"
     t.json "target"
@@ -114,8 +114,8 @@ ActiveRecord::Schema.define(version: 20171023193604) do
     t.datetime "updated_at", null: false
     t.boolean "visible", default: false
     t.boolean "master", default: false
-    t.integer "formable_id"
     t.string "formable_type"
+    t.integer "formable_id"
     t.integer "position", default: 0, null: false
     t.index ["formable_type", "formable_id"], name: "index_forms_on_formable_type_and_formable_id"
   end
@@ -416,11 +416,11 @@ ActiveRecord::Schema.define(version: 20171023193604) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "title"
-    t.json "targets", default: [], array: true
     t.string "sound_clip_file_name"
     t.string "sound_clip_content_type"
     t.integer "sound_clip_file_size"
     t.datetime "sound_clip_updated_at"
+    t.json "targets", default: [], array: true
     t.text "description"
     t.string "menu_sound_clip_file_name"
     t.string "menu_sound_clip_content_type"


### PR DESCRIPTION
In order to run experiments that target specific templates, we need to be able to identify the template. This adds a meta tag with the template name, e.g.

```html
<meta name="liquid_layout" content="fundraiser with title below image" />
```