### PR TITLE
Updates rendering direction of the page based on language

### DIFF
--- a/app/views/layouts/generic.slim
+++ b/app/views/layouts/generic.slim
@@ -33,3 +33,8 @@ html lang= I18n.locale
     = render partial: "shared/google_analytics_snippet"
     = render partial: "shared/mouse_flow"
     = render partial: "shared/linkedin_analytics"
+
+
+  javascript:
+    let direction = I18n.locale === 'ar' ? 'rtl' : 'ltr';
+    document.documentElement.setAttribute('dir', direction)


### PR DESCRIPTION
## Overview

The [member authentication page was not being shown in Arabic](https://app.asana.com/0/1119304937718815/1202110539227254/f), instead fallbacks to default English

### Fix

- I don't think this is a translation issue, since we already have translations for the content in our codebase.
- I tried on [an STG page](https://action-staging.sumofus.org/a/sample-petition-page), when I made a monthly donation with a new user the Member Auth page renders in Arabic. 
- The only issue which I noticed was the direction was not set as rtl. 
- I have fixed that in this PR.


### Screen Recording

[Loom Message - 5 May 2022 - Watch Video](https://www.loom.com/share/2f02abf7a0e54d13ac44fc50bada7782)