### PR TITLE
Modified the copy functionality to include title and first paragraph

### DIFF
--- a/vendor/theme/templates/partials/_social_share_band.liquid
+++ b/vendor/theme/templates/partials/_social_share_band.liquid
@@ -73,7 +73,8 @@
       console.log(e);
       var url = location.origin + location.pathname;
       var plainTitle = document.querySelector('.share-title').textContent;
-      navigator.clipboard.writeText(plainTitle + url);
+      var plainContent = document.querySelector('.main-feature > p:first-of-type').textContent + '\n';
+      navigator.clipboard.writeText(plainTitle + url + plainContent);
     }
 
     $('.copy').fadeOut(100, () => {

--- a/vendor/theme/templates/partials/_social_share_band.liquid
+++ b/vendor/theme/templates/partials/_social_share_band.liquid
@@ -23,7 +23,6 @@
     <img class="copy" src="{{ 'Copy.png' | asset_src }}" aria-hidden="true" alt="" />
     <span class="copied" style="display: none;" role="status">{{ 'share.copied' | t }}</span>
   </a>
-
   </div>
 </section>
 <script type="text/javascript">
@@ -57,9 +56,26 @@
     console.log('printShareClickHandler');
     window.print();
   };
-  function copyLinkShareClickHandler() {
+  async function copyRichText () {
+    var translatedLinkLabel = window.I18n?.translate('page.more_info') || 'More information';
+    var title = document.querySelector('.share-title').outerHTML;
+    var link = `<br><a href='${location.origin + location.pathname}'>${translatedLinkLabel}</a>`;
+    const content = title + document.querySelector('.main-feature > p:first-of-type').innerHTML + link;
+    const blob = new Blob([content], { type: "text/html" });
+    const richTextInput = new ClipboardItem({ "text/html": blob });
+    await navigator.clipboard.write([richTextInput]);
+  };
+  async function copyLinkShareClickHandler() {
     console.log('copyLinkShareClickHandler');
-    navigator.clipboard.writeText(location.origin + location.pathname);
+    try {
+      await copyRichText();
+    } catch(e) {
+      console.log(e);
+      var url = location.origin + location.pathname;
+      var plainTitle = document.querySelector('.share-title').textContent;
+      navigator.clipboard.writeText(plainTitle + url);
+    }
+
     $('.copy').fadeOut(100, () => {
       $('.copied').show();
     });


### PR DESCRIPTION
### Overview
This  pull request is a follow-up from #2016 
Flora thought the copy functionality would include the copy of all the page content; however, that's a more extensive feature that's complex to develop due to the clipboard APIs, browser support, and image handling.
I suggested this patch; instead, which will provide extended functionality without increasing the complexity too much and thus extending the delivery date.
* The copy link button will copy the page title, the first paragraph of the main content, and the page link.

### Ticket
https://app.asana.com/0/1119304937718815/1202770241564374/f

### Notes
The Clipboard API is not fully supported for all browsers; for example, Firefox does not support `ClipboardItem`
![Screen Shot 2022-08-18 at 12 19 47](https://user-images.githubusercontent.com/15176901/185466614-c5cf60ff-9e4f-4eff-ae48-7a8df1835d02.png)

If the first paragraph happens to have an image, it can be supported by some browsers, but it widely varies.
![Screen Shot 2022-08-18 at 12 19 55](https://user-images.githubusercontent.com/15176901/185466734-fb9ad8fa-03ef-438c-860f-562a9ffd4764.png)

Here's the [documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem).

**I added a try-catch block to handle incompatibility issues by copying in plain text.**


### Video

https://user-images.githubusercontent.com/15176901/185465136-457ff0c3-35ee-48ce-8924-fd5665f8b28c.mp4


