### PR TITLE
Email_Tool: Handling Consented Member's Cookies

### DIFF
--- a/app/javascript/plugins/email_tool/EmailToolView.js
+++ b/app/javascript/plugins/email_tool/EmailToolView.js
@@ -78,7 +78,7 @@ export class EmailToolView extends Component {
     };
     // For double optin countries consented field should not have a value
     if (this.props.consented !== null) {
-      payload.consented = this.props.consented ? 1 : 0;
+      payload.email.consented = this.props.consented ? 1 : 0;
     }
     return payload;
   }

--- a/app/services/email_tool_sender.rb
+++ b/app/services/email_tool_sender.rb
@@ -10,7 +10,7 @@ class EmailToolSender
     @target = @plugin.find_target(params[:target_id])
     @page = Page.find(page_id)
     @params = params.slice(:from_email, :from_name, :body, :subject, :target_id, :country, :email_service,
-                           :clicked_copy_body_button)
+                           :clicked_copy_body_button, :consented)
     @tracking_params = tracking_params.slice(
       :akid, :referring_akid, :referrer_id, :rid, :source, :action_mobile
     )
@@ -43,7 +43,6 @@ class EmailToolSender
   end
 
   def create_action
-    # TODO: Not handling consent.
     # No new members for EEA countries
     @action = ManageAction.create(
       {
@@ -52,7 +51,8 @@ class EmailToolSender
         email: @params[:from_email],
         country: @params[:country],
         email_service: @params[:email_service],
-        clicked_copy_body_button: @params[:clicked_copy_body_button]
+        clicked_copy_body_button: @params[:clicked_copy_body_button],
+        consented: @params[:consented]
       }.merge(action_target_params, @tracking_params)
     )
   end


### PR DESCRIPTION
This PR Fixes missing "consented" flag in Email Tool.
Due to this missing flag, the new Member's record was not created even when User consents to store their details in form of cookies. 