### PR TITLE
Avoid session cookie to always change even if the session is the same

### DIFF
--- a/config/initializers/session_update.rb
+++ b/config/initializers/session_update.rb
@@ -1,0 +1,34 @@
+require 'rack/session/abstract/id' # defeat autoloading
+module ActionDispatch
+  class Request
+    class Session # :nodoc:
+      def changed?
+        @changed
+      end
+
+      def load_for_write!
+        load! unless loaded?
+        @changed = true
+      end
+    end
+  end
+end
+
+module Rack
+  module Session
+    module Abstract
+      class Persisted
+        private
+
+        def commit_session?(req, session, options)
+          if options[:skip]
+            false
+          else
+            has_session = session.changed? || forced_session_update?(session, options)
+            has_session && security_matches?(req, options)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Overview
While testing #2029  from pronto, I faced the issue that the session cookie on champaign always changes with every request even tho the session is the same.
That has an explanation that you can read here.
To avoid that, I added this code to the initializers; that way, the session cookie will only change when the actual session changes.

### Ticket
https://app.asana.com/0/0/1202899413944407/f