### PR TITLE
Changed order to show link at the end

### DIFF
--- a/vendor/theme/templates/partials/_social_share_band.liquid
+++ b/vendor/theme/templates/partials/_social_share_band.liquid
@@ -74,7 +74,7 @@
       var url = location.origin + location.pathname;
       var plainTitle = document.querySelector('.share-title').textContent;
       var plainContent = document.querySelector('.main-feature > p:first-of-type').textContent + '\n';
-      navigator.clipboard.writeText(plainTitle + url + plainContent);
+      navigator.clipboard.writeText(plainTitle + plainContent + url);
     }
 
     $('.copy').fadeOut(100, () => {


### PR DESCRIPTION
### Overview
During QA, I noticed the link was showing after the title instead of the end.
This is only for the browsers that doesn't support the clipboard api