### PR TITLE
Define custom autocomplete values

### DIFF
--- a/app/views/plugins/email_pensions/_form.slim
+++ b/app/views/plugins/email_pensions/_form.slim
@@ -18,7 +18,7 @@
 
       .form-group.field_with_errors
         = label_with_tooltip(f, :test_email_address, t('plugins.email_tool.email_address_for_testing'), t('plugins.email_tool.tooltips.email_address_for_testing'))
-        = f.text_field :test_email_address, class: 'form-control'
+        = f.text_field :test_email_address, class: 'form-control', autocomplete: 'email'
         - if plugin.test_email_address
           .has-error
             strong = t('plugins.email_tool.test_email_warning')

--- a/app/views/plugins/email_tools/_form.slim
+++ b/app/views/plugins/email_tools/_form.slim
@@ -20,7 +20,7 @@
 
       .form-group.field_with_errors
         = label_with_tooltip(f, :test_email_address, t('plugins.email_tool.email_address_for_testing'), t('plugins.email_tool.tooltips.email_address_for_testing'))
-        = f.text_field :test_email_address, class: 'form-control'
+        = f.text_field :test_email_address, class: 'form-control', autocomplete: 'email'
         - if plugin.test_email_address
           .has-error
             strong = t('plugins.email_tool.test_email_warning')

--- a/app/views/plugins/shared/_subject_editor.slim
+++ b/app/views/plugins/shared/_subject_editor.slim
@@ -3,9 +3,9 @@
   = label_with_tooltip f, :email_subjects, t('plugins.email_tool.subject'), t('plugins.email_tool.tooltips.email_content')
   .form-element__choice-fields
     - plugin.email_subjects << '' if plugin.email_subjects.empty?
-    - plugin.email_subjects.each do |subject|
+    - plugin.email_subjects.each_with_index do |subject, i|
       .form-element__choice-field
-        = f.text_field :email_subjects, value: subject, multiple: true, class: 'form-control'
+        = f.text_field :email_subjects, value: subject, multiple: true, class: 'form-control', autocomplete: "subject-#{i}"
         a.form-element__remove-choice
           small
             span.glyphicon.glyphicon-remove


### PR DESCRIPTION
This stops chrome from replacing subject lines with autocomplete value for email.

![e8b09133b25727e722e13e26878f6ac7](https://user-images.githubusercontent.com/12949/39703418-e5172124-51ff-11e8-941b-1b41d3cf39a6.gif)
