### PR TITLE
Unintended donations experiment [PART 4]

### DIFF
--- a/app/javascript/experiments/unintended-donations.js
+++ b/app/javascript/experiments/unintended-donations.js
@@ -1,5 +1,5 @@
 export default {
-  experimentId: 'T4bb5RtkToSmDAZLuNSIXQ',
+  experimentId: 'Gl736h6mS_aKsi963Xtnlg',
   pageLoad: false,
   activationEvent: 'optimize.activate',
 };

--- a/app/javascript/plugins/fundraiser/FundraiserView.js
+++ b/app/javascript/plugins/fundraiser/FundraiserView.js
@@ -81,8 +81,14 @@ export class FundraiserView extends Component {
         ) || {};
 
       if (variant && variant === '1' && this.props.idMismatch) {
+        const { donationAmount } = this.props.fundraiser;
         this.props.resetMember();
-        this.props.changeStep(0);
+        if (donationAmount && donationAmount > 0) {
+          this.props.selectAmount(donationAmount);
+          this.props.changeStep(1);
+        } else {
+          this.props.changeStep(0);
+        }
       }
     }
   }


### PR DESCRIPTION
### Overview
The variant for the experiment is lower than the control for a little; however, we would like to test a small change:
* Instead of landing the members in step 1 any time we found an ID mismatch, we land them on step two if there is an amount selection
    * This scenario is for when a member clicks on a specific amount on a fundraiser mailing.
    * If there is no amount selection (member clicked on "Donate another amount" from the mailing), everything continues as is for variant 1, and we land the member on the first step. 

### Ticket
https://app.asana.com/0/1119304937718815/1202919967075456/f

### Video

https://user-images.githubusercontent.com/15176901/188754899-1c8764aa-e03d-4baf-ada0-cce2382dd31b.mp4

