### PR TITLE
Define db pool size via settings

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -36,3 +36,4 @@ production:
   password: <%= ENV['RDS_PASSWORD'] %>
   host: <%= ENV['RDS_HOSTNAME'] %>
   port: <%= ENV['RDS_PORT'] %>
+  pool: <%= Settings.db_pool_size || 5 %>

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -138,3 +138,4 @@ member_services_secret: <%= ENV['MEMBER_SERVICES_SECRET'] %>
 oxr_app_id: <%= ENV['OXR_APP_ID'] %>
 api_key: <%= ENV['CHAMPAIGN_API_KEY'] %>
 mailer_topic_arn: <%= ENV['MAILING_TOPIC_ARN'] %>
+db_pool_size: <%= ENV['DPS'] %>


### PR DESCRIPTION
Currently using a default pool size of 5 connections per app instance. Our database can handle a great number more.