### PR TITLE
Allow users who have done 2 or more previous transactions to donate

### DIFF
--- a/app/services/payment_request_authorizer.rb
+++ b/app/services/payment_request_authorizer.rb
@@ -40,6 +40,7 @@ class PaymentRequestAuthorizer
     total_donations = begin
                         ::Payment::Braintree::Customer.find_by(email: email).transactions.count
                       rescue StandardError
+                        0
                       end
     return true if total_donations >= 2
 

--- a/app/services/payment_request_authorizer.rb
+++ b/app/services/payment_request_authorizer.rb
@@ -1,0 +1,57 @@
+class PaymentRequestAuthorizer
+  include ActiveModel::Validations
+
+  attr_accessor :email, :recaptcha, :action, :params
+
+  validates :email,     presence: true
+  validates :recaptcha, presence: true
+  validates :action,    presence: true
+  validate :verify_recaptcha
+  validate :verify_user_donations, unless: :valid_captcha?
+
+  def initialize(email:, recaptcha:, action:, params: {})
+    @email = email.to_s.strip
+    @recaptcha = recaptcha
+    @action = action
+    @params = params
+  end
+
+  def valid_captcha?
+    @valid_captcha
+  end
+
+  def verify_recaptcha
+    @captcha = Recaptcha3.new(token: recaptcha, action: action)
+    @valid_captcha = @captcha.human?
+
+    unless valid_captcha?
+      msg = 'Transaction rejected [recaptcha failure] '
+      msg += "- score: #{@captcha.score} - #{params}"
+      Rails.logger.error(msg)
+
+      return false
+    end
+    Rails.logger.info("Transaction recaptcha score: #{@captcha.score} - #{params}")
+  end
+
+  def verify_user_donations
+    return false unless email.present?
+
+    total_donations = begin
+                        ::Payment::Braintree::Customer.find_by(email: email).transactions.count
+                      rescue StandardError
+                      end
+    return true if total_donations >= 2
+
+    errors.add(:base, 'Invalid request')
+    # .valid? method returns false if we add the following line
+    # in `verify_recaptcha` method.
+
+    errors.add(:recaptcha, @captcha.errors) if @captcha.errors.present?
+    msg = 'Transaction rejected: [insufficient donations] '
+    msg += "user: #{email}'s past total donations: #{total_donations}"
+    Rails.logger.info(msg)
+
+    false
+  end
+end

--- a/spec/controllers/api/go_cardless_controller_spec.rb
+++ b/spec/controllers/api/go_cardless_controller_spec.rb
@@ -18,6 +18,7 @@ describe Api::GoCardlessController do
     allow(SecureRandom).to receive(:uuid) { 'fake_session_id' }
     allow(MobileDetector).to receive(:detect) { { action_mobile: 'tablet' } }
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   describe 'GET #start_flow' do

--- a/spec/controllers/api/payment/braintree_controller_spec.rb
+++ b/spec/controllers/api/payment/braintree_controller_spec.rb
@@ -7,6 +7,7 @@ describe Api::Payment::BraintreeController do
     allow(Page).to receive(:find) { page }
     allow(MobileDetector).to receive(:detect).and_return(action_mobile: 'mobile')
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   let(:page) do

--- a/spec/features/express_donations/email_one_click_spec.rb
+++ b/spec/features/express_donations/email_one_click_spec.rb
@@ -65,6 +65,7 @@ feature 'Express From Mailing Link' do
     allow(ChampaignQueue).to receive(:push)
     allow(FundingCounter).to receive(:update)
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   VCR.use_cassette('money_from_oxr') do

--- a/spec/features/express_donations/page_one_click_spec.rb
+++ b/spec/features/express_donations/page_one_click_spec.rb
@@ -19,6 +19,7 @@ feature 'One Click From Save Payment Methods from Page' do
     allow(ChampaignQueue).to receive(:push)
     allow(FundingCounter).to receive(:update)
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   scenario 'Authenticated member makes an express donation' do

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -15,6 +15,7 @@ describe 'Express Donation' do
     allow(ChampaignQueue).to receive(:push)
     allow(FundingCounter).to receive(:update)
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   describe 'making multiple transactions on the same page with after 10 mins' do
@@ -420,6 +421,7 @@ describe 'Braintree API' do
     allow(MobileDetector).to receive(:detect).and_return(action_mobile: 'desktop')
     allow(FundingCounter).to receive(:update)
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   describe 'making a transaction' do

--- a/spec/requests/api/braintree/failure_spec.rb
+++ b/spec/requests/api/braintree/failure_spec.rb
@@ -69,6 +69,7 @@ describe 'Braintree API' do
   before :each do
     allow(ChampaignQueue).to receive(:push)
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   describe 'unsuccessfuly' do

--- a/spec/requests/api/braintree/webhook_spec.rb
+++ b/spec/requests/api/braintree/webhook_spec.rb
@@ -33,6 +33,7 @@ describe 'Braintree API' do
     allow(ChampaignQueue).to receive(:push)
     allow(Analytics::Page).to receive(:increment)
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   shared_examples 'has no unintended consequences' do

--- a/spec/requests/api/go_cardless/go_cardless_spec.rb
+++ b/spec/requests/api/go_cardless/go_cardless_spec.rb
@@ -34,6 +34,7 @@ describe 'GoCardless API' do
 
     allow(FundingCounter).to receive(:update)
     allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+    allow_any_instance_of(PaymentRequestAuthorizer).to receive(:valid?).and_return(true)
   end
 
   describe 'redirect flow' do

--- a/spec/services/payment_request_authorizer_spec.rb
+++ b/spec/services/payment_request_authorizer_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe PaymentRequestAuthorizer do
+  include Rails.application.routes.url_helpers
+
+  let(:page) { create(:page, publish_status: 'published') }
+
+  let(:customer) do
+    attrs = FactoryBot.attributes_for(:payment_braintree_customer)
+    Payment::Braintree::Customer.create(attrs)
+  end
+
+  # rubocop:disable LineLength
+  let(:valid_data) do
+    { recaptcha: '03AOLTBLTx8PMg5ysKEN5nLmhzDad2lIHsf7rSVaDogDrChLL6hprN3nLFMjpvtr0FWewUDezV_SgV-YfUSU2yOyClXx6xaI4OxRsELoi4626iU31B4pdx3pCtcpNNBA8u1yB7IJxtpLM-E7_vdy7IfvS0YEB1758VVpxiJEbGTLmLb111SjTkFBWuhZ3XyrHFca-22uLzKpawc8RQ1-j57ZR3SMel4DCkNzveSWjYYH381z_MAY7Ev5Q7tK6_iEqrqUsgSt1wF-xtht5fLmjKXYkknPN3SB1_32mRl9BBuMzfIl6wO-GUnWhKbzEpsSlSqbEhljS_38GxViA3gC1eu5cOQWhKde56-EKYOG1JaTb8QiyamDoKKetITV8yWy8ZlmcspgD0Gv9B',
+      action: 'donate/83',
+      email: 'test@example.com',
+      params: { page: '1' } }
+  end
+  # rubocop:enable LineLength
+  let(:invalid_data) do
+    { token: nil, action: nil }
+  end
+
+  let(:empty_data) do
+    { recaptcha: nil, action: nil, email: nil, params: {} }
+  end
+
+  describe '.valid?' do
+    context 'empty data' do
+      subject { PaymentRequestAuthorizer.new(empty_data) }
+
+      it 'should validates presence of recaptcha, action and email' do
+        subject.valid?
+        expect(subject.errors.size).to eql 3
+        expect(subject.errors.full_messages).to include("Email can't be blank",
+                                                        "Recaptcha can't be blank", "Action can't be blank")
+      end
+    end
+
+    context 'With valid captcha' do
+      before do
+        allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+      end
+
+      subject { PaymentRequestAuthorizer.new(valid_data) }
+
+      it 'should return true' do
+        expect(subject.valid?).to be_truthy
+      end
+
+      it 'should not have any errors' do
+        subject.valid?
+        expect(subject.errors.full_messages).to be_empty
+      end
+    end
+
+    context 'With valid captcha and no donations' do
+      before do
+        allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(true)
+      end
+
+      let(:customer) { create(:payment_braintree_customer) }
+      subject { PaymentRequestAuthorizer.new(valid_data.merge(email: customer.email)) }
+
+      it 'should return true' do
+        expect(subject.valid?).to be_truthy
+      end
+
+      it 'should not have any errors' do
+        subject.valid?
+        expect(subject.errors.full_messages).to be_empty
+      end
+    end
+
+    context 'With invalid captcha and non existing user' do
+      before do
+        allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(false)
+      end
+
+      subject { PaymentRequestAuthorizer.new(valid_data) }
+
+      it 'should return false' do
+        expect(subject.valid?).to be_falsy
+      end
+
+      it 'should have any errors' do
+        subject.valid?
+        expect(subject.errors.full_messages).to include('Invalid request')
+      end
+    end
+
+    context 'With invalid captcha and more than 2 donations' do
+      before do
+        allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(false)
+      end
+
+      subject { PaymentRequestAuthorizer.new(valid_data.merge(email: customer.email)) }
+
+      it 'should return true' do
+        attrs = FactoryBot.attributes_for(:payment_braintree_transaction, page_id: page.id)
+        4.times { customer.transactions.create(attrs) }
+
+        expect(subject.valid?).to be_truthy
+        expect(subject.errors.full_messages).to be_empty
+      end
+    end
+
+    context 'With invalid captcha and 1 donation' do
+      before do
+        allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(false)
+        Payment::Braintree::Transaction.delete_all
+      end
+
+      subject { PaymentRequestAuthorizer.new(valid_data.merge(email: customer.email)) }
+
+      it 'should return false' do
+        attrs = FactoryBot.attributes_for(:payment_braintree_transaction, page_id: page.id)
+        customer.transactions.create(attrs)
+        expect(subject.valid?).to be_falsy
+      end
+
+      it 'should not have any errors' do
+        subject.valid?
+        expect(subject.errors.full_messages).to include('Invalid request')
+      end
+    end
+
+    context 'With invalid captcha and no donations' do
+      before do
+        allow_any_instance_of(Recaptcha3).to receive(:human?).and_return(false)
+        Payment::Braintree::Transaction.delete_all
+      end
+
+      subject { PaymentRequestAuthorizer.new(valid_data.merge(email: customer.email)) }
+
+      it 'should return true' do
+        expect(subject.valid?).to be_falsy
+      end
+
+      it 'should not have any errors' do
+        subject.valid?
+        expect(subject.errors.full_messages).to include('Invalid request')
+      end
+    end
+  end
+end


### PR DESCRIPTION
If Re-captcha score is less than 0.2, check whether the user have made at-least 2 donations already if so allow him to continue to the payment else block him.

