### PR TITLE
Raise errors for deprecations

### DIFF
--- a/.circleci/airbrake_register_deploy.sh
+++ b/.circleci/airbrake_register_deploy.sh
@@ -3,11 +3,12 @@
 ENVIRONMENT=production
 REPOSITORY=https://github.com/SumOfUs/Champaign
 USERNAME=CircleCI
+REVISION=$(git describe --tags)
 
 echo "Registering deploy with Airbrake"
 echo "Airbrake Project ID: ${AIRBRAKE_PROJECT_ID}"
 
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d '{"environment":"'${ENVIRONMENT}'","username":"'${USERNAME}'","repository":"'${REPOSITORY}'","revision":"'${CIRCLE_SHA1}'"}' \
+  -d '{"environment":"'${ENVIRONMENT}'","username":"'${USERNAME}'","repository":"'${REPOSITORY}'","revision":"'${REVISION}'"}' \
   "https://airbrake.io/api/v4/projects/${AIRBRAKE_PROJECT_ID}/deploys?key=${AIRBRAKE_PROJECT_KEY}"

--- a/.circleci/deploy_testing.sh
+++ b/.circleci/deploy_testing.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -eu -o pipefail
 
-SOURCE_BUNDLE=$CIRCLE_SHA1-config.zip
+branch=`echo $CIRCLE_BRANCH | tr -s \/ - | tr -s . - | tr -s \\ -`
+version=`git describe --tags`
+label=champaign-$branch-$version
+SOURCE_BUNDLE=$label-config.zip
 
 echo 'Deleting configuration files that do not apply to feature deployment'
 rm .ebextensions/04_newrelic.config
@@ -9,7 +12,7 @@ rm .ebextensions/05_nginx_proxy.config
 
 echo 'Shipping source bundle to S3...'
 cat Dockerrun.aws.json.template | envsubst > Dockerrun.aws.json
-zip -r9 $CIRCLE_SHA1-config.zip Dockerrun.aws.json ./.ebextensions/
+zip -r9 $SOURCE_BUNDLE Dockerrun.aws.json ./.ebextensions/
 aws configure set default.region $AWS_REGION
 aws s3 cp $SOURCE_BUNDLE s3://$EB_BUCKET/$SOURCE_BUNDLE
 
@@ -19,8 +22,8 @@ aws s3 sync public/packs/ s3://$S3_BUCKET/packs/
 
 echo 'Creating new application version...'
 aws elasticbeanstalk create-application-version --application-name "$AWS_APPLICATION_NAME" \
-  --version-label $CIRCLE_SHA1 --source-bundle S3Bucket=$EB_BUCKET,S3Key=$SOURCE_BUNDLE
+  --version-label $label --source-bundle S3Bucket=$EB_BUCKET,S3Key=$SOURCE_BUNDLE
 
 echo 'Updating environment...'
 aws elasticbeanstalk update-environment --environment-name $AWS_ENVIRONMENT_NAME \
-    --version-label $CIRCLE_SHA1
+    --version-label $label

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-flow-typed/

--- a/app/javascript/components/consent/ConsentControls.css
+++ b/app/javascript/components/consent/ConsentControls.css
@@ -12,7 +12,7 @@
 .ConsentControls.warning .notice {
   padding: 10px;
   margin-bottom: 10px;
-  background: rgb(255, 251, 222);
+  background: rgb(136, 133, 113);
 }
 
 .ConsentControls .notice {
@@ -27,15 +27,14 @@
   display: block;
   margin-right: 30px;
   margin-bottom: 10px;
-  font-weight: 95%;
-}
-.ConsentControls input[type="radio"]:focus {
-  box-shadow: 0 1px 8px 2px #00c0cf;
+  font-size: 85%;
+  clear: left;
 }
 
-.simple .ConsentControls input[type="radio"] {
+.simple .ConsentControls input[type='radio'] {
   float: left;
   display: block;
+  background: transparent;
 }
 
 .simple .ConsentControls label span {
@@ -44,13 +43,13 @@
 }
 
 /* Selectable Buttons variant */
-.selectable-buttons .ConsentControls input[type="radio"] {
+.selectable-buttons .ConsentControls input[type='radio'] {
   display: none;
 }
 .selectable-buttons .ConsentControls label {
   display: block;
   background: white;
-  border: 1px solid #F73415;
+  border: 1px solid #f73415;
   margin: 15px 0 0 0;
   padding: 10px 5px 10px 10px;
   cursor: pointer;
@@ -58,6 +57,6 @@
 
 .selectable-buttons .ConsentControls label:hover,
 .selectable-buttons .ConsentControls label.active {
-  background: #F73415;
+  background: #f73415;
   color: white;
 }

--- a/app/javascript/legacy/member-facing/backbone/action_form.js
+++ b/app/javascript/legacy/member-facing/backbone/action_form.js
@@ -76,6 +76,7 @@ const ActionForm = Backbone.View.extend({
       this.selectizeDropdowns();
     }
     this.$submitButton = this.$('.action-form__submit-button');
+    this.$formWrapper = this.$('.form-wrapper');
     this.buttonText = this.$submitButton.text();
     this.setupState();
     this.enableGDPRConsent();
@@ -376,7 +377,7 @@ const ActionForm = Backbone.View.extend({
   enableGDPRConsent() {
     if (this.gdprContainer) return;
     this.gdprContainer = document.createElement('div');
-    this.$submitButton.before(this.gdprContainer);
+    this.$formWrapper.append(this.gdprContainer);
 
     render(
       <ComponentWrapper store={window.champaign.store} locale={I18n.locale}>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -134,9 +134,9 @@ api_key: '1234'
 mailer_topic_arn: 'mailer_topic_arn'
 
 recaptcha3:
-  site_key: <%= ENV['RECAPTCHA_SITE_KEY'] %>
-  secret_key: <%= ENV['RECAPTCHA_SECRET_KEY'] %>
-  min_score: <%= ENV['RECAPTCHA_MIN_SCORE'] %>
+  site_key: 'site_key' 
+  secret_key: 'secret_key'
+  min_score: '0.6'
 
 recaptcha2:
   site_key: 'site_key'

--- a/spec/controllers/api/go_cardless_controller_spec.rb
+++ b/spec/controllers/api/go_cardless_controller_spec.rb
@@ -17,7 +17,7 @@ describe Api::GoCardlessController do
     allow(Page).to receive(:find) { page }
     allow(SecureRandom).to receive(:uuid) { 'fake_session_id' }
     allow(MobileDetector).to receive(:detect) { { action_mobile: 'tablet' } }
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   describe 'GET #start_flow' do

--- a/spec/controllers/api/payment/braintree_controller_spec.rb
+++ b/spec/controllers/api/payment/braintree_controller_spec.rb
@@ -6,7 +6,7 @@ describe Api::Payment::BraintreeController do
   before do
     allow(Page).to receive(:find) { page }
     allow(MobileDetector).to receive(:detect).and_return(action_mobile: 'mobile')
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   let(:page) do

--- a/spec/features/express_donations/email_one_click_spec.rb
+++ b/spec/features/express_donations/email_one_click_spec.rb
@@ -64,7 +64,7 @@ feature 'Express From Mailing Link' do
   before do
     allow(ChampaignQueue).to receive(:push)
     allow(FundingCounter).to receive(:update)
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   scenario 'Authenticated member makes a one-click donation' do

--- a/spec/features/express_donations/page_one_click_spec.rb
+++ b/spec/features/express_donations/page_one_click_spec.rb
@@ -18,7 +18,7 @@ feature 'One Click From Save Payment Methods from Page' do
   before do
     allow(ChampaignQueue).to receive(:push)
     allow(FundingCounter).to receive(:update)
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   scenario 'Authenticated member makes an express donation' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,7 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers, type: :request
   config.include Requests::RequestHelpers, type: :request
   config.infer_spec_type_from_file_location!
+  config.raise_errors_for_deprecations!
 
   # During testing, the app-under-test that the browser driver connects to
   # uses a different database connection to the database connection used by

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -14,7 +14,7 @@ describe 'Express Donation' do
   before do
     allow(ChampaignQueue).to receive(:push)
     allow(FundingCounter).to receive(:update)
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   describe 'making multiple transactions on the same page with after 10 mins' do
@@ -419,7 +419,7 @@ describe 'Braintree API' do
     allow(Analytics::Page).to receive(:increment)
     allow(MobileDetector).to receive(:detect).and_return(action_mobile: 'desktop')
     allow(FundingCounter).to receive(:update)
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   describe 'making a transaction' do

--- a/spec/requests/api/braintree/failure_spec.rb
+++ b/spec/requests/api/braintree/failure_spec.rb
@@ -68,7 +68,7 @@ describe 'Braintree API' do
 
   before :each do
     allow(ChampaignQueue).to receive(:push)
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   describe 'unsuccessfuly' do

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -32,7 +32,7 @@ describe 'Braintree API' do
   before :each do
     allow(ChampaignQueue).to receive(:push)
     allow(Analytics::Page).to receive(:increment)
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   shared_examples 'has no unintended consequences' do

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -33,7 +33,7 @@ describe 'GoCardless API' do
     allow(MobileDetector).to receive(:detect).and_return(action_mobile: 'tablet')
 
     allow(FundingCounter).to receive(:update)
-    Recaptcha3.any_instance.stub(:human?).and_return(true)
+    allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
   end
 
   describe 'redirect flow' do


### PR DESCRIPTION
Backport a few other updates that have been rolled back from development:

* CSS updates to fix the sidebar look and feel.
* GDPR consent checkboxes are now appended to the form instead of in the button wrapper.
* Improve AWS labelling of artifacts:
    ```diff
    - 3ebbaa02308cbdf6ab84d1653afdf5b3ce381d22
    + champaign-master-v3.0-1-3ebbaa023-config.zip
    ```
* Update deprecated syntax in rspec files.