### PR TITLE
Don't run simple_format on emails body

### DIFF
--- a/app/services/email_sender.rb
+++ b/app/services/email_sender.rb
@@ -20,7 +20,7 @@ class EmailSender
       item: {
         MailingId: "#{opts[:id]}:#{Time.now.to_i}",
         UserId: opts[:from_email],
-        Body: simple_format(opts[:body]),
+        Body: opts[:body],
         Subject: opts[:subject],
         ToEmails: format_emails_list(opts[:to]),
         FromName: opts[:from_name],

--- a/spec/requests/api/emails_spec.rb
+++ b/spec/requests/api/emails_spec.rb
@@ -42,7 +42,7 @@ describe 'Emails', type: :request do
             item: {
               MailingId: /foo-bar:\d*/,
               UserId: 'john@email.com',
-              Body: '<p>Lorem ipsum</p>',
+              Body: 'Lorem ipsum',
               Subject: 'A Subject',
               ToEmails: ["#{target.name} <#{target.email}>"],
               FromName: 'John Doe',


### PR DESCRIPTION
Simple format replaces `\n` with `<br>` adding extra new lines that makes the emails look funny. Like this one:

![screen shot 2018-06-13 at 6 07 08 pm](https://user-images.githubusercontent.com/278462/41378235-d65caac6-6f34-11e8-9c06-a4b2ab0a5cf7.png)

Can someone please test this on staging and deploy it tomorrow? 