### PR TITLE
Fix progress tracker styling

### DIFF
--- a/app/javascript/plugins/progress-tracker.js
+++ b/app/javascript/plugins/progress-tracker.js
@@ -8,11 +8,20 @@ export default class ProgressTracker {
   }
 
   addEventListeners() {
+    const $header = $('.header-logo');
     ee.on('action:submitted_success', this.show);
     ee.on('action:submitted_success', () => this.tick('signed'));
     ee.on('fundraiser:transaction_success', () => this.tick('donated'));
-    window.addEventListener('share', () => this.tick('shared'), false);
+    window.addEventListener(
+      'share',
+      () => {
+        $header.hide();
+        this.tick('shared');
+      },
+      false
+    );
     $('.two-step__decline').on('click', () => {
+      $header.hide();
       this.cross('shared');
     });
   }

--- a/app/javascript/plugins/progress-tracker.js
+++ b/app/javascript/plugins/progress-tracker.js
@@ -18,7 +18,11 @@ export default class ProgressTracker {
   }
 
   show() {
+    const $header = $('.header-logo');
     const $tracker = $('.header-logo .progress-tracker');
+
+    $header.addClass('with-progress-tracker');
+
     $tracker
       .removeClass('hidden-closed')
       .clone()


### PR DESCRIPTION
The progress tracker header should have a transparent header, then transition to the teal background when the tracker is activated. This PR adds a `.with-progress-tracker` class to the header when the tracker is activated. Styles updated in the relevant `sou-assets` branch.