### PR TITLE
Removing bot verification until pronto ReCaptcha is fixed

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -5,7 +5,7 @@ class Api::Payment::BraintreeController < PaymentController
   protect_from_forgery with: :exception, prepend: true
   skip_before_action :verify_authenticity_token, raise: false
   before_action :check_api_key, only: [:refund]
-  before_action :verify_bot, only: [:transaction]
+  #before_action :verify_bot, only: [:transaction]
 
   def token
     @merchant_account_id = unsafe_params[:merchantAccountId]


### PR DESCRIPTION
### Overview
We need to enable ReCaptcha again. However, pronto development is blocked, and all cypress donation specs fail.

### NOTES
Revert this PR once https://github.com/SumOfUs/pronto/pull/224 is merged
