### PR TITLE
Prevent page from not loading the donation bar if members had adBlocker installed

### DIFF
--- a/app/javascript/plugins/fundraiser/FundraiserView.js
+++ b/app/javascript/plugins/fundraiser/FundraiserView.js
@@ -53,6 +53,10 @@ export class FundraiserView extends Component {
         this.setState({
           isLoaded: true,
         });
+      } else {
+        this.setState({
+          isLoaded: true,
+        });
       }
     }, 500);
 


### PR DESCRIPTION
### Overview
I added a loading state on #1921, but if the members had some adBlockers installed, the extension would block google optimize script, and the loading state will remain falsy. 
With this PR, if the google optimize script is undefined (blocked), I set the loading state to true, and the donation bar should be shown to the end-user.

### Ticket
https://app.asana.com/0/1119304937718815/1202183747645773/f

### Notes
Not all the ad blockers are blocking Google Optimize, the one with the problem right now is http://adblockultimate.net/