### PR TITLE
Make spacing consistent in EmailEditor and raw email

### DIFF
--- a/app/assets/stylesheets/campaigner-facing/page-edit.scss
+++ b/app/assets/stylesheets/campaigner-facing/page-edit.scss
@@ -27,7 +27,7 @@ body.page-edit-body {
   ol,
   ul,
   p {
-    margin-bottom: 0;
+    margin-bottom: .7em;
     margin-top: 0;
   }
 }

--- a/app/javascript/components/EmailEditor/EmailEditor.js
+++ b/app/javascript/components/EmailEditor/EmailEditor.js
@@ -64,7 +64,7 @@ export default class EmailEditor extends Component {
       this.state.header,
       stateToHTML(this.state.editorState.getCurrentContent()),
       this.state.footer,
-    ]).join('<br />');
+    ]).join('');
   }
 
   updateSubject = (subject: string) => {
@@ -78,6 +78,9 @@ export default class EmailEditor extends Component {
       this.update();
     });
   };
+
+  // class applied to content blocks
+  blockStyleFn = () => 'editor-content-block';
 
   render() {
     const { header, footer, errors } = this.props;
@@ -118,6 +121,7 @@ export default class EmailEditor extends Component {
               <Editor
                 editorState={this.state.editorState}
                 onChange={this.onEditorChange}
+                blockStyleFn={this.blockStyleFn}
               />
               {footer && (
                 <div

--- a/app/javascript/components/EmailEditor/EmailEditor.scss
+++ b/app/javascript/components/EmailEditor/EmailEditor.scss
@@ -14,9 +14,14 @@
     min-height: 250px;
     resize: vertical;
   }
+
+  .editor-content-block {
+    margin-bottom: .6em;
+  }
 }
 
 .EmailEditor-header,
 .EmailEditor-footer {
   color: #999;
+  margin-bottom: .6em;
 }


### PR DESCRIPTION
Removes extra `<br />` that was being inserted between header, body and footer. It also adds some CSS styles to ensure that there's a similar spacing in both the edit view (summernote) and the draft-js editor.