### PR TITLE
Adds tracking pixels for FB, Instagram & tiktok for a specific campaign

### DIFF
--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -15,6 +15,10 @@ html lang="#{@page.language.try(:code).try(:downcase)}" dir=("#{@page.language.t
     = favicon_link_tag "org-favicon.ico"
     = metamagic
 
+    / This piece of code is added to run ads via ad agency only for the specified campaign, to be discarded once the ad ends
+    - if "#{@page.slug}" == "email-your-mp-no-special-treatment-in-the-online-safety-bill"
+      = render partial: "shared/ad_agency_pixel"
+
     = javascript_include_tag "https://www.googleoptimize.com/optimize.js?id=#{Settings.google_optimize.key}"
     = javascript_include_tag 'https://code.jquery.com/jquery-2.2.4.min.js'
     = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/jquery-ujs/1.2.2/rails.min.js'
@@ -39,7 +43,6 @@ html lang="#{@page.language.try(:code).try(:downcase)}" dir=("#{@page.language.t
     .mobile-indicator
 
     = render partial: "shared/facebook_pixel" unless Rails.env.testing?
-    = render partial: "shared/tiktok_pixel"
 
     = javascript_packs_with_chunks_tag "globals", "member_facing", "plugins"
 

--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -39,6 +39,7 @@ html lang="#{@page.language.try(:code).try(:downcase)}" dir=("#{@page.language.t
     .mobile-indicator
 
     = render partial: "shared/facebook_pixel" unless Rails.env.testing?
+    = render partial: "shared/tiktok_pixel"
 
     = javascript_packs_with_chunks_tag "globals", "member_facing", "plugins"
 

--- a/app/views/shared/_ad_agency_pixel.slim
+++ b/app/views/shared/_ad_agency_pixel.slim
@@ -5,3 +5,15 @@ javascript:
     ttq.load('CATDAOBC77U1K6S9KRAG');
     ttq.page();
   }(window, document, 'ttq');
+
+  !function(f,b,e,v,n,t,s){
+    if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)
+  }(window, document,'script', 'https://connect.facebook.net/en_US/fbevents.js');
+
+  fbq('init', '1437790973016616');
+  fbq('track', 'PageView');

--- a/app/views/shared/_tiktok_pixel.slim
+++ b/app/views/shared/_tiktok_pixel.slim
@@ -1,0 +1,7 @@
+javascript:
+  !function (w, d, t) {
+    w.TiktokAnalyticsObject=t;var ttq=w[t]=w[t]||[];ttq.methods=["page","track","identify","instances","debug","on","off","once","ready","alias","group","enableCookie","disableCookie"],ttq.setAndDefer=function(t,e){t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}};for(var i=0;i<ttq.methods.length;i++)ttq.setAndDefer(ttq,ttq.methods[i]);ttq.instance=function(t){for(var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e},ttq.load=function(e,n){var i="https://analytics.tiktok.com/i18n/pixel/events.js";ttq._i=ttq._i||{},ttq._i[e]=[],ttq._i[e]._u=i,ttq._t=ttq._t||{},ttq._t[e]=+new Date,ttq._o=ttq._o||{},ttq._o[e]=n||{};var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src=i+"?sdkid="+e+"&lib="+t;var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(o,a)};
+
+    ttq.load('CATDAOBC77U1K6S9KRAG');
+    ttq.page();
+  }(window, document, 'ttq');

--- a/vendor/theme/templates/layouts/email-members-of-united-kingdom-parliament.liquid
+++ b/vendor/theme/templates/layouts/email-members-of-united-kingdom-parliament.liquid
@@ -22,26 +22,3 @@
 </main>
 
 {% include 'Simple Footer' %}
-
-
- <!-- Meta Pixel Code -->
-<script>
-  !function(f,b,e,v,n,t,s)
-  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-  n.queue=[];t=b.createElement(e);t.async=!0;
-  t.src=v;s=b.getElementsByTagName(e)[0];
-  s.parentNode.insertBefore(t,s)}(window, document,'script',
-  'https://connect.facebook.net/en_US/fbevents.js');
-  fbq('init', '1437790973016616');
-  fbq('track', 'PageView');
-</script>
-<noscript>
-  <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=1437790973016616&ev=PageView&noscript=1"/>
-</noscript>
-<!-- End Meta Pixel Code -->
-
-<!-- Tiktok tracking code -->
-
-<!-- End Tiktok tracking code -->

--- a/vendor/theme/templates/layouts/email-members-of-united-kingdom-parliament.liquid
+++ b/vendor/theme/templates/layouts/email-members-of-united-kingdom-parliament.liquid
@@ -43,12 +43,5 @@
 <!-- End Meta Pixel Code -->
 
 <!-- Tiktok tracking code -->
-<script>
-!function (w, d, t) {
-  w.TiktokAnalyticsObject=t;var ttq=w[t]=w[t]||[];ttq.methods=["page","track","identify","instances","debug","on","off","once","ready","alias","group","enableCookie","disableCookie"],ttq.setAndDefer=function(t,e){t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}};for(var i=0;i<ttq.methods.length;i++)ttq.setAndDefer(ttq,ttq.methods[i]);ttq.instance=function(t){for(var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e},ttq.load=function(e,n){var i="https://analytics.tiktok.com/i18n/pixel/events.js";ttq._i=ttq._i||{},ttq._i[e]=[],ttq._i[e]._u=i,ttq._t=ttq._t||{},ttq._t[e]=+new Date,ttq._o=ttq._o||{},ttq._o[e]=n||{};var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src=i+"?sdkid="+e+"&lib="+t;var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(o,a)};
 
-  ttq.load('CATDAOBC77U1K6S9KRAG');
-  ttq.page();
-}(window, document, 'ttq');
-</script>
 <!-- End Tiktok tracking code -->

--- a/vendor/theme/templates/layouts/email-members-of-united-kingdom-parliament.liquid
+++ b/vendor/theme/templates/layouts/email-members-of-united-kingdom-parliament.liquid
@@ -23,3 +23,32 @@
 
 {% include 'Simple Footer' %}
 
+
+ <!-- Meta Pixel Code -->
+<script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '1437790973016616');
+  fbq('track', 'PageView');
+</script>
+<noscript>
+  <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=1437790973016616&ev=PageView&noscript=1"/>
+</noscript>
+<!-- End Meta Pixel Code -->
+
+<!-- Tiktok tracking code -->
+<script>
+!function (w, d, t) {
+  w.TiktokAnalyticsObject=t;var ttq=w[t]=w[t]||[];ttq.methods=["page","track","identify","instances","debug","on","off","once","ready","alias","group","enableCookie","disableCookie"],ttq.setAndDefer=function(t,e){t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}};for(var i=0;i<ttq.methods.length;i++)ttq.setAndDefer(ttq,ttq.methods[i]);ttq.instance=function(t){for(var e=ttq._i[t]||[],n=0;n<ttq.methods.length;n++)ttq.setAndDefer(e,ttq.methods[n]);return e},ttq.load=function(e,n){var i="https://analytics.tiktok.com/i18n/pixel/events.js";ttq._i=ttq._i||{},ttq._i[e]=[],ttq._i[e]._u=i,ttq._t=ttq._t||{},ttq._t[e]=+new Date,ttq._o=ttq._o||{},ttq._o[e]=n||{};var o=document.createElement("script");o.type="text/javascript",o.async=!0,o.src=i+"?sdkid="+e+"&lib="+t;var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(o,a)};
+
+  ttq.load('CATDAOBC77U1K6S9KRAG');
+  ttq.page();
+}(window, document, 'ttq');
+</script>
+<!-- End Tiktok tracking code -->


### PR DESCRIPTION
## Overview

To add new pixels for FB, Instagram & Tiktok for an Email MP campaign - [Email your MP: say no to a two-tier internet](https://actions.sumofus.org/a/email-your-mp-no-special-treatment-in-the-online-safety-bill/). This is for an external ad agency.

### Ticket
[Tracking pixel for email MP tool campaign](https://app.asana.com/0/1119304937718815/1202508133592193/f)


### Test

[Email your MP: say no to a two-tier internet](https://feature.sumofus.org/a/email-your-mp-no-special-treatment-in-the-online-safety-bill/)

Facebook Pixel
<img width="395" alt="Screenshot 2022-06-29 at 4 08 07 PM" src="https://user-images.githubusercontent.com/49471498/176417066-ccf30054-1a34-4db8-8ac9-bb0b60d762c8.png">


Tiktok Pixel
<img width="401" alt="Screenshot 2022-06-29 at 4 06 30 PM" src="https://user-images.githubusercontent.com/49471498/176416781-49affac6-075d-4f03-9209-3933a0d1e47b.png">


### Follow Up
To remove the pixels once the experiment is completed

