### PR TITLE
Send Merchant Account Id to PaymentMethod Create

### DIFF
--- a/app/javascript/components/Payment/Payment.js
+++ b/app/javascript/components/Payment/Payment.js
@@ -121,8 +121,7 @@ export class Payment extends Component {
             braintree.localPayment.create(
               {
                 client: client,
-                merchantAccountId:
-                  champaign.configuration.localPaymentMerchantAccountId,
+                merchantAccountId: this.props.merchantAccountId,
               },
               (localPaymentErr, localPaymentInstance) => {
                 this.setState({
@@ -381,6 +380,7 @@ export class Payment extends Component {
       ...(data.threeDSecureInfo?.threeDSecureAuthenticationId && {
         authenticationId: data.threeDSecureInfo.threeDSecureAuthenticationId,
       }),
+      merchantAccountId: this.props.merchantAccountId,
     };
 
     this.emitTransactionSubmitted();

--- a/app/javascript/components/Payment/Payment.js
+++ b/app/javascript/components/Payment/Payment.js
@@ -380,7 +380,6 @@ export class Payment extends Component {
       ...(data.threeDSecureInfo?.threeDSecureAuthenticationId && {
         authenticationId: data.threeDSecureInfo.threeDSecureAuthenticationId,
       }),
-      merchantAccountId: this.props.merchantAccountId,
     };
 
     this.emitTransactionSubmitted();

--- a/app/lib/payment_processor/braintree/subscription.rb
+++ b/app/lib/payment_processor/braintree/subscription.rb
@@ -111,7 +111,8 @@ module PaymentProcessor
           customer_id: existing_customer.customer_id,
           billing_address: billing_options,
           options: {
-            verify_card: true
+            verify_card: true,
+            verification_merchant_account_id: MerchantAccountSelector.for_currency(@currency)
           },
           device_data: @device_data
         }

--- a/spec/lib/payment_processor/braintree/subscription_spec.rb
+++ b/spec/lib/payment_processor/braintree/subscription_spec.rb
@@ -69,7 +69,8 @@ module PaymentProcessor
               payment_method_nonce: required_options[:nonce],
               customer_id: customer.customer_id,
               options: {
-                verify_card: true
+                verify_card: true,
+                verification_merchant_account_id: 'AUD'
               },
               device_data: { foo: 'bar' },
               billing_address: {

--- a/spec/liquid/liquid_helper_spec.rb
+++ b/spec/liquid/liquid_helper_spec.rb
@@ -58,7 +58,7 @@ describe LiquidHelper do
       create :plugins_petition, page: page, target: '', active: true
       create :plugins_petition, page: page, target: 'mf doom', active: true
       create :plugins_petition, page: page, target: '', active: true
-      expect(LiquidHelper.globals(page: page)[:petition_target]).to eq 'koch brothers'
+      expect(LiquidHelper.globals(page: page)[:petition_target]).to eq 'mf doom'
     end
   end
 end

--- a/spec/liquid/liquid_helper_spec.rb
+++ b/spec/liquid/liquid_helper_spec.rb
@@ -58,7 +58,7 @@ describe LiquidHelper do
       create :plugins_petition, page: page, target: '', active: true
       create :plugins_petition, page: page, target: 'mf doom', active: true
       create :plugins_petition, page: page, target: '', active: true
-      expect(LiquidHelper.globals(page: page)[:petition_target]).to eq 'mf doom'
+      expect(LiquidHelper.globals(page: page)[:petition_target]).to eq 'koch brothers'
     end
   end
 end

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -1218,7 +1218,8 @@ describe 'Braintree API' do
                                                                               customer_id: customer.customer_id,
                                                                               device_data: {},
                                                                               options: {
-                                                                                verify_card: true
+                                                                                verify_card: true,
+                                                                                verification_merchant_account_id: 'EUR'
                                                                               },
                                                                               billing_address: {
                                                                                 first_name: 'Bernie',


### PR DESCRIPTION
### Overview
During the QA of 3DS, we encountered an error when trying to make a monthly donation. The error we are getting back from BT is:

````
Merchant account must match the 3D Secure authorization merchant account. (94284 on merchant_account_id)
````

The error happens when we call the `transaction` endpoint in Champaign; however, the issue is actually happening when we call the `create` method `::Braintree::PaymentMethod.create(payment_method_options)` because we are not sending the merchant account id information; therefore, Braintree uses the default.

The issue is affecting both, Champaign and Pronto.

### Ticket
https://app.asana.com/0/1119304937718815/1201335394700376/f

