### PR TITLE
Undo debugging changes for failed deployment

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -17,7 +17,6 @@ function ebextensions_setup() {
     mv temp .ebextensions/04_newrelic.config
     envsubst '$APP_DOMAIN' <.ebextensions/05_nginx_proxy.config >temp
     mv temp .ebextensions/05_nginx_proxy.config
-    aws configure set default.region $AWS_REGION
 }
 
 function sync_s3() {

--- a/.ebextensions/02_container_commands.config
+++ b/.ebextensions/02_container_commands.config
@@ -12,6 +12,7 @@ files:
       -e CACHE_HOST=$CACHE_HOST \
       -e CACHE_PORT=$CACHE_PORT \
       -e AWS_REGION=$AWS_REGION \
+      -e AWS_SECRETS_MANAGER_PREFIX=$AWS_SECRETS_MANAGER_PREFIX \
       aws_beanstalk/staging-app:latest bundle exec rake db:migrate champaign:seed_liquid
   "/home/ec2-user/docker-housekeeping.sh":
     mode: "000755"

--- a/app/lib/secrets_manager.rb
+++ b/app/lib/secrets_manager.rb
@@ -10,6 +10,8 @@ module SecretsManager
       JSON.parse(secrets_manager.get_secret_value(
         secret_id: secret_name(secret_id)
       ).secret_string)
+    rescue StandardError
+      {}
     end
 
     private

--- a/config/initializers/application_secrets.rb
+++ b/config/initializers/application_secrets.rb
@@ -1,27 +1,27 @@
 require './app/lib/secrets_manager'
 
 if Rails.env == 'production' && Settings.aws_secrets_manager_prefix.present?
-  omniauth_secrets = SecretsManager.get_value('dev/omniauth')
+  omniauth_secrets = SecretsManager.get_value('omniauth')
   ak_secrets = SecretsManager.get_value('prod/actionKitApi')
-  database_secrets = SecretsManager.get_value('dev/champaignDB')
-  gocardless_secrets = SecretsManager.get_value('dev/gocardless')
+  database_secrets = SecretsManager.get_value('champaignDB')
+  gocardless_secrets = SecretsManager.get_value('gocardless')
   smtp_secrets = SecretsManager.get_value('prod/smtp')
   twilio_secrets = SecretsManager.get_value('prod/twilio')
-  recaptcha2_secrets = SecretsManager.get_value('dev/recaptchaTwo')
-  recaptcha3_secrets = SecretsManager.get_value('dev/recaptchaThree')
-  braintree_secrets = SecretsManager.get_value('dev/braintree')
-  airbrake_secrets = SecretsManager.get_value('dev/champaignAirbrake')
+  recaptcha2_secrets = SecretsManager.get_value('recaptchaTwo')
+  recaptcha3_secrets = SecretsManager.get_value('recaptchaThree')
+  braintree_secrets = SecretsManager.get_value('braintree')
+  airbrake_secrets = SecretsManager.get_value('champaignAirbrake')
 
   secrets = {
     omniauth_client_secret: omniauth_secrets['secret'],
     omniauth_client_id: omniauth_secrets['clientId'],
     ak_username: ak_secrets['username'],
     ak_password: ak_secrets['password'],
-    share_progress_api_key: SecretsManager.get_value('dev/shareProgressApi')['apiKey'],
+    share_progress_api_key: SecretsManager.get_value('shareProgressApi')['apiKey'],
     mixpanel_token: SecretsManager.get_value('prod/mixpanel')['token'],
-    secret_key_base: SecretsManager.get_value('dev/champaignSecretKeyBase')['secretKeyBase'],
-    api_key: SecretsManager.get_value('dev/champaign')['apiKey'],
-    member_services_secret: SecretsManager.get_value('dev/memberServices')['secret'],
+    secret_key_base: SecretsManager.get_value('champaignSecretKeyBase')['secretKeyBase'],
+    api_key: SecretsManager.get_value('champaign')['apiKey'],
+    member_services_secret: SecretsManager.get_value('memberServices')['secret'],
     database: {
       dbname: database_secrets['dbname'],
       username: database_secrets['username'],
@@ -31,7 +31,10 @@ if Rails.env == 'production' && Settings.aws_secrets_manager_prefix.present?
     },
     gocardless: {
       token: gocardless_secrets['token'],
-      secret: gocardless_secrets['secret']
+      secret: gocardless_secrets['secret'],
+      environment: Settings.gocardless.environment,
+      gbp_charge_day: Settings.gocardless.gbp_charge_day
+
     },
     smtp: {
       user_name: smtp_secrets['username'],
@@ -44,19 +47,22 @@ if Rails.env == 'production' && Settings.aws_secrets_manager_prefix.present?
     calls: {
       targeting_secret: SecretsManager.get_value('prod/callToolTargeting')['secret']
     },
-    devise_secret_key: SecretsManager.get_value('dev/deviseSecret')['secretKey'],
+    devise_secret_key: SecretsManager.get_value('deviseSecret')['secretKey'],
     'recaptcha2' => {
       site_key: recaptcha2_secrets['siteKey'],
       secret_key: recaptcha2_secrets['secretKey']
     },
     'recaptcha3' => {
       site_key: recaptcha3_secrets['siteKey'],
-      secret_key: recaptcha3_secrets['secretKey']
+      secret_key: recaptcha3_secrets['secretKey'],
+      min_score: Settings.recaptcha3.min_score
     },
     braintree: {
       merchant_id: braintree_secrets['merchantId'],
       public_key: braintree_secrets['publicKey'],
-      private_key: braintree_secrets['privateKey']
+      private_key: braintree_secrets['privateKey'],
+      environment: Settings.braintree.environment,
+      merchants: Settings.braintree.merchants
     },
     sentry_dsn: SecretsManager.get_value('prod/sentry')['dsn'],
     airbrake_project_id: airbrake_secrets['projectId'],


### PR DESCRIPTION
### Overview
* Reverted the temp changes used to debug issues with deployment on staging:
    * #1972
    *  #1971
    *  #1970
    *  #1969
    *  #1968
* Fixed an issue with Braintree and GoCardless discovered thanks to cypress on a pronto PR: https://github.com/SumOfUs/pronto/pull/145
    * If we add setting values and then reload the settings if one nested object omits an existing property, it gets unset. 