### PR TITLE
Adding user auth endpoint to be used by pronto

### DIFF
--- a/app/controllers/api/user_auth_controller.rb
+++ b/app/controllers/api/user_auth_controller.rb
@@ -2,7 +2,6 @@
 
 class Api::UserAuthController < ApplicationController
   before_action :authenticate_http_token
-  TOKEN = Settings.pronto.api_secret_key.to_s
 
   def authenticate
     if authenticate_user!
@@ -17,7 +16,7 @@ class Api::UserAuthController < ApplicationController
 
   def authenticate_http_token
     authenticate_or_request_with_http_token do |token, _options|
-      ActiveSupport::SecurityUtils.secure_compare(token, TOKEN)
+      ActiveSupport::SecurityUtils.secure_compare(token, Settings.pronto_api_secret_key)
     end
   end
 end

--- a/app/controllers/api/user_auth_controller.rb
+++ b/app/controllers/api/user_auth_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Api::UserAuthController < ApplicationController
+  before_action :authenticate_http_token
+  TOKEN = Settings.pronto.api_secret_key.to_s
+
+  def authenticate
+    if authenticate_user!
+      render json: {
+        authenticated: true
+      }, status: 200
+      nil
+    end
+  end
+
+  private
+
+  def authenticate_http_token
+    authenticate_or_request_with_http_token do |token, _options|
+      ActiveSupport::SecurityUtils.secure_compare(token, TOKEN)
+    end
+  end
+end

--- a/config/initializers/application_secrets.rb
+++ b/config/initializers/application_secrets.rb
@@ -65,6 +65,10 @@ if Rails.env == 'production' && Settings.aws_secrets_manager_prefix.present?
       merchants: Settings.braintree.merchants,
       subscription_plans: Settings.braintree.subscription_plans
     },
+    pronto: {
+      domain: Settings.pronto.domain,
+      api_secret_key: SecretsManager.get_value('pronto')['secretApiKey']
+    },
     sentry_dsn: SecretsManager.get_value('prod/sentry_dsn')['champaign'],
     airbrake_project_id: airbrake_secrets['projectId'],
     airbrake_api_key: airbrake_secrets['apiKey']

--- a/config/initializers/application_secrets.rb
+++ b/config/initializers/application_secrets.rb
@@ -65,10 +65,7 @@ if Rails.env == 'production' && Settings.aws_secrets_manager_prefix.present?
       merchants: Settings.braintree.merchants,
       subscription_plans: Settings.braintree.subscription_plans
     },
-    pronto: {
-      domain: Settings.pronto.domain,
-      api_secret_key: SecretsManager.get_value('pronto')['secretApiKey']
-    },
+    pronto_api_secret_key: SecretsManager.get_value('pronto')['secretApiKey'],
     sentry_dsn: SecretsManager.get_value('prod/sentry_dsn')['champaign'],
     airbrake_project_id: airbrake_secrets['projectId'],
     airbrake_api_key: airbrake_secrets['apiKey']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,8 @@ Rails.application.routes.draw do
       post 'track', to: '/share/shares#track'
     end
 
+    get 'user/auth', to: '/api/user_auth#authenticate', as: 'authenticate'
+
     get 'donations/total'
 
     resources :email_target_emails, only: [:index] do

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,7 @@
 # General Champaign settings.
 pronto:
   domain: 'https://pronto-development.sumofus.org'
+  api_secret_key: 'for local devlopment get me from secrets manager and replace me on development.local.yml'
 google_optimize:
   key: "OPT-5XL8RFP"
 secret_key_base: secret_key_base

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,10 +1,10 @@
 # General Champaign settings.
 pronto:
   domain: 'https://pronto-development.sumofus.org'
-  api_secret_key: 'for local devlopment get me from secrets manager and replace me on development.local.yml'
 google_optimize:
   key: "OPT-5XL8RFP"
 secret_key_base: secret_key_base
+pronto_api_secret_key: 'for local devlopment get me from secrets manager and replace me on development.local.yml'
 omniauth_client_secret: omniauth_client_secret
 omniauth_client_id: omniauth_client_id
 liquid_templating_source: db

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,6 +1,7 @@
 # Production Settings for Champaign
 pronto:
   domain: <%= ENV['PRONTO_DOMAIN'] || 'https://action.sumofus.org' %>
+  api_secret_key: 'secreto'
 
 google_optimize:
   key: <%= ENV['GOOGLE_OPTIMIZE'] || 'OPT-PS8FHLC' %>

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,12 +1,12 @@
 # Production Settings for Champaign
 pronto:
   domain: <%= ENV['PRONTO_DOMAIN'] || 'https://action.sumofus.org' %>
-  api_secret_key: 'secreto'
 
 google_optimize:
   key: <%= ENV['GOOGLE_OPTIMIZE'] || 'OPT-PS8FHLC' %>
 # General Champaign settings.
 secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
+pronto_api_secret_key: 'secreto'
 omniauth_client_secret: <%= ENV['OMNIAUTH_CLIENT_SECRET'] %>
 omniauth_client_id: <%= ENV['OMNIAUTH_CLIENT_ID'] %>
 liquid_templating_source: <%= ENV['LIQUID_TEMPLATING_SOURCE'] || 'store' %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -16,6 +16,7 @@
 google_optimize:
   key: "test-1234"
 secret_key_base: 'a fake secret key'
+pronto_api_secret_key: 'secreto'
 omniauth_client_secret: 'a fake client secret'
 omniauth_client_id: 'a fake client_id'
 homepage_url: 'http://sumofus.org'


### PR DESCRIPTION
### Overview
* We need a way to validate the session cookie created by champaign auth flow from pronto. To do that securely, I have added the following work to this PR:
    * Using HTTP token authentication as `before_action` 
        * For this, I added a `secretApiKey` into the secrets manager (one for dev and the other for production environments); this key needs to be present in the `Authorization` header from the pronto request. **This is our first secure filter**.
    * Using the existing champaign authentication method to validate the user session (for this to work, we need to pass on the cookies from the pronto request).
* If either of the above secure checks fails, the endpoint will return a 401 response. 

### Ticket
https://app.asana.com/0/0/1202899413944404/f

### Request/Response Examples

**Authorized**

Request:
```console
curl --location --request GET 'http://localhost:3000/api/user/auth/' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer TheSecretApiKeyHere' \
--header 'Cookie: _session_id=THE_SESSION_ID_COOKIE_VALUE_HERE' \
--data-raw ''
```

Response Status: 200
```json
{
    "authenticated": true
}
```

**Unauthorized (due to invalid api secret key)**

Request:
```console
curl --location --request GET 'http://localhost:3000/api/user/auth/' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer TheInvalidSecretApiKeyHere' \
--header 'Cookie: _session_id=THE_SESSION_ID_COOKIE_VALUE_HERE' \
--data-raw ''
```

Response Status: 401
```text
HTTP Token: Access denied.
```

**Unauthorized (due to invalid session id cookie)**

Request:
```console
curl --location --request GET 'http://localhost:3000/api/user/auth/' \
--header 'Accept: application/json' \
--header 'Authorization: Bearer TheSecretApiKeyHere' \
--header 'Cookie: _session_id=THE_INVALID_SESSION_ID_COOKIE_VALUE_HERE' \
--data-raw ''
```

Response Status: 401
```json
{
    "error": "You need to sign in or sign up before continuing."
}
```