### PR TITLE
Adds pending action emails for NL lang

### DIFF
--- a/app/views/pending_action_mailer/confirm_action.nl.html.erb
+++ b/app/views/pending_action_mailer/confirm_action.nl.html.erb
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="<%= @page.language_code %>">
+  <head>
+    <title><%= @subject %></title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <style type="text/css">
+      body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
+      table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; }
+      img { -ms-interpolation-mode: bicubic; }
+      img { border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; }
+      table { border-collapse: collapse !important; }
+      body { height: 100% !important; margin: 0 !important; padding: 0 !important; width: 100% !important; }
+      a[x-apple-data-detectors] { color: inherit !important; text-decoration: none !important; font-size: inherit !important; font-family: inherit !important; font-weight: inherit !important; line-height: inherit !important; }
+      u + #body a { color: inherit; text-decoration: none; font-size: inherit; font-family: inherit; font-weight: inherit; line-height: inherit; }
+      #MessageViewBody a { color: inherit; text-decoration: none; font-size: inherit; font-family: inherit; font-weight: inherit; line-height: inherit; }
+    </style>
+  </head>
+  <body style="margin: 0 !important; padding: 0 !important;">
+    <!--[if (gte mso 9)|(IE)]>
+    <table cellspacing="0" cellpadding="0" border="0" width="720" align="center" role="presentation"><tr><td>
+    <![endif]-->
+    <div role="article" aria-label="An email from SumOfUs" lang="<%= @page.language_code %>" style="background-color: white; color: #2b2b2b; font-family: 'Avenir Next', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; font-size: 18px; font-weight: 400; line-height: 28px; margin: 0 auto; max-width: 720px; padding: 40px 20px 40px 20px;">
+        <header>
+            <a href="https://sumofus.org/">
+              <center>
+                <img src="https://s3.amazonaws.com/s3.sumofus.org/images/sou-horizontal-logo-1.png" role="presentation" width="170" height="auto" />
+              </center>
+            </a>
+        </header>
+
+        <br/>
+
+        <main>
+          <div style="background-color: #f1f1f1; border-radius: 4px; padding: 24px 48px;">
+            <!--[if (gte mso 9)|(IE)]>
+            <table cellspacing="0" cellpadding="0" border="0" width="720" align="center" role="presentation"><tr><td style="background-color: f1f1f1; padding: 24px 48px 24px 48px;">
+            <![endif]-->
+            <p>Click here to confirm your signature and make sure you continue to receive e-mails from SumOfUs.</p>
+
+            <a href="<%= confirm_api_action_confirmations_url(token: @token, consented: true)%>" style="text-decoration: underline; margin-left:15px;margin-right:15px;display:block;border-bottom:10px;border:#000;padding-top:10px;padding-bottom:10px;padding-right:10px;padding-left:10px;font-family:Arial,sans-serif;font-size:20px;color:#ffffff;line-height:24px;text-align:center;background-color:#f8492e; border-radius:2px;width:220px;margin-left:auto;margin-right:auto;margin-bottom:0px;font-weight:600;text-decoration:none;">
+              Confirm my signature
+            </a>
+            <p>
+              <center>
+                <a href="<%= confirm_api_action_confirmations_url(token: @token) %>" style="font-size: 14px; color: #333; display: block;">
+                  I would like to sign this petition, but not receive any further e-mails
+                </a>
+              </center>
+            </p>
+            <!--[if (gte mso 9)|(IE)]>
+            </td></tr></table>
+            <![endif]-->
+        </div>
+      </main>
+    </div>
+    <!--[if (gte mso 9)|(IE)]>
+    </td></tr></table>
+    <![endif]-->
+  </body>
+</html>

--- a/app/views/pending_action_mailer/confirm_action.nl.html.erb
+++ b/app/views/pending_action_mailer/confirm_action.nl.html.erb
@@ -37,15 +37,15 @@
             <!--[if (gte mso 9)|(IE)]>
             <table cellspacing="0" cellpadding="0" border="0" width="720" align="center" role="presentation"><tr><td style="background-color: f1f1f1; padding: 24px 48px 24px 48px;">
             <![endif]-->
-            <p>Click here to confirm your signature and make sure you continue to receive e-mails from SumOfUs.</p>
+            <p>Klik hier om je handtekening te bevestigen en om ervoor te zorgen dat je emails van SumOfUs blijft ontvangen.</p>
 
             <a href="<%= confirm_api_action_confirmations_url(token: @token, consented: true)%>" style="text-decoration: underline; margin-left:15px;margin-right:15px;display:block;border-bottom:10px;border:#000;padding-top:10px;padding-bottom:10px;padding-right:10px;padding-left:10px;font-family:Arial,sans-serif;font-size:20px;color:#ffffff;line-height:24px;text-align:center;background-color:#f8492e; border-radius:2px;width:220px;margin-left:auto;margin-right:auto;margin-bottom:0px;font-weight:600;text-decoration:none;">
-              Confirm my signature
+              Mijn handtekening bevestigen
             </a>
             <p>
               <center>
                 <a href="<%= confirm_api_action_confirmations_url(token: @token) %>" style="font-size: 14px; color: #333; display: block;">
-                  I would like to sign this petition, but not receive any further e-mails
+                  Ik wil graag deze petitie ondertekenen, maar geen e-mails meer ontvangen.
                 </a>
               </center>
             </p>

--- a/app/views/pending_action_mailer/confirm_action.nl.text.slim
+++ b/app/views/pending_action_mailer/confirm_action.nl.text.slim
@@ -1,0 +1,3 @@
+| Click here to confirm your signature and make sure you continue to receive e-mails from SumOfUs
+
+= link_to "Validate my signature", confirm_api_action_confirmations_url(token: @token, consented: true)

--- a/app/views/pending_action_mailer/confirm_action.nl.text.slim
+++ b/app/views/pending_action_mailer/confirm_action.nl.text.slim
@@ -1,3 +1,3 @@
-| Click here to confirm your signature and make sure you continue to receive e-mails from SumOfUs
+| Klik hier om je handtekening te bevestigen en om ervoor te zorgen dat je emails van SumOfUs blijft ontvangen.
 
 = link_to "Validate my signature", confirm_api_action_confirmations_url(token: @token, consented: true)

--- a/app/views/pending_action_mailer/reminder.nl.html.slim
+++ b/app/views/pending_action_mailer/reminder.nl.html.slim
@@ -1,0 +1,17 @@
+h3 Hi #{@name.titleize},
+
+p We're happy that you want to support our petition "#{@page.title}". Unfortunately, you haven’t confirmed your signature, yet.
+
+p We'd love to stay in touch with you by email to keep you informed about this and other SumOfUs campaigns (you can unsubscribe at any time). Please click one of the following links:
+
+h3
+ = link_to "I want to sign and receive updates about this and other campaigns", confirm_api_action_confirmations_url(token: @token, consented: true)
+p
+ = link_to "I want to sign but don’t want any updates", confirm_api_action_confirmations_url(token: @token)
+
+p Your signature only counts if you click to confirm!
+
+p
+ | Best regards,
+ br
+ | The team at SumOfUs

--- a/app/views/pending_action_mailer/reminder.nl.html.slim
+++ b/app/views/pending_action_mailer/reminder.nl.html.slim
@@ -1,17 +1,17 @@
-h3 Hi #{@name.titleize},
+h3 Hallo #{@name.titleize},
 
-p We're happy that you want to support our petition "#{@page.title}". Unfortunately, you haven’t confirmed your signature, yet.
+p We zijn heel blij dat je onze petitie "#{@page.title}" wil ondersteunen. Helaas heb je je handtekening nog niet bevestigd.
 
-p We'd love to stay in touch with you by email to keep you informed about this and other SumOfUs campaigns (you can unsubscribe at any time). Please click one of the following links:
+p We blijven graag met je in contact via e-mail, zodat we je op de hoogte kunnen houden van deze en andere SumOfUs campagnes (je kunt je op elk moment uitschrijven). Klik op één van de volgende links:
 
 h3
- = link_to "I want to sign and receive updates about this and other campaigns", confirm_api_action_confirmations_url(token: @token, consented: true)
+ = link_to "Ik wil tekenen en ik ontvang graag updates over deze en andere campagnes", confirm_api_action_confirmations_url(token: @token, consented: true)
 p
- = link_to "I want to sign but don’t want any updates", confirm_api_action_confirmations_url(token: @token)
+ = link_to "Ik wil tekenen maar ik ontvang liever geen updates", confirm_api_action_confirmations_url(token: @token)
 
-p Your signature only counts if you click to confirm!
+p Je handtekening telt alleen als je klikt om hem te bevestigen!
 
 p
- | Best regards,
+ | Met vriendelijke groet,
  br
- | The team at SumOfUs
+ | Het team van SumOfUs

--- a/app/views/pending_action_mailer/reminder.nl.text.slim
+++ b/app/views/pending_action_mailer/reminder.nl.text.slim
@@ -1,0 +1,14 @@
+| Hi #{@name.titleize},
+
+  We're happy that you want to support our petition "#{@page.title}". Unfortunately, you haven’t confirmed your signature, yet.
+
+  We'd love to stay in touch with you by email to keep you informed about this and other SumOfUs campaigns (you can unsubscribe at any time). Please click one of the following links:
+
+= link_to "I want to sign and receive updates about this and other campaigns", confirm_api_action_confirmations_url(token: @token, consented: true)
+
+= link_to "I want to sign but don’t want any updates", confirm_api_action_confirmations_url(token: @token)
+
+| Your signature only counts if you click to confirm!
+
+| Best regards,
+  The team at SumOfUs

--- a/app/views/pending_action_mailer/reminder.nl.text.slim
+++ b/app/views/pending_action_mailer/reminder.nl.text.slim
@@ -1,14 +1,14 @@
-| Hi #{@name.titleize},
+| Hallo #{@name.titleize},
 
-  We're happy that you want to support our petition "#{@page.title}". Unfortunately, you haven’t confirmed your signature, yet.
+  We zijn heel blij dat je onze petitie "#{@page.title}" wil ondersteunen. Helaas heb je je handtekening nog niet bevestigd.
 
-  We'd love to stay in touch with you by email to keep you informed about this and other SumOfUs campaigns (you can unsubscribe at any time). Please click one of the following links:
+  We blijven graag met je in contact via e-mail, zodat we je op de hoogte kunnen houden van deze en andere SumOfUs campagnes (je kunt je op elk moment uitschrijven). Klik op één van de volgende links:
 
-= link_to "I want to sign and receive updates about this and other campaigns", confirm_api_action_confirmations_url(token: @token, consented: true)
+= link_to "Ik wil tekenen en ik ontvang graag updates over deze en andere campagnes", confirm_api_action_confirmations_url(token: @token, consented: true)
 
-= link_to "I want to sign but don’t want any updates", confirm_api_action_confirmations_url(token: @token)
+= link_to "Ik wil tekenen maar ik ontvang liever geen updates", confirm_api_action_confirmations_url(token: @token)
 
-| Your signature only counts if you click to confirm!
+| Je handtekening telt alleen als je klikt om hem te bevestigen!
 
-| Best regards,
-  The team at SumOfUs
+| Met vriendelijke groet,
+  Het team van SumOfUs


### PR DESCRIPTION
## Overview

### Ticket

[Dutch petition can't be signed if the country field is "Duitsland" (Germany)](https://app.asana.com/0/1119304937718815/1202381186106512/f)

Champaign fails to submit a petition if I try to sign a petition with "Duitsland" selected from the "Land" country list.

### Issue

- Initial observations revealed that it didn't happen for all the members, there was a specific pattern with the user's email address.
- When debugged further it was revealed that the confirm action email service was broken & it was causing the error
- Once an action is detected we will check if it's a Double OptIn country & if that's the case then a double optin email is triggered. Here the email template for the NL language was not available & has caused the issue. 

### Solution

- Added the NL language templates for _confirm signature_ email &  _remind confirm signature_ email