### PR TITLE
Release

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,7 +12,7 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   before_action :redirect_unless_published, only: %i[show follow_up]
   before_action :localize, only: %i[show follow_up double_opt_in_notice]
   before_action :record_tracking, only: %i[show]
-  before_action :redirect_to_experiment, only: [:show]
+  before_action :redirect_to_donations_experiment, only: [:show]
 
   def index
     @pages = Search::PageSearcher.search(search_params)
@@ -205,9 +205,10 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
     set_locale(@page.language_code)
   end
 
-  def redirect_to_experiment
+  def redirect_to_donations_experiment
     return unless @page.published?
     return unless @page.language_code
+    return unless @page.donation_page?
     return if user_signed_in?
 
     path_match = %r{^/a/}

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -61,7 +61,7 @@ class Page < ApplicationRecord # rubocop:disable Metrics/ClassLength
   extend FriendlyId
   has_paper_trail
 
-  PRONTO_TEMPLATES = ['Default: Petition And Scroll To Share Greenpeace'].freeze
+  PRONTO_TEMPLATES = ['Default: Petition And Scroll To Share Greenpeace', 'Fundraiser With Title Below Image'].freeze
 
   enum follow_up_plan: %i[with_liquid with_page] # TODO: - :with_link
   enum publish_status: %i[published unpublished archived]
@@ -216,7 +216,7 @@ class Page < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # the page is considered as petition page.
   # FIXME: This method is *not* reliable and intermittently tests
   def donation_page?
-    plugins.first.is_a?(Plugins::Fundraiser)
+    plugins&.first.is_a?(Plugins::Fundraiser) || false
   end
 
   def set_ak_slug

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module Champaign
 
     config.i18n.available_locales = %i[en fr de es pt nl ar]
     config.i18n.enforce_available_locales = true
+    config.middleware.use Pronto
   end
 end
 

--- a/lib/middleware/pronto.rb
+++ b/lib/middleware/pronto.rb
@@ -8,6 +8,18 @@ class Pronto
     end
   end
 
+  class TemplateMatcher
+    PRONTO_TEMPLATES = ['Default: Petition And Scroll To Share Greenpeace', 'Fundraiser With Title Below Image'].freeze
+
+    def self.has_pronto_inclusion_template(liquid_layout_id)
+      layout ||= LiquidLayout.find(liquid_layout_id)
+      PRONTO_TEMPLATES.include?(layout&.title.to_s)
+    rescue StandardError => e
+      puts "Error trying to get liquid_layout with id #{liquid_layout_id} from pronto middleware - error: #{e.message}."
+      false
+    end
+  end
+
   def initialize(app)
     @app = app
   end
@@ -21,7 +33,7 @@ class Pronto
     if path_match
       page = Page.find_by(slug: path_match)
 
-      if page&.language_code == 'en' && page&.petition_page?
+      if page&.petition_page? && TemplateMatcher.has_pronto_inclusion_template(page&.liquid_layout_id)
         location = "#{Settings.pronto.domain}/#{req.fullpath}"
         return [301, { 'Location' => location, 'Content-Type' => 'text/html', 'Content-Length' => '0' }, []]
       end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -728,10 +728,15 @@ describe Page do
 
   describe '#has_pronto_inclusion_template?' do
     let(:with) { create :page, liquid_layout: create(:liquid_layout, title: 'Default: Petition And Scroll To Share Greenpeace') }
+    let(:with_fundraiser) { create :page, liquid_layout: create(:liquid_layout, title: 'Fundraiser With Title Below Image') }
     let(:without) { create :page, liquid_layout: create(:liquid_layout, title: 'another title') }
 
     it 'returns true when template title matches' do
       expect(with.has_pronto_inclusion_template?).to be true
+    end
+
+    it 'returns true when fundraiser template title matches' do
+      expect(with_fundraiser.has_pronto_inclusion_template?).to be true
     end
 
     it 'returns false when template title does not match' do


### PR DESCRIPTION
Extend pronto supported templates for donations experiment (#2011)* including donation pronto supported template

* extending tests

* separate method for fundraisers

* fixing test

* fixing test

* fixed typo

* set default

* undo not needed change

* null check

* solving tests issues

* addint dependencies to tests

* adding plugins

* Revert "adding plugins"

This reverts commit 742e8ad7a18df34dfa99a38e9299c067d6663632.

* another try to fix test

* one more

* removed petition experiment method add back pronto middleware

* Added fundraiser template

Co-authored-by: subbiah <subbiah@f22labs.com>