### PR TITLE
Enable 3DS Support

### DIFF
--- a/app/javascript/components/Payment/Payment.js
+++ b/app/javascript/components/Payment/Payment.js
@@ -36,8 +36,7 @@ import { isDirectDebitSupported } from '../../util/directDebitDecider';
 import './Payment.css';
 
 const BRAINTREE_TOKEN_URL =
-  process.env.BRAINTREE_TOKEN_URL ||
-  'https://1j1tytu4da.execute-api.us-west-2.amazonaws.com/dev/braintree/token';
+  process.env.BRAINTREE_TOKEN_URL || '/api/payment/braintree/token';
 const LOCAL_PAYMENT_PROVIDERS = ['ideal', 'giropay'];
 
 export class Payment extends Component {

--- a/app/javascript/state/fundraiser/reducer.js
+++ b/app/javascript/state/fundraiser/reducer.js
@@ -64,6 +64,19 @@ export const initialState = {
   oneClickError: false,
   title: '',
   supportedLocalCurrency: true,
+  merchantAccounts: {
+    USD: 'sumofus',
+    GBP: 'sumofus2_GBP',
+    EUR: 'sumofus2_EUR',
+    CHF: 'SumOfUs_CHF',
+    CAD: 'SumOfUs_CAD',
+    AUD: 'SumOfUs_AUD',
+    NZD: 'SumOfUs_NZD',
+    MXN: 'SumOfUs_MXN',
+    ARS: 'SumOfUs_ARS',
+    BRL: 'SumOfUs_BRL',
+  },
+  merchantAccountId: 'sumofus',
 };
 
 export default (state = initialState, action) => {
@@ -96,19 +109,21 @@ export default (state = initialState, action) => {
         formValues: {},
       };
     case 'change_currency': {
-      const { preselectAmount, donationBands } = state;
+      const { preselectAmount, donationBands, merchantAccounts } = state;
       const currency = supportedCurrency(action.payload, keys(donationBands));
       const localPaymentTypes = getLocalPaymentTypes({
         country: state.form.country || state.formValues.country,
         recurring: state.recurring,
         currency: currency,
       });
+      const merchantAccountId = merchantAccounts[currency.toUpperCase()];
 
       return {
         ...state,
         ...featuredAmountState(preselectAmount, { donationBands, currency }),
         currency,
         localPaymentTypes,
+        merchantAccountId,
       };
     }
     case 'change_amount':

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@types/react-dom": "^16.8.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "backbone": "^1.4.0",
-    "braintree-web": "^3.46.0",
+    "braintree-web": "^3.52.0",
     "c3": "^0.7.1",
     "classnames": "^2.2.6",
     "cookieconsent": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,47 +921,52 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@braintree/asset-loader@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@braintree/asset-loader/-/asset-loader-0.3.1.tgz#2ee703193fba9f479e674e76ac83f2ccfd6e7a9e"
-  integrity sha512-6Jkps+3iobSwMOqSXHUwIU39QARDFr0T6R/OcIAKX51SlZbc8q9VXl+lxjsDDnNF8cybXn07OGEypeNs9ZKJ6g==
+"@braintree/asset-loader@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@braintree/asset-loader/-/asset-loader-0.4.4.tgz#9a5eda24c3627bfd5c7f7483cd48f0e411dd2f09"
+  integrity sha512-uVhXC5dydmngmNVuDiKgfXSlz4kv4x5ytIJodI8N5SY16mRh13m/UmbQ7yH+o8DQqp50qPZ45MUHIZkXKPg85w==
   dependencies:
-    promise-polyfill "^8.1.0"
+    promise-polyfill "^8.1.3"
 
-"@braintree/browser-detection@1.9.0", "@braintree/browser-detection@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@braintree/browser-detection/-/browser-detection-1.9.0.tgz#bbaca6965a0685d0d91fd6e9194db034857d1d46"
-  integrity sha512-EEj6I9vRuxfvWRo4se5b13BP2nBVOJS9qoMKjFLJAMW+84/xgCaN6pYbZH8G6rDXhPUdkzqUPEGB3n+VdNFjTQ==
+"@braintree/browser-detection@1.12.1", "@braintree/browser-detection@^1.12.0":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@braintree/browser-detection/-/browser-detection-1.12.1.tgz#917af7834ea37615957f0e1eef67def9d0b142db"
+  integrity sha512-i/54qrax5o/WbJJhsE/7qqKE594/kGhR+xSu/w13rT7Mlr/uITkWDXzxffcKQ6l6FQxK0IG0EfgT6TJpWgZcUQ==
 
-"@braintree/class-list@0.1.0":
+"@braintree/class-list@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@braintree/class-list/-/class-list-0.2.0.tgz#4c4352ac19c262f61526f93d07d248244b399ec4"
+  integrity sha512-iLXJT51jnBFuGvyTAQqZ2uwyEVwdyapyz52F5MK1Uoh2ZOiPJ5hoqI0wncyCP2KfqrgyCpOkkEaLMLb/94unGA==
+
+"@braintree/event-emitter@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@braintree/event-emitter/-/event-emitter-0.4.1.tgz#204eaad8cf84eb7bf81fb288a359d34eda85a396"
+  integrity sha512-X41357O3OXUDlnwMvS1m0GQEn3zB3s3flOBeg2J5OBvLvdJEIAVpPkblABPtsPrlciDSvfv1aSG5ixHPgFH0Zg==
+
+"@braintree/extended-promise@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@braintree/extended-promise/-/extended-promise-0.4.1.tgz#b44f8e6236ddb43434be11924f00fa69f8782a36"
+  integrity sha512-00n7m4z+swWHoFQLHLvrIBIEoxnGUBsl3ogvX79ITpcn8CHczDwtxYy5+RhMoAraRdfN3oB+8QIpN3KOxs2Q7w==
+
+"@braintree/iframer@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@braintree/iframer/-/iframer-1.1.0.tgz#7e59b975c2a48bd92616f653367a5214fc2ddd4b"
+  integrity sha512-tVpr7U6u6bqeQlHreEjYMNtnHX62vLnNWziY2kQLqkWhvusPuY5DfuGEIPpWqsd+V/a1slyTQaxK6HWTlH6A/Q==
+
+"@braintree/sanitize-url@5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-5.0.2.tgz#b23080fa35520e993a8a37a0f5bca26aa4650a48"
+  integrity sha512-NBEJlHWrhQucLhZGHtSxM2loSaNUMajC7KOYJLyfcdW/6goVoff2HoYI3bz8YCDN0wKGbxtUL0gx2dvHpvnWlw==
+
+"@braintree/uuid@0.1.0", "@braintree/uuid@^0.1.0":
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@braintree/class-list/-/class-list-0.1.0.tgz#d6c8606ce6a82b4b37f28e32eadd090abcf1adaa"
-  integrity sha512-AmXPsYhiNJKcxuwkgQjwyyTwFCeRlyFTeUJ9ecV/jLxS8ZH8fCAB4enYgArMRyvCekZZkqLK54kOJ6+OJBzJwA==
+  resolved "https://registry.yarnpkg.com/@braintree/uuid/-/uuid-0.1.0.tgz#ab9355015a7fb0e25cf3c2ff9cd32ece8ea304b0"
+  integrity sha512-YvZJdlNcK5EnR+7M8AjgEAf4Qx696+FOSYlPfy5ePn80vODtVAUU0FxHnzKZC0og1VbDNQDDiwhthR65D4Na0g==
 
-"@braintree/event-emitter@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@braintree/event-emitter/-/event-emitter-0.3.0.tgz#8239ad51c71707b317f30da2d29abb369f91a579"
-  integrity sha512-yzC81QgTuL18RK9Da4C5oAyta5OLNZ3mGqiGKZFc8BKxOnGJN5ObhiFiOdbMbvPUYJQ4teZsal7j00o5RFlGcQ==
-
-"@braintree/extended-promise@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@braintree/extended-promise/-/extended-promise-0.3.0.tgz#84e99105e520c6c454c3922848b13222b8999c50"
-  integrity sha512-AOBCcLlDo/JzxKfHN0s3QQjtDjVPgQAQ5INUomloTfg6qq5inEdHOkvts8Z/9RqqoCrOKgEbnRpGgWMQn+z1RA==
-
-"@braintree/iframer@1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@braintree/iframer/-/iframer-1.0.3.tgz#21dd1fd4cebd4154aeab1efa4d5b0d5f4384364e"
-  integrity sha1-Id0f1M69QVSuqx76TVsNX0OENk4=
-
-"@braintree/sanitize-url@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-4.0.1.tgz#16e719eba72693f95989c05f2b3b424f2aabc5b0"
-  integrity sha512-THIQtVN491hY2rTZ/h5boj0CwDKrZQIUnfaj6RbpGwRJKfmEIgNpgcCJC3KZl1Vux9bQmdE2P4Q7cYUoSUQ4MA==
-
-"@braintree/wrap-promise@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@braintree/wrap-promise/-/wrap-promise-2.0.0.tgz#6bf4bd934f18bb1b460bdd608d81154db8d2ff65"
-  integrity sha512-I9s8c/bHBx7gM04yHGKjRoyqX1NhT4d3RIQjLZDW+yFI3DRmi/8JYDpxQeW4fiU6bWX2f3KV1Oa8r2nwKeaAwA==
+"@braintree/wrap-promise@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@braintree/wrap-promise/-/wrap-promise-2.1.0.tgz#7e27ffc5dacd2d71533b0c42506eea8e7c2e50fa"
+  integrity sha512-UIrJB+AfKU0CCfbMoWrsGpd2D/hBpY/SGgFI6WRHPOwhaZ3g9rz1weiJ6eb6L9KgVyunT7s2tckcPkbHw+NzeA==
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -2169,25 +2174,26 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-braintree-web@^3.46.0:
-  version "3.62.1"
-  resolved "https://registry.yarnpkg.com/braintree-web/-/braintree-web-3.62.1.tgz#01694b01e866cb38178fedc96d5b141b20b20f47"
-  integrity sha512-pGVGibbFGARY3blztlUMXaXsoJjcH8BfUGlzXstabc8hZJ9sLc9ZBamb6DShx1m68AW0cDckiGWdvmGXlBBMSA==
+braintree-web@^3.52.0:
+  version "3.83.0"
+  resolved "https://registry.yarnpkg.com/braintree-web/-/braintree-web-3.83.0.tgz#490c40afa6dd35029309057fad618f008124deb2"
+  integrity sha512-i8kbZRRJ0P3ADKTXNveFjA5AE74bNTHvmERA91t8HTY19aPkuDzyAs4/InEzxdsBeLByZzyDu4ldw5MAuAkGHg==
   dependencies:
-    "@braintree/asset-loader" "0.3.1"
-    "@braintree/browser-detection" "1.9.0"
-    "@braintree/class-list" "0.1.0"
-    "@braintree/event-emitter" "0.3.0"
-    "@braintree/extended-promise" "0.3.0"
-    "@braintree/iframer" "1.0.3"
-    "@braintree/sanitize-url" "4.0.1"
-    "@braintree/wrap-promise" "2.0.0"
-    card-validator "6.2.0"
-    credit-card-type "8.3.0"
-    framebus "3.0.2"
-    inject-stylesheet "2.0.0"
-    promise-polyfill "8.1.3"
-    restricted-input "2.1.0"
+    "@braintree/asset-loader" "0.4.4"
+    "@braintree/browser-detection" "1.12.1"
+    "@braintree/class-list" "0.2.0"
+    "@braintree/event-emitter" "0.4.1"
+    "@braintree/extended-promise" "0.4.1"
+    "@braintree/iframer" "1.1.0"
+    "@braintree/sanitize-url" "5.0.2"
+    "@braintree/uuid" "0.1.0"
+    "@braintree/wrap-promise" "2.1.0"
+    card-validator "8.1.1"
+    credit-card-type "9.1.0"
+    framebus "5.1.2"
+    inject-stylesheet "5.0.0"
+    promise-polyfill "8.2.1"
+    restricted-input "3.0.4"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -2459,12 +2465,12 @@ capture-exit@^2.0.0:
   dependencies:
     rsvp "^4.8.4"
 
-card-validator@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/card-validator/-/card-validator-6.2.0.tgz#59037c6480df5786473cab720f165ba868560e0b"
-  integrity sha512-1vYv45JaE9NmixZr4dl6ykzbFKv7imI9L7MQDs235b/a7EGbG8rrEsipeHtVvscLSUbl3RX6UP5gyOe0Y2FlHA==
+card-validator@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/card-validator/-/card-validator-8.1.1.tgz#418f5f32435553fb9ca2a02634ad413bb38697a9"
+  integrity sha512-cN4FsKwoTfTFnqPwVc7TQLSsH/QMDB3n/gWm0XelcApz4sKipnOQ6k33sa3bWsNnnIpgs7eXOF+mUV2UQAX2Sw==
   dependencies:
-    credit-card-type "^8.0.0"
+    credit-card-type "^9.1.0"
 
 cardinal@^1.0.0:
   version "1.0.0"
@@ -2923,10 +2929,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-credit-card-type@8.3.0, credit-card-type@^8.0.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/credit-card-type/-/credit-card-type-8.3.0.tgz#f93c187c9362411544158c91d552efcc443aa87a"
-  integrity sha512-czfZUpQ7W9CDxZL4yFLb1kFtM/q2lTOY975hL2aO+DC8+GRNDVSXVCHXhVFZPxiUKmQCZbFP8vIhxx5TBQaThw==
+credit-card-type@9.1.0, credit-card-type@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/credit-card-type/-/credit-card-type-9.1.0.tgz#54dd96c93b6579623e9c8656e6798fc2b93f5f05"
+  integrity sha512-CpNFuLxiPFxuZqhSKml3M+t0K/484pMAnfYWH14JoD7OZMnmC0Lmo+P7JX9SobqFpRoo7ifA18kOHdxJywYPEA==
 
 cross-fetch@^3.0.4:
   version "3.0.6"
@@ -4538,10 +4544,12 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framebus@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/framebus/-/framebus-3.0.2.tgz#0c99c70cb507522aae6ed485e1317fc913873a8a"
-  integrity sha512-OqhYkhgRYlpKZoSl5EA3whKh8O8omFPCzf7MGzFqC6CtrT8lg7evNgU6QdjC3uY3ATq5saMDiY5HJ8KGiGDYCA==
+framebus@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/framebus/-/framebus-5.1.2.tgz#cb38cf6a282d405411227cfaab4a1095ca9e8e15"
+  integrity sha512-Z/y6/0gHVx4Td4c0jkDiASBo0pXlJ2fKOP6CynSFnxTzqojG9xOKOFOqoYkcBHlz1vP4t4yHHR6Esp+GsYIh/Q==
+  dependencies:
+    "@braintree/uuid" "^0.1.0"
 
 fresh@0.5.2:
   version "0.5.2"
@@ -5256,10 +5264,10 @@ ini@^1.3.4, ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-inject-stylesheet@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/inject-stylesheet/-/inject-stylesheet-2.0.0.tgz#5153437cbb30c55a203613a6f079a94089b6c361"
-  integrity sha512-XiItpXWDXRrH1VhG5AnHghuZdpDp6UeugiOKBr3RGmANucucHwKuT0BPSB0zpDqiX3P+rhhJFip1rxOI18+/Tw==
+inject-stylesheet@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/inject-stylesheet/-/inject-stylesheet-5.0.0.tgz#bb34acf05ca6ed86e5763d886cd6c9b19f360ab1"
+  integrity sha512-GzncrJP8E/pavMQzoO93CXoYCfTttwVm2cX2TyXJdgtVE0cCvWSFCn1/uMsM6ZkEg7LUsOcKuamcLiGWlv2p9A==
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -8538,10 +8546,10 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise-polyfill@8.1.3, promise-polyfill@^8.1.0:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
-  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
+promise-polyfill@8.2.1, promise-polyfill@^8.1.3:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.2.1.tgz#1fa955b325bee4f6b8a4311e18148d4e5b46d254"
+  integrity sha512-3p9zj0cEHbp7NVUxEYUWjQlffXqnXaZIMPkAO7HhFh8u5636xLRDHOUo2vpWSK0T2mqm6fKLXYn1KP6PAZ2gKg==
 
 promise@^7.1.1:
   version "7.3.1"
@@ -9173,12 +9181,12 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-restricted-input@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/restricted-input/-/restricted-input-2.1.0.tgz#3e2ff79e8fee53d3152cf859063701ded206582f"
-  integrity sha512-dH4cNfdTgChSlqYGff0zMtLSPWj3oU4oph9GvHgWhDEiHftk7/B9Ci5y5mCts2atvcm2a0gTZ8XqNaP9cVzMwg==
+restricted-input@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/restricted-input/-/restricted-input-3.0.4.tgz#6e4453097632f3f18aa8201d6c291357e5771211"
+  integrity sha512-HNrlYBkaQS3SPaTNp5PwqA2iY2hKHJAC1TSdPAi7Nst2jwW76ejantGp0BSf4ckMXPygmDPlxqDRvJ1rRd3mEQ==
   dependencies:
-    "@braintree/browser-detection" "^1.9.0"
+    "@braintree/browser-detection" "^1.12.0"
 
 ret@~0.1.10:
   version "0.1.15"


### PR DESCRIPTION
### Overview
* We have some reports about declined transactions due to 3D Secure authentication not being performed during checkout.
    * For us to enable 3DS we needed to ask Braintree support to enable it for our merchant account (prod and sandbox) 
        * For the **sandbox** account **we had to create a new one** since the one we're currently using is a marketplace account and 3DS is not supported for those types of accounts. 
    * Upgraded `braintree-web` package version
    * When creating the hosted fields in `createHostedFields` method, add the 3DS instance creation
        * Added the instance to the state so it is available for us when needed.
            * If for any reason the 3DS instance creation fails, the site should not break and the user should be able to continue with the donation as if 3DS was never enabled nor implemented at all.
                * The development console will show an error, but it shouldn't be more than that.  
        * The 3DS version we're using is `v2`
    * After tokenizing the hostedfields on form submission (when we get the nonce)
        * We call the `verifyCard`method from 3DS
            * **In the SandBox env:**
                * **If we use testing cards that trigger the challenge but are successful**
                    * A popup will appear and we need to input the given code for it to close and continue the flow
                        * Since the test card is for a successful transaction, 3DS will not fail and the transaction will be processed successfully.
                            * When 3DS succeeds, Braintree gives us an `authenticationId` that we need to include in the transaction payload.
                * **if we use testing cards that trigger the challenge but are unsuccessful**
                    * A popup will appear and we need to input the given code for it to close and continue the flow
                        * Since the test card is for an unsuccessful transaction, 3DS will fail and the transaction will not be processed. The UI will show an error message.
                * **if we use testing cards that don't trigger the challenge and are successful**
                    * Regular flow should be presented to the user and no popup should be shown
            * **In production env:** 
                * Everything should be very similar to the sandbox, however, the Bank is in charge of triggering the challenge or not as well as for failing the responses.
                    * That being said, the popup we will start seeing on staging is just a mock, but in production that will vary from bank to bank.  

### Ticket
https://app.asana.com/0/1119304937718815/1201335394700376/f

### Demo / Proof of working

#### Test Card that triggers the challenge but is successful
<details>
  <summary>Video</summary>

https://user-images.githubusercontent.com/15176901/149424356-63f4ef7a-aba6-4d3f-bb3b-6da2acd0ed4e.mp4
</details>

#### Test Card that triggers the challenge and is unsuccessful
<details>
  <summary>Video</summary>

https://user-images.githubusercontent.com/15176901/149424609-d0cd5141-fd8b-41a5-acfb-acfb14f6d73a.mp4
</details>


#### Test Card that doesn't trigger the challenge and is successful
<details>
  <summary>Video</summary>

https://user-images.githubusercontent.com/15176901/149424841-5cfbb1ae-9c15-4b9e-b12b-b2f7aa215595.mp4
</details>

## Important Notes for Reviewers
* Pronto needs the same work, I'll open a PR for it
* We will need to change the Braintree env variables all over the place to use the new Sandbox account
    * The current Sandbox has the Paypal sandbox account linked, we need to unlink it and link it to the new one
    * ARS currency is not available on the new Sandbox account, we will need to reach out to Braintree about it
        * Is actually not available on both, I guess it was in the past and that's how you added ARS?  





