### PR TITLE
pronto redirect

### DIFF
--- a/app/admin/page.rb
+++ b/app/admin/page.rb
@@ -2,7 +2,7 @@
 
 ActiveAdmin.register Page do
   actions :all, except: %i[new destroy]
-  permit_params :publish_status, :featured
+  permit_params :publish_status, :featured, :pronto
 
   config.per_page = 20
   scope :publish_status, show_count: false
@@ -24,13 +24,5 @@ ActiveAdmin.register Page do
     column :publish_status
     column :status
     actions
-  end
-
-  sidebar 'Previous Versions', only: :show do
-    attributes_table_for page do
-      row :versions do
-        render '/versions/versions_link', model: page, model_name: 'page'
-      end
-    end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,6 +12,7 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   before_action :redirect_unless_published, only: %i[show follow_up]
   before_action :localize, only: %i[show follow_up double_opt_in_notice]
   before_action :record_tracking, only: %i[show]
+  before_action :redirect_to_pronto, only: [:show]
 
   def index
     @pages = Search::PageSearcher.search(search_params)
@@ -199,5 +200,11 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
 
   def localize
     set_locale(@page.language_code)
+  end
+
+  def redirect_to_pronto
+    if @page.pronto
+      redirect_to("https://pronto.sumofus.org/#{request.fullpath}") if rand.round == 1
+    end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -203,7 +203,7 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def redirect_to_pronto
-    if @page.pronto
+    if @page.pronto && @page.published? && !user_signed_in?
       redirect_to("https://pronto.sumofus.org/#{request.fullpath}") if rand.round == 1
     end
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -23,6 +23,7 @@
 #  meta_tags                  :string
 #  notes                      :text
 #  optimizely_status          :integer          default("optimizely_enabled"), not null
+#  pronto                     :boolean          default(FALSE)
 #  publish_actions            :integer          default("secure"), not null
 #  publish_status             :integer          default("unpublished"), not null
 #  slug                       :string           not null

--- a/db/migrate/20220223114525_add_pronto_flag_to_page.rb
+++ b/db/migrate/20220223114525_add_pronto_flag_to_page.rb
@@ -1,0 +1,5 @@
+class AddProntoFlagToPage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :pronto, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_14_122450) do
+ActiveRecord::Schema.define(version: 2022_02_23_114525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -244,6 +244,7 @@ ActiveRecord::Schema.define(version: 2021_12_14_122450) do
     t.decimal "total_donations", precision: 10, scale: 2, default: "0.0"
     t.decimal "fundraising_goal", precision: 10, scale: 2, default: "0.0"
     t.string "ak_slug", default: ""
+    t.boolean "pronto", default: false
     t.index ["campaign_id"], name: "index_pages_on_campaign_id"
     t.index ["follow_up_liquid_layout_id"], name: "index_pages_on_follow_up_liquid_layout_id"
     t.index ["follow_up_page_id"], name: "index_pages_on_follow_up_page_id"

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -6,7 +6,7 @@ describe PagesController do
   let(:user) { instance_double('User', id: '1') }
   let(:default_language) { instance_double(Language, code: :en) }
   let(:language) { instance_double(Language, code: :fr) }
-  let(:page) { instance_double('Page', published?: true, featured?: true, to_param: 'foo', id: '1', liquid_layout: '3', follow_up_liquid_layout: '4', language: default_language) }
+  let(:page) { instance_double('Page', published?: true, featured?: true, pronto: false, to_param: 'foo', id: '1', liquid_layout: '3', follow_up_liquid_layout: '4', language: default_language) }
   let(:renderer) do
     instance_double(
       'LiquidRenderer',
@@ -208,10 +208,10 @@ describe PagesController do
 
     context 'on pages with localization' do
       let(:french_page) do
-        instance_double(Page, valid?: true, published?: true, language_code: language.code, id: '42', liquid_layout: '5')
+        instance_double(Page, valid?: true, pronto: false, published?: true, language_code: language.code, id: '42', liquid_layout: '5')
       end
       let(:english_page) do
-        instance_double(Page, valid?: true, published?: true, language_code: default_language.code, id: '66', liquid_layout: '5')
+        instance_double(Page, valid?: true, pronto: false, published?: true, language_code: default_language.code, id: '66', liquid_layout: '5')
       end
 
       context 'with french' do

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -23,6 +23,7 @@
 #  meta_tags                  :string
 #  notes                      :text
 #  optimizely_status          :integer          default("optimizely_enabled"), not null
+#  pronto                     :boolean          default(FALSE)
 #  publish_actions            :integer          default("secure"), not null
 #  publish_status             :integer          default("unpublished"), not null
 #  slug                       :string           not null

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -23,6 +23,7 @@
 #  meta_tags                  :string
 #  notes                      :text
 #  optimizely_status          :integer          default("optimizely_enabled"), not null
+#  pronto                     :boolean          default(FALSE)
 #  publish_actions            :integer          default("secure"), not null
 #  publish_status             :integer          default("unpublished"), not null
 #  slug                       :string           not null


### PR DESCRIPTION
For routing traffic to pronto we're required to find suitable mailings where we can email a pronto url to half of the selected list. With this update we can have Champaign manage traffic to pronto directly. By setting the pronto flag to true (via the admin interface) on a particular page would redirect half of all traffic to pronto. NB: This PR isn't a solution for redirecting all petition traffic to pronto once we go live.