### PR TITLE
Including all thermometer settings on the api response

### DIFF
--- a/app/views/api/pages/show.json.jbuilder
+++ b/app/views/api/pages/show.json.jbuilder
@@ -90,8 +90,14 @@ json.fundraiser do
   end
 end
 
-json.actions_offset_count actionsThermometer.offset if actionsThermometer
-json.donations_offset_count donationsThermometer.offset if donationsThermometer
+json.thermometer do 
+  if actionsThermometer
+    json.actions actionsThermometer
+  end
+  if donationsThermometer
+    json.donations donationsThermometer
+  end
+end
 
 json.sources do
   json.array! @page.links, :title, :source, :url, :date


### PR DESCRIPTION
### Overview
We need the `active` setting from the thermometer configuration to use it in pronto.
I have included all the settings and put them into their own `thermometer` node; I think it makes more sense and makes the JSON response cleaner.

### Ticket
https://app.asana.com/0/1119304937718815/1202883154800683/f

### Example Request/Response

**Request**
```console
curl --location --request GET 'http://localhost:3000/api/pages/test-petition-123.json' 
```

**Response**
```json
{
    "id": 13,
    "title": "test petition 123",
    "slug": "test-petition-123",
    "content": "",
    "created_at": "2022-04-06T20:54:49.715Z",
    "updated_at": "2022-08-30T18:49:28.800Z",
    "publish_status": "published",
    "featured": false,
    "action_count": 12,
    "campaign_action_count": 12,
    "meta_description": "",
    "template_name": "Default: Petition And Scroll To Share Greenpeace",
    "follow_up_template": null,
    "share_buttons": [],
    "language": "en",
     ...
    "thermometer": {
        "actions": {
            "id": 23,
            "title": null,
            "offset": 0,
            "page_id": 13,
            "active": false,
            "created_at": "2022-04-06T20:54:49.768Z",
            "updated_at": "2022-08-30T18:49:28.793Z",
            "ref": ""
        },
        "donations": {
            "id": 24,
            "title": null,
            "offset": 0,
            "page_id": 13,
            "active": true,
            "created_at": "2022-04-06T20:54:49.803Z",
            "updated_at": "2022-04-06T21:01:09.292Z",
            "ref": ""
        }
    },
    "sources": []
}
```