### PR TITLE
Follow up: Only super admin users can perform crud operations for liquid templates

### DIFF
--- a/app/controllers/liquid_layouts_controller.rb
+++ b/app/controllers/liquid_layouts_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class LiquidLayoutsController < ApplicationController
+  before_action :authenticate_user!
   before_action :authenticate_super_admin!, only: %i[edit update destroy new]
   before_action :set_liquid_layout, only: %i[show edit update destroy]
 

--- a/app/controllers/liquid_layouts_controller.rb
+++ b/app/controllers/liquid_layouts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class LiquidLayoutsController < ApplicationController
-  before_action :authenticate_super_admin!
+  before_action :authenticate_super_admin!, only: %i[edit update destroy new]
   before_action :set_liquid_layout, only: %i[show edit update destroy]
 
   def index

--- a/spec/controllers/liquid_layouts_controller_spec.rb
+++ b/spec/controllers/liquid_layouts_controller_spec.rb
@@ -24,7 +24,8 @@ require 'rails_helper'
 #
 describe LiquidLayoutsController do
   include_examples 'session authentication',
-                   [{ get:  [:new] }]
+                   [{ get:  [:index] },
+                    { get:  [:new] }]
 
   # This should return the minimal set of attributes required to create a valid
   # LiquidLayout. As you add validations to LiquidLayout, be sure to

--- a/spec/controllers/liquid_layouts_controller_spec.rb
+++ b/spec/controllers/liquid_layouts_controller_spec.rb
@@ -41,7 +41,6 @@ describe LiquidLayoutsController do
   let(:user) { build(:user, email: 'test@example.com', admin: true) }
 
   before do
-    allow(request.env['warden']).to receive(:authenticate!) { user }
     allow(controller).to receive(:current_user) { user }
   end
 

--- a/spec/controllers/liquid_layouts_controller_spec.rb
+++ b/spec/controllers/liquid_layouts_controller_spec.rb
@@ -24,8 +24,7 @@ require 'rails_helper'
 #
 describe LiquidLayoutsController do
   include_examples 'session authentication',
-                   [{ get:  [:index] },
-                    { get:  [:new] }]
+                   [{ get:  [:new] }]
 
   # This should return the minimal set of attributes required to create a valid
   # LiquidLayout. As you add validations to LiquidLayout, be sure to
@@ -41,6 +40,7 @@ describe LiquidLayoutsController do
   let(:user) { build(:user, email: 'test@example.com', admin: true) }
 
   before do
+    allow(request.env['warden']).to receive(:authenticate!) { user }
     allow(controller).to receive(:current_user) { user }
   end
 


### PR DESCRIPTION
### Overview
Only super admins can perform crud operations on templates; that work was done on #1924. However, it would be ok if not admin users still can see the list of available templates and not be able to edit them or add new templates.