### PR TITLE
Error handling for one click api endpoint

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -14,15 +14,31 @@ class Api::Payment::BraintreeController < PaymentController
 
   def express_payment
     @page = Page.find(params[:page_id])
+    @follow_up_url = ''
 
-    @process_one_click ||= PaymentProcessor::Braintree::OneClickFromUri.new(
-      params.to_unsafe_hash,
-      page: @page,
-      member: recognized_member,
-      cookied_payment_methods: params.to_unsafe_hash['payment_method_ids']
-    ).process
+    begin
+      @follow_up_url = PageFollower.new_from_page(
+        @page
+      ).follow_up_path
+    rescue StandardError
+    end
 
-    render json: { body: cookies.signed[:payment_methods], one_click: @process_one_click, params: params }
+    begin
+      @process_one_click ||= PaymentProcessor::Braintree::OneClickFromUri.new(
+        params.to_unsafe_hash,
+        page: @page,
+        member: recognized_member,
+        cookied_payment_methods: params.to_unsafe_hash['payment_method_ids']
+      ).process
+    rescue ArgumentError => e
+      @status = 400
+      @status = 404 if e.to_s == 'PaymentProcessor::Exceptions::CustomerNotFound'
+      render json: { error: e, success: false }, status: @status
+    rescue StandardError => e
+      render json: { error: e.message, success: false }, status: 500
+    else
+      render json: { success: @process_one_click, follow_up_url: @follow_up_url }, status: 200
+    end
   end
 
   def payment_methods

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -192,6 +192,8 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
       member: recognized_member,
       cookied_payment_methods: cookies.signed[:payment_methods]
     ).process
+  rescue StandardError
+    @process_one_click = false
   end
 
   def redirect_unless_published

--- a/app/lib/payment_processor/braintree/one_click.rb
+++ b/app/lib/payment_processor/braintree/one_click.rb
@@ -21,6 +21,8 @@ module PaymentProcessor::Braintree
       if sale.success?
         action = create_action(extra_fields(sale))
         store_locally(sale, action)
+      else
+        raise "Error while making a sale transaction on BrainTree: #{sale}" unless sale.success?
       end
 
       sale

--- a/app/lib/payment_processor/braintree/one_click_from_uri.rb
+++ b/app/lib/payment_processor/braintree/one_click_from_uri.rb
@@ -12,7 +12,7 @@ module PaymentProcessor::Braintree
     end
 
     def process
-      return false unless one_click?
+      raise ArgumentError, 'Invalid request arguments' unless one_click?
 
       PaymentProcessor::Braintree::OneClick.new(options, @cookied_payment_methods, member).run
       self


### PR DESCRIPTION
### Overview
* Error handling for the new express_payment API endpoint
    * Handling invalid arguments as bad request response
    * Handling BT customer not found as 404
    * Handling every other error as an internal server error 
* Modified the success response
    *  Included the follow-up URL
    * Adding a `success` property
    * Removed not needed information from the response

### Ticket
https://app.asana.com/0/1119304937718815/1201871673365341/f

### Example request
```console
curl --location --request POST 'http://localhost:3000/api/payment/braintree/pages/10/express_payment' \
--header 'Content-Type: application/json' \
--data-raw '{
    "one_click": true,
    "payment_method_id":551,
    "currency": "MXN",
    "amount": "10",
    "recurring_default": "one_off",
    "user": {
        "form_id": 166,
        "name": "Yesi Molina",
        "email": "yesi+33@sumofus.org",
        "postal": "31160",
        "country": "MX"
    },
    "allow_duplicate": true
}'
````

Response:
```json
{"error":"PaymentProcessor::Exceptions::CustomerNotFound","success":false}
```