### PR TITLE
Removes hardwired postal code for call actions to ak

### DIFF
--- a/app/controllers/api/emails_controller.rb
+++ b/app/controllers/api/emails_controller.rb
@@ -49,7 +49,6 @@ class Api::EmailsController < ApplicationController
       page_id: params[:page_id],
       name: params[:from_name],
       email: params[:from_email],
-      postal: '10000',
       country: params[:country],
       action_target: params[:target_name],
       action_target_email: params[:to_email],

--- a/app/services/email_tool_sender.rb
+++ b/app/services/email_tool_sender.rb
@@ -46,7 +46,6 @@ class EmailToolSender
         page_id:             @page.id,
         name:                @params[:from_name],
         email:               @params[:from_email],
-        postal:              '10000',
         action_target:       @target&.name,
         action_target_email: @target&.email,
         country:             @params[:country]


### PR DESCRIPTION
In the past, AK required a postal code value (zip) for US based members. This requirement seems to have now been dropped. I've tested this change with various types of users from different locations, including the US.