### PR TITLE
Pass EOY goals for currencies hash in the api/donations/total endpoint

### DIFF
--- a/app/controllers/api/donations_controller.rb
+++ b/app/controllers/api/donations_controller.rb
@@ -2,6 +2,9 @@ class Api::DonationsController < ApplicationController
   # Fetches the sum of all donations (one off and recurring) for a given date range
   # If a date range is not provided, it will default to donations in the current
   # calendar month
+  #
+  # This endpoint is only used for the EOY donations thermometer. That's why the data includes also a hash of
+  # EOY donations goals in different currencies, rounded around the base goal of 600000 USD.
   def total
     params.permit(:start, :end)
     start_date = params.fetch(:start, Date.today.beginning_of_month).to_date
@@ -12,7 +15,8 @@ class Api::DonationsController < ApplicationController
     response = {
       meta: { start: start_date.to_s, end: end_date.to_s },
       data: {
-        total_donations: TransactionService.totals(start_date...end_date)
+        total_donations: TransactionService.totals(start_date...end_date),
+        eoy_goals: TransactionService.goals(60_000_000)
       }
     }
 

--- a/spec/controllers/api/donations_controller_spec.rb
+++ b/spec/controllers/api/donations_controller_spec.rb
@@ -31,5 +31,13 @@ RSpec.describe Api::DonationsController, type: :controller do
       get :total, params: { end: 'not a date' }
       expect(response).to have_http_status(:bad_request)
     end
+
+    it 'returns both total donations and EOY fundraising goals' do
+      get :total, params: { start: '2019-11-29', end: '2019-12-31' }
+      json_hash = JSON.parse(response.body).with_indifferent_access
+      expect(json_hash[:data].keys).to match(%w[total_donations eoy_goals])
+      expect(json_hash[:data][:eoy_goals].keys).to match(%w[USD GBP EUR CHF AUD NZD CAD])
+      expect(json_hash[:data][:total_donations].keys).to match(%w[USD GBP EUR CHF AUD NZD CAD])
+    end
   end
 end


### PR DESCRIPTION
This is needed for the EOY thermometer in mailings.