### PR TITLE
Release

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -5,6 +5,7 @@ require 'champaign_queue'
 require 'browser'
 
 class PagesController < ApplicationController
+  newrelic_ignore_enduser only: %i[show follow_up double_opt_in_notice]
   before_action :authenticate_user!, except: %i[show follow_up double_opt_in_notice]
   before_action :get_page, only: %i[edit update destroy follow_up double_opt_in_notice analytics actions preview]
   before_action :get_page_or_homepage, only: [:show]

--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -4,6 +4,11 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     title  = @page.title
     meta name="viewport" content="width=device-width, initial-scale=1.0"
     meta name="description" content="#{@page.meta_description.present? ? @page.meta_description : t('branding.description') }"
+
+    = stylesheet_pack_tag "globals"
+    = javascript_pack_tag "sentry"
+    = javascript_pack_tag "globals"
+
     - if Settings.facebook_app_id.present?
       meta property="fb:app_id" content="#{Settings.facebook_app_id}"
     = @page.meta_tags&.html_safe
@@ -16,15 +21,12 @@ html lang="#{@page.language.try(:code).try(:downcase)}"
     - canonical_url = @page.canonical_url.blank? ? member_facing_page_url(@page) : @page.canonical_url
     link rel="canonical" href=canonical_url
 
-    = javascript_pack_tag "sentry"
     = javascript_include_tag "https://cdn.polyfill.io/v2/polyfill.min.js?features=Intl.~locale.en,Intl.~locale.de,Intl.~locale.fr&rum=1&unknown=polyfill"
     = render partial: "shared/optimizely_snippet" unless @page.optimizely_disabled?
     = render partial: "shared/js_locale"
     = render partial: "layouts/mixpanel" if Settings.mixpanel_token
     = render 'shared/page_object'
     = render 'pages/personalization', data: @data
-    = javascript_pack_tag "globals"
-    = stylesheet_pack_tag "globals"
   body
     = render partial: "layouts/notification"
 


### PR DESCRIPTION
* Disables frontend newrelic instrumentation for member facing pages
* Only try to `window.open(...).focus` when possible.