### PR TITLE
Send merchantAccountId when generating bt token

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -8,7 +8,8 @@ class Api::Payment::BraintreeController < PaymentController
   # before_action :verify_bot, only: [:transaction]
 
   def token
-    render json: { token: ::Braintree::ClientToken.generate }
+    @merchant_account_id = unsafe_params[:merchantAccountId]
+    render json: { token: ::Braintree::ClientToken.generate(merchant_account_id: @merchant_account_id) }
   end
 
   def webhook


### PR DESCRIPTION
I left the change unstaged; this should have been part of #1797 🤦🏼‍♀️ 