### PR TITLE
Validate user in transaction payloads

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -73,10 +73,19 @@ class Api::Payment::BraintreeController < PaymentController
   end
 
   def user_params
-    params
+    user_data = params
       .require(:user).permit!
       .merge(mobile_value)
       .to_hash
       .symbolize_keys
+      .compact
+
+    raise Api::Exceptions::InvalidParameters unless valid_user?(user_data)
+
+    user_data
+  end
+
+  def valid_user?(user)
+    user.slice(:email, :name, :country).all? { |_, value| value.present? }
   end
 end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -17,6 +17,7 @@ module ExceptionHandler
     rescue_from Api::Exceptions::InvalidTokenError,  with: :invalid_token
     rescue_from Api::Exceptions::ExpiredTokenError,  with: :expired_token
     rescue_from Api::Exceptions::UnauthorizedError,  with: :unauthorized
+    rescue_from Api::Exceptions::InvalidParameters,  with: :invalid_parameters
 
     rescue_from ActionController::ParameterMissing, with: :invalid_parameters
 

--- a/app/lib/api/exceptions.rb
+++ b/app/lib/api/exceptions.rb
@@ -7,5 +7,6 @@ module Api
     class UnauthorizedError < AuthenticationError; end
     class InvalidTokenError < AuthenticationError; end
     class ExpiredTokenError < AuthenticationError; end
+    class InvalidParameters < StandardError; end
   end
 end


### PR DESCRIPTION
Ideally we should be using the plugin's form to validate the user, but at the moment this should suffice.