### PR TITLE
Adding consent component to email tool

### DIFF
--- a/app/javascript/plugins/email_pension/EmailPensionView.js
+++ b/app/javascript/plugins/email_pension/EmailPensionView.js
@@ -253,18 +253,6 @@ class EmailPensionView extends Component {
             </div>
 
             <div className="EmailToolView-note">
-              {/* <div>
-                <Button
-                  className="button"
-                  onClick={() => window.open(this.generateMailToLink())}
-                >
-                  <FormattedMessage
-                    id="email_tool.form.send_email"
-                    defaultMessage="Send with your email client"
-                  />
-                </Button>
-              </div> */}
-
               <div className="section title">
                 <FormattedMessage
                   id="email_tool.form.choose_email_service"
@@ -456,7 +444,6 @@ class EmailPensionView extends Component {
               >
                 {this.state.emailService === 'other_email_services' ? (
                   <FormattedMessage
-                    // id="email_tool.form.submit_action"
                     id="email_tool.form.submit"
                     defaultMessage="Submit Action"
                   />

--- a/app/javascript/plugins/email_tool/EmailToolView.js
+++ b/app/javascript/plugins/email_tool/EmailToolView.js
@@ -78,7 +78,10 @@ export class EmailToolView extends Component {
   validateForm() {
     const errors = {};
     // For GDPR countries alone this field should have value
-    if (this.props.isRequiredNew && this.props.consented === null) {
+    if (
+      this.props.isRequiredNew &&
+      (this.props.consented === null || this.props.consentRequired)
+    ) {
       this.props.setShowConsentRequired(true);
       errors['consented'] = true;
     }

--- a/app/javascript/plugins/email_tool/EmailToolView.js
+++ b/app/javascript/plugins/email_tool/EmailToolView.js
@@ -79,7 +79,7 @@ export class EmailToolView extends Component {
     const errors = {};
     // For GDPR countries alone this field should have value
     if (this.props.isRequiredNew && this.props.consented === null) {
-      this.props.showConsentRequired(true);
+      this.props.setShowConsentRequired(true);
       errors['consented'] = true;
     }
     this.setState({ errors: errors });
@@ -164,7 +164,12 @@ export class EmailToolView extends Component {
 
   onNameChange = name => this.setState({ name });
 
-  onEmailChange = email => this.setState({ email });
+  onEmailChange = email => {
+    if (this.props.isRequiredNew) {
+      this.props.setShowConsentRequired(true);
+    }
+    this.setState({ email });
+  };
 
   onEmailServiceChange = emailService => this.setState({ emailService });
 
@@ -430,9 +435,14 @@ export class EmailToolView extends Component {
             <ConsentComponent
               alwaysShow={true}
               isRequired={
-                this.props.isRequiredNew || this.props.isRequiredExisting
+                this.props.isRequiredNew ||
+                this.props.isRequiredExisting ||
+                this.props.consentRequired
               }
             />
+            <span>{`isRequiredNew: ${this.props.isRequiredNew}`}</span>
+            <span>{`isRequiredExisting: ${this.props.isRequiredExisting}`}</span>
+            <span>{`showConsentRequired: ${this.props.consentRequired}`}</span>
             <FormGroup>
               <Button
                 disabled={this.state.isSubmitting || !this.state.emailService}
@@ -460,16 +470,22 @@ export class EmailToolView extends Component {
 }
 
 export const mapStateToProps = ({ consent }) => {
-  const { consented, isRequiredNew, isRequiredExisting } = consent;
+  const {
+    consented,
+    isRequiredNew,
+    isRequiredExisting,
+    showConsentRequired: consentRequired,
+  } = consent;
   return {
     consented,
     isRequiredNew,
     isRequiredExisting,
+    consentRequired,
   };
 };
 
 export const mapDispatchToProps = dispatch => ({
-  showConsentRequired: consentRequired =>
+  setShowConsentRequired: consentRequired =>
     dispatch(showConsentRequired(consentRequired)),
 });
 

--- a/app/javascript/plugins/email_tool/EmailToolView.js
+++ b/app/javascript/plugins/email_tool/EmailToolView.js
@@ -78,10 +78,7 @@ export class EmailToolView extends Component {
   validateForm() {
     const errors = {};
     // For GDPR countries alone this field should have value
-    if (
-      this.props.isRequiredNew &&
-      (this.props.consented === null || this.props.consentRequired)
-    ) {
+    if (this.props.isRequiredNew && this.props.consented === null) {
       this.props.setShowConsentRequired(true);
       errors['consented'] = true;
     }
@@ -167,12 +164,7 @@ export class EmailToolView extends Component {
 
   onNameChange = name => this.setState({ name });
 
-  onEmailChange = email => {
-    if (this.props.isRequiredNew) {
-      this.props.setShowConsentRequired(true);
-    }
-    this.setState({ email });
-  };
+  onEmailChange = email => this.setState({ email });
 
   onEmailServiceChange = emailService => this.setState({ emailService });
 
@@ -438,9 +430,7 @@ export class EmailToolView extends Component {
             <ConsentComponent
               alwaysShow={true}
               isRequired={
-                this.props.isRequiredNew ||
-                this.props.isRequiredExisting ||
-                this.props.consentRequired
+                this.props.isRequiredNew || this.props.isRequiredExisting
               }
             />
             <FormGroup>
@@ -470,17 +460,11 @@ export class EmailToolView extends Component {
 }
 
 export const mapStateToProps = ({ consent }) => {
-  const {
-    consented,
-    isRequiredNew,
-    isRequiredExisting,
-    showConsentRequired: consentRequired,
-  } = consent;
+  const { consented, isRequiredNew, isRequiredExisting } = consent;
   return {
     consented,
     isRequiredNew,
     isRequiredExisting,
-    consentRequired,
   };
 };
 

--- a/app/javascript/plugins/email_tool/EmailToolView.js
+++ b/app/javascript/plugins/email_tool/EmailToolView.js
@@ -440,9 +440,6 @@ export class EmailToolView extends Component {
                 this.props.consentRequired
               }
             />
-            <span>{`isRequiredNew: ${this.props.isRequiredNew}`}</span>
-            <span>{`isRequiredExisting: ${this.props.isRequiredExisting}`}</span>
-            <span>{`showConsentRequired: ${this.props.consentRequired}`}</span>
             <FormGroup>
               <Button
                 disabled={this.state.isSubmitting || !this.state.emailService}

--- a/app/javascript/plugins/email_tool/EmailToolView.js
+++ b/app/javascript/plugins/email_tool/EmailToolView.js
@@ -1,11 +1,14 @@
 import React, { Component } from 'react';
-import { compact, get, join, sample, forEach, template } from 'lodash';
+import { connect } from 'react-redux';
+import { compact, get, join, sample, isEmpty } from 'lodash';
 import Select from '../../components/SweetSelect/SweetSelect';
 import Input from '../../components/SweetInput/SweetInput';
 import Button from '../../components/Button/Button';
 import FormGroup from '../../components/Form/FormGroup';
 import EmailEditor from '../../components/EmailEditor/EmailEditor';
 import ErrorMessages from '../../components/ErrorMessages';
+import ConsentComponent from '../../components/consent/ConsentComponent';
+import { showConsentRequired } from '../../state/consent/index';
 import { FormattedMessage } from 'react-intl';
 import './EmailToolView.scss';
 import { MailerClient } from '../../util/ChampaignClient';
@@ -25,7 +28,7 @@ function emailTargetAsSelectOption(target) {
   };
 }
 
-export default class EmailToolView extends Component {
+export class EmailToolView extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -55,6 +58,7 @@ export default class EmailToolView extends Component {
   payload() {
     return {
       page_id: this.props.pageId,
+      consented: this.props.consented ? 1 : 0,
       email: {
         body: this.state.body,
         subject: this.state.subject,
@@ -69,6 +73,17 @@ export default class EmailToolView extends Component {
         ...this.props.trackingParams,
       },
     };
+  }
+
+  validateForm() {
+    const errors = {};
+    // For GDPR countries alone this field should have value
+    if (this.props.isRequiredNew && this.props.consented === null) {
+      this.props.showConsentRequired(true);
+      errors['consented'] = true;
+    }
+    this.setState({ errors: errors });
+    return isEmpty(errors);
   }
 
   // Event Handlers
@@ -120,6 +135,9 @@ export default class EmailToolView extends Component {
 
   onSubmit = e => {
     e.preventDefault();
+    const valid = this.validateForm();
+
+    if (!valid) return;
     this.handleSendEmail();
     this.setState(s => ({ ...s, isSubmitting: true, errors: {} }));
     MailerClient.sendEmail(this.payload()).then(
@@ -231,18 +249,6 @@ export default class EmailToolView extends Component {
             </div>
 
             <div className="EmailToolView-note">
-              {/* <div>
-                <Button
-                  className="button"
-                  onClick={() => window.open(this.generateMailToLink())}
-                >
-                  <FormattedMessage
-                    id="email_tool.form.send_email"
-                    defaultMessage="Send with your email client"
-                  />
-                </Button>
-              </div> */}
-
               <div className="section title">
                 <FormattedMessage
                   id="email_tool.form.choose_email_service"
@@ -421,7 +427,12 @@ export default class EmailToolView extends Component {
                 </React.Fragment>
               )}
             </div>
-
+            <ConsentComponent
+              alwaysShow={true}
+              isRequired={
+                this.props.isRequiredNew || this.props.isRequiredExisting
+              }
+            />
             <FormGroup>
               <Button
                 disabled={this.state.isSubmitting || !this.state.emailService}
@@ -430,13 +441,11 @@ export default class EmailToolView extends Component {
               >
                 {this.state.emailService === 'other_email_services' ? (
                   <FormattedMessage
-                    // id="email_tool.form.submit_action"
                     id="email_tool.form.submit"
                     defaultMessage="Submit Action"
                   />
                 ) : (
                   <FormattedMessage
-                    // id="email_tool.form.submit_action"
                     id="email_tool.form.submit_and_send_email"
                     defaultMessage="Submit Action &amp; Send Email"
                   />
@@ -449,3 +458,19 @@ export default class EmailToolView extends Component {
     );
   }
 }
+
+export const mapStateToProps = ({ consent }) => {
+  const { consented, isRequiredNew, isRequiredExisting } = consent;
+  return {
+    consented,
+    isRequiredNew,
+    isRequiredExisting,
+  };
+};
+
+export const mapDispatchToProps = dispatch => ({
+  showConsentRequired: consentRequired =>
+    dispatch(showConsentRequired(consentRequired)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(EmailToolView);

--- a/app/services/unsafe_email_sender.rb
+++ b/app/services/unsafe_email_sender.rb
@@ -33,7 +33,7 @@ class UnsafeEmailSender
         email: @params[:from_email],
         action_targets: @params[:recipients],
         country: @params[:country],
-        consented: @params[:consented] || false,
+        consented: @params[:consented],
         email_service: @params[:email_service],
         clicked_copy_body_button: @params[:clicked_copy_body_button]
       }.merge(@tracking_params)

--- a/app/services/unsafe_email_sender.rb
+++ b/app/services/unsafe_email_sender.rb
@@ -33,7 +33,7 @@ class UnsafeEmailSender
         email: @params[:from_email],
         action_targets: @params[:recipients],
         country: @params[:country],
-        consented: @params[:consented] || true,
+        consented: @params[:consented] || false,
         email_service: @params[:email_service],
         clicked_copy_body_button: @params[:clicked_copy_body_button]
       }.merge(@tracking_params)

--- a/app/services/unsafe_email_sender.rb
+++ b/app/services/unsafe_email_sender.rb
@@ -5,7 +5,6 @@ class UnsafeEmailSender
     @plugin = Plugins::Email.find_by(page_id: page_id)
     @page = Page.find(page_id)
     @params = email_params.to_hash.with_indifferent_access
-    # @recipients = recipients.to_hash.with_indifferent_access
     @tracking_params = tracking_params.to_hash.with_indifferent_access.slice(
       :akid, :referring_akid, :referrer_id, :rid, :source, :action_mobile
     )
@@ -26,25 +25,7 @@ class UnsafeEmailSender
     errors.empty?
   end
 
-  # def send_email
-  #   EmailSender.run(
-  #     id: @page.slug,
-  #     recipients: to_emails,
-  #     from_name: @params[:from_name],
-  #     from_email: from_email,
-  #     reply_to: reply_to_emails,
-  #     subject: @params[:subject],
-  #     body: @params[:body]
-  #   )
-  # end
-
-  def existing_member
-    @existing_member ||= Member.find_by_email(@params[:from_email])
-  end
-
   def create_action
-    # TODO: Not handling consent.
-    # No new members for EEA countries
     @action = ManageAction.create(
       {
         page_id: @page.id,
@@ -52,10 +33,7 @@ class UnsafeEmailSender
         email: @params[:from_email],
         action_targets: @params[:recipients],
         country: @params[:country],
-        # TODO: Update UI to support consent selection
-        # consented: @params[:consented] || true,
-
-        consented: existing_member ? existing_member.consented? : false,
+        consented: @params[:consented] || true,
         email_service: @params[:email_service],
         clicked_copy_body_button: @params[:clicked_copy_body_button]
       }.merge(@tracking_params)


### PR DESCRIPTION
### Overview
* Added the consent component to the email tool so the members can opt-in/out.
    * Defaulted to false in case this same email sender is used somewhere else where we haven't added the consent UI yet 

### Ticket
https://app.asana.com/0/1119304937718815/1202585536107850/f

### Notes
This PR needs to include `Plugin:EmailTool` as part of the following condition, so double opt-in works for the email tool too:
https://github.com/SumOfUs/Champaign/blob/development/app/services/manage_action.rb#L135

### Screenshots
![Screen Shot 2022-07-13 at 17 35 32](https://user-images.githubusercontent.com/15176901/178855622-fe7f42d7-b1ec-4f12-bed8-8b3ce0ac380c.png)

![Screen Shot 2022-07-13 at 17 35 41](https://user-images.githubusercontent.com/15176901/178855629-d061f2f0-a889-4755-8968-1ff9b49f3efe.png)

