### PR TITLE
Remove redundant spec that also sporadically fails

### DIFF
--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -104,20 +104,4 @@ describe Link do
       end
     end
   end
-
-  describe 'associated page' do
-    Timecop.freeze do
-      let!(:page) { create(:page, links: [link]) }
-
-      it 'touches page on update' do
-        old_time = Time.now.utc
-
-        Timecop.travel(1.hour) do
-          expect { link.update(source: 'BBC') }.to change {
-            page.reload.updated_at.to_s
-          }.from(old_time.to_s).to((old_time + 1.hour).to_s)
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
I've encountered a few times that this spec sporadically fails:

![screen shot 2018-04-24 at 1 47 47 pm](https://user-images.githubusercontent.com/278462/39201792-7580ee46-47c6-11e8-9b60-522ca99ba4e7.png)

When I looked closely at this spec I decided to remove it since it's just testing the ActiveRecord method `#update`. 