### PR TITLE
Fix missing optimization tags

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -140,6 +140,10 @@ class Page < ApplicationRecord
     language&.code || I18n.default_locale
   end
 
+  def optimization_tags
+    tag_names << plugin_names
+  end
+
   private
 
   def switch_plugins

--- a/app/views/pages/_show.slim
+++ b/app/views/pages/_show.slim
@@ -2,7 +2,7 @@
 - meta twitter: twitter_meta(@page, share_card)
 - meta og: facebook_meta(@page, share_card)
 
-- meta optimization_tags: @page.meta_tags
+- meta optimization_tags: @page.optimization_tags
 - meta liquid_layout: @page.liquid_layout.title.downcase
 = @rendered
 = render 'shared/page_object'


### PR DESCRIPTION
Our previous `<meta name="optimization_tags" value="..." />` was fetched from a method called `meta_tags` on the page model. This was broken by a recent addition of actual meta tags to the page model. This PR brings the previous functionality back, but names it `optimization_tags` on the Page model.