### PR TITLE
Feature/email tool feedback changes

### DIFF
--- a/app/assets/stylesheets/member-facing/form.scss
+++ b/app/assets/stylesheets/member-facing/form.scss
@@ -86,6 +86,7 @@
       -moz-appearance: none;
       appearance: none;
       -webkit-tap-highlight-color: transparent;
+      background: none;
     }
 
     input[type='radio']::before {

--- a/app/assets/stylesheets/member-facing/fundraiser.scss
+++ b/app/assets/stylesheets/member-facing/fundraiser.scss
@@ -272,6 +272,12 @@
       }
     }
 
+    // Fix for iOS radio button black square bug
+    .form--big input[type='radio'] {
+      background: none;
+    }
+
+
     .overlay-toggle__close-button {
       display: none;
     }

--- a/app/assets/stylesheets/member-facing/fundraiser.scss
+++ b/app/assets/stylesheets/member-facing/fundraiser.scss
@@ -272,11 +272,6 @@
       }
     }
 
-    // Fix for iOS radio button black square bug
-    .form--big input[type='radio'] {
-      background: none;
-    }
-
 
     .overlay-toggle__close-button {
       display: none;

--- a/app/javascript/plugins/email_tool/EmailToolView.js
+++ b/app/javascript/plugins/email_tool/EmailToolView.js
@@ -109,7 +109,7 @@ export default class EmailToolView extends Component {
   }
 
   composeAllTargetEmails = () => {
-    let toEmailAddresses = null;
+    let toEmailAddresses;
     if (this.state.target.id === 'all') {
       forEach(this.props.targets, target => {
         toEmailAddresses = toEmailAddresses
@@ -227,20 +227,6 @@ export default class EmailToolView extends Component {
                   />
                 </FormGroup>
               )}
-              {/* {this.props.manualTargeting && (
-                <FormGroup>
-                  <Select
-                    clearable={false}
-                    name="Target"
-                    label={
-                      <FormattedMessage id="email_tool.form.select_target" />
-                    }
-                    value={get(this.state.target, 'id', undefined)}
-                    options={this.state.targetsForSelection}
-                    onChange={this.onTargetChange}
-                  />
-                </FormGroup>
-              )} */}
 
               <FormGroup>
                 <Input

--- a/app/services/email_tool_sender.rb
+++ b/app/services/email_tool_sender.rb
@@ -48,15 +48,21 @@ class EmailToolSender
         page_id: @page.id,
         name: @params[:from_name],
         email: @params[:from_email],
-        action_target: @target&.name,
-        action_target_email: @target&.email,
         country: @params[:country],
         email_service: @params[:email_service]
-      }.merge(@tracking_params)
+      }.merge(action_target_params).merge(@tracking_params)
     )
   end
 
   private
+
+  def action_target_params
+    if @params[:target_id] == 'all'
+      { action_target: 'multiple', action_target_email: to_emails }
+    else
+      { action_target: @target&.name, action_target_email: @target&.email }
+    end
+  end
 
   def to_emails
     if @plugin.test_email_address.blank?
@@ -103,7 +109,7 @@ class EmailToolSender
     add_error(:base, 'Please make sure a country is being sent') if @params[:country].blank?
 
     target_id = @params[:target_id]
-    if target_id.present? && @plugin.find_target(target_id).nil?
+    if target_id.present? && target_id != 'all' && @plugin.find_target(target_id).nil?
       add_error(:base, I18n.t('email_tool.form.errors.target.outdated'))
     end
   end

--- a/app/services/email_tool_sender.rb
+++ b/app/services/email_tool_sender.rb
@@ -50,7 +50,7 @@ class EmailToolSender
         email: @params[:from_email],
         country: @params[:country],
         email_service: @params[:email_service]
-      }.merge(action_target_params).merge(@tracking_params)
+      }.merge(action_target_params, @tracking_params)
     )
   end
 

--- a/spec/services/email_tool_sender_spec.rb
+++ b/spec/services/email_tool_sender_spec.rb
@@ -105,6 +105,14 @@ et a neque. Nam non mi in eros sollicitudin imperdiet.',
   end
 
   context 'creating an action' do
+    it 'assigns default value for country if the value is nil' do
+      service = EmailToolSender.new(page.id, params.merge(country: nil))
+      expect {
+        service.run
+      }.to change(Action, :count).by(1)
+      expect(service.action.form_data['country']).to eq 'US'
+    end
+
     it 'creates an action and member with the correct params (not-EEA country)' do
       service = EmailToolSender.new(page.id, params)
       expect {
@@ -175,7 +183,8 @@ et a neque. Nam non mi in eros sollicitudin imperdiet.',
       expect(service.errors[:base]).to include(/targets information has recently changed/)
     end
 
-    # Skipping since default country will be set as US within EmailToolSender
+    # Skipping since default country will be set as US within EmailToolSender,
+    # verifying default country in a previous test
     xit 'validates the presence of country' do
       service = EmailToolSender.new(page.id, {})
       expect(service.run).to be false

--- a/spec/services/email_tool_sender_spec.rb
+++ b/spec/services/email_tool_sender_spec.rb
@@ -175,7 +175,8 @@ et a neque. Nam non mi in eros sollicitudin imperdiet.',
       expect(service.errors[:base]).to include(/targets information has recently changed/)
     end
 
-    it 'validates the presence of country' do
+    # Skipping since default country will be set as US within EmailToolSender
+    xit 'validates the presence of country' do
       service = EmailToolSender.new(page.id, {})
       expect(service.run).to be false
       expect(service.errors[:base]).to include('Please make sure a country is being sent')


### PR DESCRIPTION
**Allow users to select all target email addresses in Email Tool.**
**_Front-end:_** Request param's `target_id` value will be `all`.
**_Back-end:_** Action's `form_data` will now have `action_target` value as `multiple` and `action_target_email` value as an array of plugin email addresses.

**Fixed black square background on radio button bug that happened on iOS Safari.**

**Assign US as the default country if country of incoming action request couldn't be recognized.**