### PR TITLE
Increase timeout in mounting the copied gift array to the EOY templat…

### DIFF
--- a/vendor/theme/templates/layouts/end-of-year-scroll-to-share-2020.liquid
+++ b/vendor/theme/templates/layouts/end-of-year-scroll-to-share-2020.liquid
@@ -306,7 +306,7 @@
         $('.AmountSelection-container').find($('input#DonationBands-custom-amount')).focus();
       });
 
-    }, 400);
+    }, 2000);
 
   });
 </script>


### PR DESCRIPTION
…e because on an initial page load when all the assets are loaded from scratch, 400 ms is apparently not enough time to have the page ready