### PR TITLE
Patch RTL style issue

### DIFF
--- a/app/assets/stylesheets/member-facing/petition.scss
+++ b/app/assets/stylesheets/member-facing/petition.scss
@@ -1,8 +1,8 @@
 $mobile-width: 700px;
 
 html[dir=rtl] .petition-bar,
-.fundraiser-bar,
-.action-form  {
+html[dir=rtl] .fundraiser-bar,
+html[dir=rtl] .action-form  {
   &__welcome-name {
     padding-right: 10px;
     padding-left: unset;

--- a/vendor/theme/stylesheets/components/photos.scss
+++ b/vendor/theme/stylesheets/components/photos.scss
@@ -81,7 +81,7 @@
   }
 }
 
-html[dir=rtl] div.mobile-title, div.header-logo__tagline, div.header-logo__logo {
+html[dir=rtl] div.mobile-title, html[dir=rtl] div.header-logo__tagline, html[dir=rtl] div.header-logo__logo {
   float: right;
 }
 


### PR DESCRIPTION
### Overview
* @edubsky  reported an issue where the campaign pages showed the sumofus logo and tagline right-aligned; this PR addresses that bug.
    * The issue was a missing `html[dir=rtl]` selector on some CSS statements, therefore the RTL only CSS was applied to the LTR version of the page for the logo. 


### Screenshots

**Before**
![Screen Shot 2022-03-04 at 12 21 43](https://user-images.githubusercontent.com/15176901/156828185-79241121-a5e7-4141-a0a2-25dd61319ccd.png)

**After**
![Screen Shot 2022-03-04 at 12 20 53](https://user-images.githubusercontent.com/15176901/156828206-94ef8b4b-a04f-4376-b5de-c4c588f05fae.png)

