### PR TITLE
Removing "New Members" metric from the analytics section

### DIFF
--- a/app/javascript/campaigner_facing/analytics.js
+++ b/app/javascript/campaigner_facing/analytics.js
@@ -61,7 +61,8 @@ class AnalyticsDashboard {
   }
 
   setYForLabel(d) {
-    let scaled = this.scale(d.value), y = this.height - scaled + 15;
+    let scaled = this.scale(d.value),
+      y = this.height - scaled + 15;
 
     if (scaled < AnalyticsDashboard.yAxisLabelLimit) {
       y -= AnalyticsDashboard.yAxisLabelLimit;
@@ -127,7 +128,10 @@ class AnalyticsDashboard {
       )
       .rangeBands([0, this.width]);
 
-    var xAxis = d3.svg.axis().scale(xScale).orient('bottom');
+    var xAxis = d3.svg
+      .axis()
+      .scale(xScale)
+      .orient('bottom');
 
     this.svg
       .append('g')
@@ -154,7 +158,6 @@ class Conductor {
     this.id = id;
     this.chart = chart;
     this.$totalAll = $('.total-actions-all');
-    this.$totalNew = $('.total-actions-new');
 
     $('button#refresh-data').on('click', this.refreshData.bind(this));
   }
@@ -170,7 +173,6 @@ class Conductor {
 
   setCounters(totals) {
     this.$totalAll.html(totals.all_total);
-    this.$totalNew.html(totals.new_total);
   }
 
   refreshData() {

--- a/app/views/api/analytics/show.json.jbuilder
+++ b/app/views/api/analytics/show.json.jbuilder
@@ -5,5 +5,4 @@ json.days_new     new_members_by_day(@page)
 
 json.totals do
   json.all_total @page.total_actions
-  json.new_total @page.total_new_members
 end

--- a/app/views/pages/_actions_analytics.slim
+++ b/app/views/pages/_actions_analytics.slim
@@ -16,9 +16,3 @@
           dd = t('pages.analytics.total_actions')
         .analytics-chart.mini-total.mini
           svg.chart
-      .totals
-        dl.new-members
-          dt.odometer.total-actions-new
-          dd = t('pages.analytics.new_members')
-        .analytics-chart.mini-new.mini
-          svg.chart


### PR DESCRIPTION
Removing it since this metric is not correct. Quoting Tara on this:

> the current stat shows the number of members that have never before taken an action on *Champaign*, which is different from the number of people who have never taken an action on *Action Kit*. Much of the difference comes from list swaps ... members that were imported directly into AK without going through Champaign, but there are other ways that people can get onto AK too ... like microsites