### PR TITLE
Fixed spec that sporadically fails

### DIFF
--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -110,12 +110,10 @@ describe Link do
       let!(:page) { create(:page, links: [link]) }
 
       it 'touches page on update' do
-        old_time = Time.now.utc
-
-        Timecop.travel(1.hour) do
+        Timecop.freeze(1.hour.from_now) do
           expect { link.update(source: 'BBC') }.to change {
             page.reload.updated_at.to_s
-          }.from(old_time.to_s).to((old_time + 1.hour).to_s)
+          }.to(Time.now.utc.to_s)
         end
       end
     end


### PR DESCRIPTION
* The `link` was created outside the Timecop loop, making the updated_at possibly out of sync 
* Replaced `travel` by `freeze` making the code simpler. 

This is a screenshot of this spec failing on CircleCI
![screen shot 2018-04-24 at 1 47 47 pm](https://user-images.githubusercontent.com/278462/39202335-fe7df6de-47c7-11e8-85e7-3069d053e701.png)
