### PR TITLE
Added ability to set custom meta tags on any page

### DIFF
--- a/app/assets/stylesheets/campaigner-facing/page-edit.scss
+++ b/app/assets/stylesheets/campaigner-facing/page-edit.scss
@@ -209,6 +209,10 @@ body.page-edit-body {
   }
 }
 
+textarea#page_meta_description {
+  height: 70px;
+}
+
 .page-edit-step__title,
 .edit-block__title,
 .centered-overlay__title {

--- a/app/assets/stylesheets/campaigner-facing/page-edit.scss
+++ b/app/assets/stylesheets/campaigner-facing/page-edit.scss
@@ -8,6 +8,18 @@ $orange: #f8492e;
 body.page-edit-body {
   position: relative;
   background-color: $page-edit-bar-color;
+
+  .toggle-links {
+    text-align: right;
+
+    a.disabled {
+      color: #AAA;
+      &:hover {
+        text-decoration: none;
+        cursor: default;
+      }
+    }
+  }
 }
 
 .note-editable {
@@ -201,9 +213,6 @@ body.page-edit-body {
 }
 
 .javascript-editor {
-  &__toggle {
-    float: right;
-  }
   .CodeMirror {
     height: 136px;
   }

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -69,6 +69,7 @@ class Page < ApplicationRecord
   validates :slug, uniqueness: true, on: :create
   validate  :primary_image_is_owned
   validates :canonical_url, allow_blank: true, format: { with: %r{\Ahttps{0,1}:\/\/.+\..+\z} }
+  validates :meta_description, length: { maximum: 140 }
 
   after_save :switch_plugins
 
@@ -100,10 +101,6 @@ class Page < ApplicationRecord
 
   def image_to_display
     primary_image || images.first
-  end
-
-  def meta_tags
-    tag_names << plugin_names
   end
 
   def dup

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -70,6 +70,7 @@ class Page < ApplicationRecord
   validate  :primary_image_is_owned
   validates :canonical_url, allow_blank: true, format: { with: %r{\Ahttps{0,1}:\/\/.+\..+\z} }
   validates :meta_description, length: { maximum: 140 }
+  validate  :meta_tags_are_valid, if: ->(o) { o.meta_tags.present? }
 
   after_save :switch_plugins
 
@@ -157,5 +158,15 @@ class Page < ApplicationRecord
 
   def transliterated_title
     I18n.transliterate(title, locale: language_code || I18n.default_locale)
+  end
+
+  def meta_tags_are_valid
+    xml = "<root> #{meta_tags} </root>"
+    doc = Nokogiri::XML(xml)
+    if doc.errors.any?
+      errors.add(:meta_tags, 'seem to be invalid HTML code')
+    elsif doc.xpath('/root//meta').empty? && doc.xpath('/root//META').empty?
+      errors.add(:meta_tags, 'must contain a list of valid "META" or "meta" tags')
+    end
   end
 end

--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -3,9 +3,10 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
   head
     title  = @page.title
     meta name="viewport" content="width=device-width, initial-scale=1.0"
-    meta name="description" content=t("branding.description")
+    meta name="description" content="#{@page.meta_description.present? ? @page.meta_description : t('branding.description') }"
     - if Settings.facebook_app_id.present?
       meta property="fb:app_id" content="#{Settings.facebook_app_id}"
+    = @page.meta_tags&.html_safe
 
     = stylesheet_link_tag "member-facing"
 

--- a/app/views/pages/_form.slim
+++ b/app/views/pages/_form.slim
@@ -18,21 +18,28 @@
           = t('pages.edit.enforce_styles')
 
       .form-group
-        - js_hidden = ''
-        - if page.javascript.blank?
-          a data-target=".javascript-editor" data-toggle="collapse" class="javascript-editor__toggle"
-            = t('pages.edit.add_javascript')
-          - js_hidden = 'collapse'
-        .javascript-editor class="#{js_hidden}"
-          = label_with_tooltip(f, :javascript, t('pages.edit.javascript'), t('tooltips.javascript'))
-          = f.text_area :javascript, class: 'form-control syntax-highlighting', 'data-highlight-mode' => 'javascript'
-
-      .clearfix
-
-      .form-group
         = label_with_tooltip(f, :meta_description, t('pages.edit.meta_description'), t('tooltips.meta_description'))
         = f.text_area :meta_description, class: 'form-control', 'max-length' => 140, placeholder: t('branding.description')
 
-      .form-group
+      .toggle-links
+        - js_enabled = page.javascript.blank?
+        - mt_enabled = page.meta_tags.blank?
+        a data-target=".javascript-editor" data-toggle="#{'collapse' if js_enabled}" class="#{'disabled' unless js_enabled}"
+          = t('pages.edit.add_javascript')
+
+        | &nbsp; | &nbsp;
+
+        a data-target=".meta-tags-editor" data-toggle="#{'collapse' if mt_enabled}" class="#{'disabled' unless mt_enabled}"
+          = t('pages.edit.add_meta_tags')
+
+
+      .form-group.meta-tags-editor class="#{'collapse' if page.meta_tags.blank?}"
         = label_with_tooltip(f, :meta_tags, t('pages.edit.meta_tags'), t('tooltips.meta_tags'))
         = f.text_area :meta_tags, class: 'form-control', placeholder: "<meta name=\"tag-name\" content=\"Lorem ipsum\">\n" * 2
+
+      .form-group
+        .javascript-editor class="#{'collapse' if page.javascript.blank?}"
+          = label_with_tooltip(f, :javascript, t('pages.edit.javascript'), t('tooltips.javascript'))
+          = f.text_area :javascript, class: 'form-control syntax-highlighting', 'data-highlight-mode' => 'javascript'
+
+

--- a/app/views/pages/_form.slim
+++ b/app/views/pages/_form.slim
@@ -26,3 +26,13 @@
         .javascript-editor class="#{js_hidden}"
           = label_with_tooltip(f, :javascript, t('pages.edit.javascript'), t('tooltips.javascript'))
           = f.text_area :javascript, class: 'form-control syntax-highlighting', 'data-highlight-mode' => 'javascript'
+
+      .clearfix
+
+      .form-group
+        = label_with_tooltip(f, :meta_description, t('pages.edit.meta_description'), t('tooltips.meta_description'))
+        = f.text_area :meta_description, class: 'form-control', 'max-length' => 140, placeholder: t('branding.description')
+
+      .form-group
+        = label_with_tooltip(f, :meta_tags, t('pages.edit.meta_tags'), t('tooltips.meta_tags'))
+        = f.text_area :meta_tags, class: 'form-control', placeholder: "<meta name=\"tag-name\" content=\"Lorem ipsum\">\n" * 2

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -152,6 +152,7 @@ en:
       notes: 'Notes'
       add_notes: 'Add internal-facing notes'
       add_javascript: 'Add javascript'
+      add_meta_tags: 'Add meta tags'
       javascript: 'Javascript'
       settings: 'Settings'
       enforce_styles: 'Override formatting to match standard page style'

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -67,6 +67,8 @@ en:
     title: "This is the the signer-facing external title that appears on the page and in Google results. It's also how the page is identified internally in Champaign."
     content: "This will maintain any formatting pasted from Google docs, so set font size to 16 and font to Helvetica Neue when pasting. You can also use this to embed images and videos inline."
     javascript: 'Put any javascript you want the page to execute here. It will be run after the page is loaded, inside a document.ready handler.'
+    meta_description: 'Description meta tag content which will show on search engines as snippet text.'
+    meta_tags: 'Custom meta tags meant for SEO optimizations. This field must contain valid HTML META tags.'
     notes: 'Notes are only visible to campaigners, here on this page.'
     tags: 'Standard SumOfUs tags as used in ActionKit'
     page_layout: "Change this to a petition page, a fundraising page, or change the appearance"
@@ -145,6 +147,8 @@ en:
     edit:
       title: 'Title'
       content: 'Body text'
+      meta_description: 'Meta description'
+      meta_tags: 'Meta tags'
       notes: 'Notes'
       add_notes: 'Add internal-facing notes'
       add_javascript: 'Add javascript'

--- a/db/migrate/20180417152308_add_seo_fieldd_to_pages.rb
+++ b/db/migrate/20180417152308_add_seo_fieldd_to_pages.rb
@@ -1,0 +1,6 @@
+class AddSeoFielddToPages < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pages, :meta_tags, :string
+    add_column :pages, :meta_description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180406135834) do
+ActiveRecord::Schema.define(version: 20180417152308) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -235,6 +235,8 @@ ActiveRecord::Schema.define(version: 20180406135834) do
     t.boolean "enforce_styles", default: false, null: false
     t.text "notes"
     t.integer "publish_actions", default: 0, null: false
+    t.string "meta_tags"
+    t.string "meta_description"
     t.index ["campaign_id"], name: "index_pages_on_campaign_id"
     t.index ["follow_up_liquid_layout_id"], name: "index_pages_on_follow_up_liquid_layout_id"
     t.index ["follow_up_page_id"], name: "index_pages_on_follow_up_page_id"

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -73,7 +73,6 @@ describe Page do
   it { is_expected.to respond_to :campaign_action_count }
   it { is_expected.to respond_to :tag_names }
   it { is_expected.to respond_to :plugin_names }
-  it { is_expected.to respond_to :meta_tags }
   it { is_expected.to respond_to :javascript }
   it { is_expected.to respond_to :canonical_url }
   it { is_expected.to respond_to :optimizely_status }

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -520,5 +520,19 @@ describe Page do
         expect(page).to be_invalid
       end
     end
+
+    describe 'meta_tags' do
+      it 'is invalid if it has the wrong format' do
+        page.meta_tags = 'random text <hello>'
+        expect(page).to be_invalid
+        expect(page.errors[:meta_tags]).to be_present
+      end
+
+      it 'is invalid if it doesn\'t contain at least one META tag' do
+        page.meta_tags = '<hello> </hello>'
+        expect(page).to be_invalid
+        expect(page.errors[:meta_tags]).to be_present
+      end
+    end
   end
 end

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'pages' do
-  let(:english)     { create :language }
-  let(:page_params) { { title: 'Away we go!', language_id: english.id } }
-  let!(:page) { create(:page, title: 'I am a page', content: 'super awesome text content yo!') }
-
   describe 'GET show' do
+    let!(:page) { create(:page, title: 'I am a page', content: 'super awesome text content yo!') }
+
     it 'is case insensitive to campaign pages slugs' do
       get "/pages/#{page.slug.capitalize}"
       expect(response.status).to be 200
@@ -16,9 +15,24 @@ describe 'pages' do
       get '/pages/randomslug'
       expect(response.status).to be 302
     end
+
+    describe 'Mega tags' do
+      it 'includes the default description meta tags' do
+        get "/pages/#{page.slug}"
+        expect(response.body).to include(I18n.t('branding.description'))
+      end
+
+      it 'includes the custom description meta tag if overriden' do
+        page.update! meta_description: 'Custom description'
+        get "/pages/#{page.slug}"
+        expect(response.body).to include('Custom description')
+      end
+    end
   end
 
   describe 'POST create' do
+    let(:english)     { create :language }
+    let(:page_params) { { title: 'Away we go!', language_id: english.id } }
     before do
       login_as(create(:user), scope: :user)
     end


### PR DESCRIPTION
For the `description` meta tag, if the field is left empty, then we use the default description that's in the locale file that we've been using. 

![screen shot 2018-04-17 at 6 50 54 pm](https://user-images.githubusercontent.com/278462/38900017-4df16da2-4270-11e8-89f5-8d936a101bca.png)

