### PR TITLE
Remove whitespace in textarea default values

### DIFF
--- a/app/liquid/views/partials/_form.liquid
+++ b/app/liquid/views/partials/_form.liquid
@@ -17,9 +17,7 @@
           <input type="hidden" name="{{field.name}}" class="form__content" id="" placeholder="{{ field.label }}" value="{{ field.default_value }}" />
         {% when 'paragraph' %}
           <textarea name="{{ field.name }}" placeholder="{{ field.label }}" data-display-mode="{{field.display_mode}}"
-                    class="form__content sweet-placeholder__field" id="" maxlength="9999">
-            {{ field.default_value }}
-          </textarea>
+                    class="form__content sweet-placeholder__field" id="" maxlength="9999">{{ field.default_value }}</textarea>
         {% when 'email' %}
           <div class="sweet-placeholder" data-display-mode="{{field.display_mode}}">
             <label class="sweet-placeholder__label">{{ field.label }}</label>


### PR DESCRIPTION
Ther was some whitespace being inserted as a result of having the value on a new line and indented (in the template). This whitespace caused the default value to be picked up, and the placeholder to never show.