### PR TITLE
Disable throttling on staging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,7 +116,7 @@ Rails.application.configure do
              port: Settings.cache.port, drive: :hiredis }
   }
 
-  config.middleware.use Rack::Attack
+  config.middleware.use Rack::Attack unless Settings.aws_secrets_manager_prefix == "dev"
 
   # In production, we only accept CORS request from sumofus.org or its subdomains.
   config.middleware.insert_before 0, Rack::Cors, logger: (-> { Rails.logger }) do


### PR DESCRIPTION
### Overview
We are being throttled on staging and this is causing our cypress tests to fail.
Disabled throttling on staging to avoid issues with cypress.

### Notes
When we enable cypress tests on production, we might need to do follow-up work on this.
In production, we don't want to disable the throttling, but we don't want to have it running on our own e2e tests, so we might need to implement some logic to make it work.