### PR TITLE
Remove transactions that are not successful and that don't have a currency recorded from the EOY donations count

### DIFF
--- a/app/services/transaction_service.rb
+++ b/app/services/transaction_service.rb
@@ -33,13 +33,15 @@ module TransactionService
   def count_go_cardless(date_range = Float::INFINITY..Float::INFINITY)
     gocardless_transactions
       .where(created_at: date_range)
+      .where.not(currency: nil)
       .group(:currency)
       .sum(:amount)
   end
 
   def count_braintree(date_range = Float::INFINITY..Float::INFINITY)
     braintree_transactions
-      .where(created_at: date_range)
+      .where(created_at: date_range, status: 'success')
+      .where.not(currency: nil)
       .group(:currency)
       .sum(:amount)
   end
@@ -48,7 +50,7 @@ module TransactionService
 
   def braintree_transactions
     ::Payment::Braintree::Transaction
-      .select(:id, :created_at, :subscription_id, :amount, :currency)
+      .select(:id, :created_at, :subscription_id, :status, :transaction_id, :transaction_created_at, :amount, :currency)
   end
 
   def gocardless_transactions


### PR DESCRIPTION
In the TransactionService building the EOY translation amounts cache, manually exclude transactions that have nil for currency, as Currency.convert in app/lib/payment_processor/currency.rb will use 'USD' as the default currency if one is not passed, which inflates the donation amounts.