### PR TITLE
Include Donation Bands On The Pages API

### DIFF
--- a/app/views/api/pages/show.json.jbuilder
+++ b/app/views/api/pages/show.json.jbuilder
@@ -59,7 +59,6 @@ json.language @page.language.code
 
 petition =  @page.plugins.select { |p| p.class.name == 'Plugins::Petition' }.first
 fundraiser = @page.plugins.select { |p| p.class.name == 'Plugins::Fundraiser' }.first
-liquid_data = fundraiser.liquid_data
 
 json.petition do 
   if petition
@@ -76,9 +75,12 @@ end
 
 json.fundraiser do 
   if fundraiser
+    liquid_data = fundraiser.liquid_data
     if fundraiser.form
       json.form fundraiser.form.form_elements.order(:position)
       json.form_id fundraiser.form.id
+    end
+    if liquid_data
       json.extract! liquid_data, :donation_bands
     end
   end

--- a/app/views/api/pages/show.json.jbuilder
+++ b/app/views/api/pages/show.json.jbuilder
@@ -78,6 +78,7 @@ json.fundraiser do
     if fundraiser.form
       json.form fundraiser.form.form_elements.order(:position)
       json.form_id fundraiser.form.id
+      json.donation_bands fundraiser.liquid_data.donation_bands
     end
   end
 end

--- a/app/views/api/pages/show.json.jbuilder
+++ b/app/views/api/pages/show.json.jbuilder
@@ -59,6 +59,7 @@ json.language @page.language.code
 
 petition =  @page.plugins.select { |p| p.class.name == 'Plugins::Petition' }.first
 fundraiser = @page.plugins.select { |p| p.class.name == 'Plugins::Fundraiser' }.first
+liquid_data = fundraiser.liquid_data
 
 json.petition do 
   if petition
@@ -78,7 +79,7 @@ json.fundraiser do
     if fundraiser.form
       json.form fundraiser.form.form_elements.order(:position)
       json.form_id fundraiser.form.id
-      json.donation_bands fundraiser.liquid_data.donation_bands
+      json.extract! liquid_data, :donation_bands
     end
   end
 end


### PR DESCRIPTION
### Overview
* Right now, the pages API does not include the donation bands in the response. This PR is adding that piece of data inside the fundraiser object so we can use it on pronto.
    * The donation bands information is [inside the fundraiser plugin model](https://github.com/SumOfUs/Champaign/blob/development/app/models/plugins/fundraiser.rb#L52) on the `liquid_data` object  
    
      