### PR TITLE
Adding language code to the petitions path

### DIFF
--- a/lib/middleware/pronto.rb
+++ b/lib/middleware/pronto.rb
@@ -34,7 +34,7 @@ class Pronto
       page = Page.find_by(slug: path_match)
 
       if page&.petition_page? && TemplateMatcher.has_pronto_inclusion_template(page&.liquid_layout_id)
-        location = "#{Settings.pronto.domain}/#{req.fullpath}"
+        location = "#{Settings.pronto.domain}/#{page.language_code}#{req.fullpath}"
         return [301, { 'Location' => location, 'Content-Type' => 'text/html', 'Content-Length' => '0' }, []]
       end
     end


### PR DESCRIPTION
### Overview
* Automatic language detection is causing a lot of confusion among campaigners now that pronto is live for the petition pages; since Campaigners usually have English as their default language on their browsers, they are being redirected to the English version of all campaigns.
     * This PR is intended **only to redirect logged-in campaigners**; however, **I couldn't find a way to authenticate the session from the pronto middleware.**
         * @osahyoun, @subbiahf22, **please chime in if you know how to do it!**  

### Ticket
https://app.asana.com/0/1119304937718815/1202845543141914/f