### PR TITLE
Send merchant account id for bt customer create

### DIFF
--- a/app/lib/payment_processor/braintree/subscription.rb
+++ b/app/lib/payment_processor/braintree/subscription.rb
@@ -145,7 +145,10 @@ module PaymentProcessor
 
         customer_options.merge(payment_method_nonce: @nonce,
                                credit_card: {
-                                 billing_address: billing_options
+                                 billing_address: billing_options,
+                                 options: {
+                                   verification_merchant_account_id: MerchantAccountSelector.for_currency(@currency)
+                                 }
                                })
       end
     end

--- a/spec/lib/payment_processor/braintree/subscription_spec.rb
+++ b/spec/lib/payment_processor/braintree/subscription_spec.rb
@@ -236,6 +236,9 @@ module PaymentProcessor
                   first_name: 'Bob',
                   last_name: 'Loblaw',
                   country_code_alpha2: 'AU'
+                },
+                options: {
+                  verification_merchant_account_id: 'AUD'
                 }
               }
             }

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -1437,6 +1437,9 @@ describe 'Braintree API' do
                                                                              street_address: '25 Elm Drive',
                                                                              postal_code: '11225',
                                                                              country_code_alpha2: 'US'
+                                                                           },
+                                                                           options: {
+                                                                             verification_merchant_account_id: 'EUR'
                                                                            }
                                                                          })
             end


### PR DESCRIPTION
When a subscription is created, we first call BT customer create method if the member is not already a customer; we need to send the merchant id for this call too; otherwise, we'll get a 3DS error regarding mismatching merchant account ids