### PR TITLE
Email tool redirections on double optin workflow

### DIFF
--- a/app/controllers/api/emails_controller.rb
+++ b/app/controllers/api/emails_controller.rb
@@ -45,15 +45,13 @@ class Api::EmailsController < ApplicationController
       }, status: :ok
       return
     end
-    write_member_cookie(@action.member_id) if @action.member_id
 
-    respond_to do |format|
-      format.html do
-        page
-        render template: 'api/emails/create_pension_email.js.erb', content_type: 'text/javascript'
-      end
-      format.js
-    end
+    write_member_cookie(@action.member_id) if @action.member_id
+    render json: {
+      success: true,
+      tracking: FacebookPixel.completed_registration_hash(page: page, action: @action),
+      follow_up_page: PageFollower.new_from_page(page).follow_up_path
+    }, status: :ok
   end
 
   private

--- a/app/javascript/plugins/email_pension/EmailPensionView.js
+++ b/app/javascript/plugins/email_pension/EmailPensionView.js
@@ -32,6 +32,8 @@ import {
   composeEmailLink,
   buildToEmailForCompose,
 } from '../../util/util';
+import { MailerClient } from '../../util/ChampaignClient';
+import URI from 'urijs';
 
 class EmailPensionView extends Component {
   constructor(props) {
@@ -185,8 +187,14 @@ class EmailPensionView extends Component {
     merge(payload, this.props.formValues);
     this.props.changeSubmitting(true);
 
-    // FIXME Handle errors
-    $.post(`/api/pages/${this.props.pageId}/pension_emails`, payload);
+    MailerClient.sendPensionEmail({ page_id: this.props.pageId, payload }).then(
+      response => {
+        window.location.href = URI(`${response.data.follow_up_page}`);
+      },
+      ({ errors }) => {
+        this.setState(s => ({ ...s, errors }));
+      }
+    );
   };
 
   onEmailServiceChange = emailService => this.setState({ emailService });

--- a/app/javascript/plugins/email_pension/EmailRepresentativeView.js
+++ b/app/javascript/plugins/email_pension/EmailRepresentativeView.js
@@ -9,6 +9,7 @@ import SelectTarget from './SelectTarget';
 import SelectCountry from '../../components/SelectCountry/SelectCountry';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import './EmailPensionView.scss';
+import { MailerClient } from '../../util/ChampaignClient';
 
 class EmailRepresentativeView extends Component {
   constructor(props) {
@@ -111,10 +112,12 @@ class EmailRepresentativeView extends Component {
     merge(payload, this.props.formValues);
     this.setState({ isSubmitting: true });
 
-    // FIXME Handle errors
-    $.post(`/api/pages/${this.props.pageId}/pension_emails`, payload).fail(
-      e => {
-        console.log('Unable to send email', e);
+    MailerClient.sendPensionEmail({ page_id: this.props.pageId, payload }).then(
+      response => {
+        window.location.href = URI(`${response.data.follow_up_page}`);
+      },
+      ({ errors }) => {
+        this.setState(s => ({ ...s, errors }));
       }
     );
   };

--- a/app/javascript/plugins/email_tool/EmailToolView.js
+++ b/app/javascript/plugins/email_tool/EmailToolView.js
@@ -146,10 +146,10 @@ export class EmailToolView extends Component {
     this.handleSendEmail();
     this.setState(s => ({ ...s, isSubmitting: true, errors: {} }));
     MailerClient.sendEmail(this.payload()).then(
-      () => {
+      response => {
         this.setState(s => ({ ...s, isSubmitting: false }));
         if (typeof this.props.onSuccess === 'function' && this.state.target) {
-          this.props.onSuccess(this.state.target);
+          this.props.onSuccess(this.state.target, response.data);
         }
       },
       ({ errors }) => {

--- a/app/javascript/plugins/email_tool/index.tsx
+++ b/app/javascript/plugins/email_tool/index.tsx
@@ -41,12 +41,16 @@ export const init = options => {
     ...memberData,
     trackingParams,
     country: memberData.country || personalization.location.country,
-    onSuccess(target) {
+    onSuccess(target, response) {
+      const searchParams: any = {
+        'target[name]': target.name,
+        'target[title]': target.title,
+      };
+      if (response?.double_opt_in) {
+        searchParams.double_opt_in = 'true';
+      }
       window.location.href = URI(`${window.location.pathname}/follow-up`)
-        .addSearch({
-          'target[name]': target.name,
-          'target[title]': target.title,
-        })
+        .addSearch(searchParams)
         .toString();
     },
   };

--- a/app/javascript/util/ChampaignClient/Base.js
+++ b/app/javascript/util/ChampaignClient/Base.js
@@ -7,7 +7,7 @@ export const parseResponse = response => {
     case 200:
     case 201:
     case 204:
-      return { success: true, errors: {} };
+      return { success: true, errors: {}, data: response.responseJSON };
     case 422:
     case 403:
       return {

--- a/app/javascript/util/ChampaignClient/MailerClient.js
+++ b/app/javascript/util/ChampaignClient/MailerClient.js
@@ -25,6 +25,31 @@ export function sendEmail(params) {
   });
 }
 
+export function sendPensionEmail(params) {
+  const { page_id, payload } = params;
+
+  return new Promise((resolve, reject) => {
+    $.post(`/api/pages/${page_id}/pension_emails`, payload)
+      .done((data, textStatus, jqXHR) => {
+        // Facebook pixel tracking
+        const tracking = data.tracking;
+        if (tracking) {
+          if (typeof window.fbq === 'function') {
+            if (tracking.user_id) {
+              window.fbq('track', 'CompleteRegistration', tracking);
+            }
+          }
+        }
+        // end of pixel tracking
+        resolve(parseResponse(jqXHR));
+      })
+      .fail((jqXHR, textStatus, errorThrown) => {
+        reject(parseResponse(jqXHR));
+      });
+  });
+}
+
 export default {
   sendEmail,
+  sendPensionEmail,
 };


### PR DESCRIPTION
Work involved:

The work at #2005 was meant to handle redirection to the follow-up page with the double-optin flag. However, when tested on STG, I found that the redirection didn't happen as expected. When debugged further the reason for that was we weren't making use of the JSON response from the API endpoint. I have fixed that in this PR.

Also for the EmailPension component, I have updated the code to send JSON response based on which the redirection happens