### PR TITLE
Update direction of generic member facing pages to rtl when the lang is AR

### DIFF
--- a/app/views/layouts/generic.slim
+++ b/app/views/layouts/generic.slim
@@ -1,5 +1,5 @@
 doctype html
-html lang="#{@page.language.try(:code).try(:downcase)}" dir=("#{@page.language.try(:code).try(:downcase)}" == 'ar' ? 'rtl' : 'ltr')
+html lang= I18n.locale dir=(I18n.locale === 'ar' ? 'rtl' : 'ltr')
   head
     title = @title
     meta name="viewport" content="width=device-width, initial-scale=1.0"

--- a/app/views/layouts/generic.slim
+++ b/app/views/layouts/generic.slim
@@ -1,5 +1,5 @@
 doctype html
-html lang= I18n.locale
+html lang="#{@page.language.try(:code).try(:downcase)}" dir=("#{@page.language.try(:code).try(:downcase)}" == 'ar' ? 'rtl' : 'ltr')
   head
     title = @title
     meta name="viewport" content="width=device-width, initial-scale=1.0"


### PR DESCRIPTION
## Overview

The [member authentication page was not being shown in Arabic](https://app.asana.com/0/1119304937718815/1202110539227254/f), instead fallbacks to default English

### Fix

- I don't think this is a translation issue, since we already have translations for the content in our codebase.
- I tried on [an STG page](https://action-staging.sumofus.org/a/sample-petition-page), when I made a monthly donation with a new user the Member Auth page renders in Arabic. 
- The only issue which I noticed was the direction was not set as rtl. 
- I have fixed that in this PR.


### Screen Recording

[Loom Message - 5 May 2022 - Watch Video](https://www.loom.com/share/2f02abf7a0e54d13ac44fc50bada7782)