### PR TITLE
Extend pronto supported templates for donations experiment

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,6 +13,7 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   before_action :localize, only: %i[show follow_up double_opt_in_notice]
   before_action :record_tracking, only: %i[show]
   before_action :redirect_to_experiment, only: [:show]
+  before_action :redirect_to_donations_experiment, only: [:show]
 
   def index
     @pages = Search::PageSearcher.search(search_params)
@@ -208,6 +209,18 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   def redirect_to_experiment
     return unless @page.published?
     return unless @page.language_code
+    return if user_signed_in?
+
+    path_match = %r{^/a/}
+    if request.path.match(path_match) && @page.has_pronto_inclusion_template?
+      redirect_to request.fullpath.gsub(path_match, "/#{@page.language_code}/a/")
+    end
+  end
+
+  def redirect_to_donations_experiment
+    return unless @page.published?
+    return unless @page.language_code
+    return unless @page.donation_page?
     return if user_signed_in?
 
     path_match = %r{^/a/}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,7 +12,6 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   before_action :redirect_unless_published, only: %i[show follow_up]
   before_action :localize, only: %i[show follow_up double_opt_in_notice]
   before_action :record_tracking, only: %i[show]
-  before_action :redirect_to_experiment, only: [:show]
   before_action :redirect_to_donations_experiment, only: [:show]
 
   def index
@@ -204,17 +203,6 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
 
   def localize
     set_locale(@page.language_code)
-  end
-
-  def redirect_to_experiment
-    return unless @page.published?
-    return unless @page.language_code
-    return if user_signed_in?
-
-    path_match = %r{^/a/}
-    if request.path.match(path_match) && @page.has_pronto_inclusion_template?
-      redirect_to request.fullpath.gsub(path_match, "/#{@page.language_code}/a/")
-    end
   end
 
   def redirect_to_donations_experiment

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -61,7 +61,7 @@ class Page < ApplicationRecord # rubocop:disable Metrics/ClassLength
   extend FriendlyId
   has_paper_trail
 
-  PRONTO_TEMPLATES = ['Default: Petition And Scroll To Share Greenpeace'].freeze
+  PRONTO_TEMPLATES = ['Default: Petition And Scroll To Share Greenpeace', 'Fundraiser With Title Below Image'].freeze
 
   enum follow_up_plan: %i[with_liquid with_page] # TODO: - :with_link
   enum publish_status: %i[published unpublished archived]

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -216,7 +216,7 @@ class Page < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # the page is considered as petition page.
   # FIXME: This method is *not* reliable and intermittently tests
   def donation_page?
-    plugins.first.is_a?(Plugins::Fundraiser) || false
+    plugins&.first.is_a?(Plugins::Fundraiser) || false
   end
 
   def set_ak_slug

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -216,7 +216,7 @@ class Page < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # the page is considered as petition page.
   # FIXME: This method is *not* reliable and intermittently tests
   def donation_page?
-    plugins.first.is_a?(Plugins::Fundraiser)
+    plugins.first.is_a?(Plugins::Fundraiser) || false
   end
 
   def set_ak_slug

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module Champaign
 
     config.i18n.available_locales = %i[en fr de es pt nl ar]
     config.i18n.enforce_available_locales = true
+    config.middleware.use Pronto
   end
 end
 

--- a/lib/middleware/pronto.rb
+++ b/lib/middleware/pronto.rb
@@ -8,6 +8,18 @@ class Pronto
     end
   end
 
+  class TemplateMatcher
+    PRONTO_TEMPLATES = ['Default: Petition And Scroll To Share Greenpeace'].freeze
+
+    def self.has_pronto_inclusion_template(liquid_layout_id)
+      layout ||= LiquidLayout.find(liquid_layout_id)
+      PRONTO_TEMPLATES.include?(layout&.title.to_s)
+    rescue StandardError => e
+      puts "Error trying to get liquid_layout with id #{liquid_layout_id} from pronto middleware - error: #{e.message}."
+      false
+    end
+  end
+
   def initialize(app)
     @app = app
   end
@@ -21,7 +33,7 @@ class Pronto
     if path_match
       page = Page.find_by(slug: path_match)
 
-      if page&.language_code == 'en' && page&.petition_page?
+      if page&.petition_page? && TemplateMatcher.has_pronto_inclusion_template(page&.liquid_layout_id)
         location = "#{Settings.pronto.domain}/#{req.fullpath}"
         return [301, { 'Location' => location, 'Content-Type' => 'text/html', 'Content-Length' => '0' }, []]
       end

--- a/lib/middleware/pronto.rb
+++ b/lib/middleware/pronto.rb
@@ -9,7 +9,7 @@ class Pronto
   end
 
   class TemplateMatcher
-    PRONTO_TEMPLATES = ['Default: Petition And Scroll To Share Greenpeace'].freeze
+    PRONTO_TEMPLATES = ['Default: Petition And Scroll To Share Greenpeace', 'Fundraiser With Title Below Image'].freeze
 
     def self.has_pronto_inclusion_template(liquid_layout_id)
       layout ||= LiquidLayout.find(liquid_layout_id)

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -146,6 +146,7 @@ describe PagesController do
     it 'does not redirect to homepage if user not logged in and page published' do
       allow(controller).to receive(:user_signed_in?) { false }
       allow(page).to receive(:published?) { true }
+      allow(page).to receive(:donation_page?) { false }
       expect(subject).not_to be_redirect
     end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -214,7 +214,7 @@ describe PagesController do
 
     context 'on pages with localization' do
       let(:french_page) do
-        instance_double(Page, valid?: true, pronto: false, published?: true, language_code: language.code, id: '42', liquid_layout: '5')
+        instance_double(Page, valid?: true, pronto: false, published?: true, language_code: language.code, id: '42', liquid_layout: '5', donation_page: false)
       end
       let(:english_page) do
         instance_double(Page, valid?: true, pronto: false, published?: true, language_code: default_language.code, id: '66', liquid_layout: '5')

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -6,7 +6,10 @@ describe PagesController do
   let(:user) { instance_double('User', id: '1') }
   let(:default_language) { instance_double(Language, code: :en) }
   let(:language) { instance_double(Language, code: :fr) }
+  let!(:follow_up_layout) { create :liquid_layout, title: 'Follow up layout' }
+  let!(:liquid_layout)    { create :liquid_layout, title: 'Liquid layout', default_follow_up_layout: follow_up_layout }
   let(:page) { instance_double('Page', published?: true, featured?: true, pronto: false, to_param: 'foo', id: '1', liquid_layout: '3', follow_up_liquid_layout: '4', language: default_language) }
+  let(:page_params) { attributes_for :page, liquid_layout_id: liquid_layout.id }
   let(:renderer) do
     instance_double(
       'LiquidRenderer',
@@ -17,7 +20,6 @@ describe PagesController do
   end
 
   include_examples 'session authentication'
-  it { is_expected.to respond_to :plugins }
 
   before do
     ActionController::Parameters.permit_all_parameters = true

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -219,10 +219,7 @@ describe PagesController do
 
       context 'with french' do
         subject { french_page }
-        before do
-          allow(Page).to receive(:find) { french_page }
-          allow(Page).to receive(:donation_page?) { false }
-        end
+        before { allow(Page).to receive(:find) { french_page } }
 
         it 'sets the locality to :fr' do
           get :show, params: { id: '42' }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -27,6 +27,8 @@ describe PagesController do
     allow(controller).to receive(:current_user) { user }
     allow_any_instance_of(ActionController::TestRequest).to receive(:location).and_return({})
     Settings.home_page_url = 'http://example.com'
+    create(:plugins_petition, page: page)
+    create(:plugins_fundraiser, page: page)
   end
 
   describe 'GET #index' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -17,6 +17,7 @@ describe PagesController do
   end
 
   include_examples 'session authentication'
+  it { is_expected.to respond_to :plugins }
 
   before do
     ActionController::Parameters.permit_all_parameters = true

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -221,7 +221,7 @@ describe PagesController do
         subject { french_page }
         before do
           allow(Page).to receive(:find) { french_page }
-          allow(page).to receive(:donation_page?) { false }
+          allow(Page).to receive(:donation_page?) { false }
         end
 
         it 'sets the locality to :fr' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -170,7 +170,8 @@ describe PagesController do
       allow(Page).to            receive(:find) { page }
       allow(page).to            receive(:update)
       allow(page).to            receive(:language_code).and_return('en')
-      allow(LiquidRenderer).to  receive(:new) { renderer }
+      allow(page).to receive(:donation_page?) { false }
+      allow(LiquidRenderer).to receive(:new) { renderer }
     end
 
     include_examples 'show and follow-up'
@@ -218,7 +219,10 @@ describe PagesController do
 
       context 'with french' do
         subject { french_page }
-        before { allow(Page).to receive(:find) { french_page } }
+        before do
+          allow(Page).to receive(:find) { french_page }
+          allow(page).to receive(:donation_page?) { false }
+        end
 
         it 'sets the locality to :fr' do
           get :show, params: { id: '42' }

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -27,8 +27,6 @@ describe PagesController do
     allow(controller).to receive(:current_user) { user }
     allow_any_instance_of(ActionController::TestRequest).to receive(:location).and_return({})
     Settings.home_page_url = 'http://example.com'
-    create(:plugins_petition, page: page)
-    create(:plugins_fundraiser, page: page)
   end
 
   describe 'GET #index' do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -214,7 +214,7 @@ describe PagesController do
 
     context 'on pages with localization' do
       let(:french_page) do
-        instance_double(Page, valid?: true, pronto: false, published?: true, language_code: language.code, id: '42', liquid_layout: '5', donation_page: false)
+        instance_double(Page, valid?: true, pronto: false, published?: true, language_code: language.code, id: '42', liquid_layout: '5')
       end
       let(:english_page) do
         instance_double(Page, valid?: true, pronto: false, published?: true, language_code: default_language.code, id: '66', liquid_layout: '5')
@@ -225,6 +225,7 @@ describe PagesController do
         before { allow(Page).to receive(:find) { french_page } }
 
         it 'sets the locality to :fr' do
+          allow(french_page).to receive(:donation_page?) { false }
           get :show, params: { id: '42' }
           expect(I18n.locale).to eq :fr
         end
@@ -234,6 +235,7 @@ describe PagesController do
           before { allow(Page).to receive(:find) { english_page } }
 
           it 'sets the locality to :en' do
+            allow(english_page).to receive(:donation_page?) { false }
             get :show, params: { id: '66' }
             expect(I18n.locale).to eq :en
           end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -728,10 +728,15 @@ describe Page do
 
   describe '#has_pronto_inclusion_template?' do
     let(:with) { create :page, liquid_layout: create(:liquid_layout, title: 'Default: Petition And Scroll To Share Greenpeace') }
+    let(:with_fundraiser) { create :page, liquid_layout: create(:liquid_layout, title: 'Fundraiser With Title Below Image') }
     let(:without) { create :page, liquid_layout: create(:liquid_layout, title: 'another title') }
 
     it 'returns true when template title matches' do
       expect(with.has_pronto_inclusion_template?).to be true
+    end
+
+    it 'returns true when fundraiser template title matches' do
+      expect(with_fundraiser.has_pronto_inclusion_template?).to be true
     end
 
     it 'returns false when template title does not match' do


### PR DESCRIPTION
### Overview
* We want to set up a google Optimize experiment to redirect the supported fundraiser templates.
    * Added the template to the `PRONTO_TEMPLATES` array
    * Added new method to handle fundraiser experiment redirects
        *  I could have used the same method, but then we will end up redirecting petition pages as part of the donations experiment.
    * Extended tests

### Ticket
https://app.asana.com/0/1119304937718815/1202699940684642/f

### Notes
@osahyoun @subbiahf22 We don't have a way to differentiate petitions vs. fundraisers with just the URL.
We need to either stop the petitions experiment and then run the fundraiser experiment or change the path for the fundraiser so we can set up the experiment on google optimize.