### PR TITLE
Monthly Sustainers post donate page changes

### DIFF
--- a/app/liquid/liquid_renderer.rb
+++ b/app/liquid/liquid_renderer.rb
@@ -69,6 +69,7 @@ class LiquidRenderer # rubocop:disable Metrics/ClassLength
       images: images,
       named_images: named_images,
       primary_image: image_urls(@page.image_to_display),
+      post_action_image: image_urls(@page.post_action_image_to_display),
       shares: Shares.get_all(@page),
       locale: @page.language&.code || 'en',
       follow_up_url: follow_up_url

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -23,6 +23,7 @@
 #  meta_tags                  :string
 #  notes                      :text
 #  optimizely_status          :integer          default("optimizely_enabled"), not null
+#  post_action_copy           :text             default("")
 #  pronto                     :boolean          default(FALSE)
 #  publish_actions            :integer          default("secure"), not null
 #  publish_status             :integer          default("unpublished"), not null
@@ -37,6 +38,7 @@
 #  follow_up_page_id          :integer
 #  language_id                :integer
 #  liquid_layout_id           :integer
+#  post_action_image_id       :integer
 #  primary_image_id           :integer
 #
 # Indexes
@@ -54,6 +56,7 @@
 #  fk_rails_...  (follow_up_liquid_layout_id => liquid_layouts.id)
 #  fk_rails_...  (language_id => languages.id)
 #  fk_rails_...  (liquid_layout_id => liquid_layouts.id)
+#  fk_rails_...  (post_action_image_id => images.id)
 #  fk_rails_...  (primary_image_id => images.id)
 #
 
@@ -74,6 +77,7 @@ class Page < ApplicationRecord # rubocop:disable Metrics/ClassLength
   belongs_to :follow_up_page, class_name: 'Page'
   belongs_to :follow_up_liquid_layout, class_name: 'LiquidLayout'
   belongs_to :primary_image, class_name: 'Image'
+  belongs_to :post_action_image, class_name: 'Image'
 
   has_many :pages_tags, dependent: :destroy
   has_many :tags, through: :pages_tags
@@ -142,6 +146,10 @@ class Page < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   def image_to_display
     primary_image || images.first
+  end
+
+  def post_action_image_to_display
+    post_action_image
   end
 
   def plugin_thermometers

--- a/app/views/api/pages/show.json.jbuilder
+++ b/app/views/api/pages/show.json.jbuilder
@@ -12,7 +12,8 @@ json.extract!(
   :featured,
   :action_count,
   :campaign_action_count,
-  :meta_description
+  :meta_description,
+  :post_action_copy
 )
 
 json.template_name  @page.liquid_layout.title
@@ -35,6 +36,7 @@ share_buttons.sort_by! { |hsh| hsh['rank'] }
 json.share_buttons share_buttons
 
 image = @page.image_to_display
+post_action_image = @page.post_action_image_to_display
 
 if image&.try(:content)
   if image.dimensions
@@ -52,6 +54,26 @@ if image&.try(:content)
     json.large do
       json.path image.content.path(:large)
       json.url image.content.url(:large)
+    end
+  end
+end
+
+if post_action_image&.try(:content)
+  if post_action_image.dimensions
+    w, h = post_action_image.dimensions.split(':')
+
+    json.width w
+    json.height h
+  end
+
+  json.post_action_image do
+    json.original do
+      json.url post_action_image.content.url
+      json.path post_action_image.content.path
+    end
+    json.large do
+      json.path post_action_image.content.path(:large)
+      json.url post_action_image.content.url(:large)
     end
   end
 end

--- a/app/views/pages/_follow_up_action_settings.slim
+++ b/app/views/pages/_follow_up_action_settings.slim
@@ -1,11 +1,12 @@
-.row
-  .col-md-12
-    = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |f|
+- if page.follow_up_liquid_layout_id.present? && page.follow_up_liquid_layout_id == 18
+  .row
+    .col-md-12
+      = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |f|
+          .form-group
+              = label_with_tooltip(f, :post_action_copy, t('pages.edit.post_donate_settings_text'), t('tooltips.post_donate_settings_text'))
+              = f.text_area :post_action_copy, class: 'form-control', 'max-length' => 140
+    .col-md-7
+      = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |form|
         .form-group
-            = label_with_tooltip(f, :post_action_copy, t('pages.edit.post_donate_settings_text'), t('tooltips.post_donate_settings_text'))
-            = f.text_area :post_action_copy, class: 'form-control', 'max-length' => 140
-  .col-md-7
-    = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |form|
-      .form-group
-          = form.label :post_action_image_id, t('pages.edit.post_action_image')
-          = form.select :post_action_image_id, page.images.map{|im| [im.content_file_name, im.id] }, { include_blank: "No image" }, class: 'form-control'
+            = form.label :post_action_image_id, t('pages.edit.post_action_image')
+            = form.select :post_action_image_id, page.images.map{|im| [im.content_file_name, im.id] }, { include_blank: "No image" }, class: 'form-control'

--- a/app/views/pages/_follow_up_action_settings.slim
+++ b/app/views/pages/_follow_up_action_settings.slim
@@ -1,0 +1,11 @@
+.row
+  .col-md-12
+    = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |f|
+        .form-group
+            = label_with_tooltip(f, :post_action_copy, t('pages.edit.post_donate_settings_text'), t('tooltips.post_donate_settings_text'))
+            = f.text_area :post_action_copy, class: 'form-control', 'max-length' => 140
+  .col-md-7
+    = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |form|
+      .form-group
+          = form.label :post_action_image_id, t('pages.edit.post_action_image')
+          = form.select :post_action_image_id, page.images.map{|im| [im.content_file_name, im.id] }, { include_blank: "No image" }, class: 'form-control'

--- a/app/views/pages/edit.slim
+++ b/app/views/pages/edit.slim
@@ -32,7 +32,7 @@ section.page-edit-step#sources data-icon='link'
   h1.page-edit-step__title = t('.sources')
   = render 'link_form', page: @page
 
-section.page-edit-step#sources data-icon='post_donate_settings'
+section.page-edit-step#postActionSettings data-icon='post_donate_settings'
   h1.page-edit-step__title = t('.post_donate_settings')
   = render 'follow_up_action_settings', page: @page
 
@@ -55,4 +55,18 @@ javascript:
     window.ee.emit("activation:toggle");
     window.ee.emit("shares:edit");
     new PageEditBar();
+    $(".radio-group__option").on("click", function() {
+      try {
+        var selectedFollowUpTemplate = $(this).find('input')[0].value;
+        console.log('click',selectedFollowUpTemplate);
+        if(selectedFollowUpTemplate === "18") {
+          console.log('Recurring ask');
+          $("#postActionSettings").removeClass('hidden-irrelevant');
+        } else {
+          $("#postActionSettings").addClass('hidden-irrelevant');
+        }
+      } catch (err){
+        console.log(err);
+      }
+    });
   });

--- a/app/views/pages/edit.slim
+++ b/app/views/pages/edit.slim
@@ -32,6 +32,10 @@ section.page-edit-step#sources data-icon='link'
   h1.page-edit-step__title = t('.sources')
   = render 'link_form', page: @page
 
+section.page-edit-step#sources data-icon='post_donate_settings'
+  h1.page-edit-step__title = t('.post_donate_settings')
+  = render 'follow_up_action_settings', page: @page
+
 - @page.plugins.each do |plugin|
   - next unless low_priority_plugins.include? plugin.class
   section.page-edit-step id=plugin_section_id(plugin) data-icon=plugin_icon(plugin)

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -77,6 +77,8 @@ en:
     follow_up: "Choose what the follow-up page should look like, or redirect to another page after the action"
     image_upload: "Use this uploader for both the page image and any images for shares."
     main_image: "Select which image should appear at the top of the page."
+    post_action_image: "Select which image should appear at the top of the page on the post donate page with recurring ask."
+    post_donate_settings_text: "Add the copy to be used on the post donate page with recurring ask"
     campaign: "Action counters of pages belonging to the same campaign are consolidated."
     canonical_url: "If a page is accessible through multiple URLs, then pick the best one for SEO. Defaults to https://our.site/a/page-slug"
     optimizely_status: "Optimizely can be slow to load, but we load it on all pages so we can run site-wide experiments. Please only disable for exceptional pages like microsites."
@@ -184,6 +186,8 @@ en:
       photos: 'Photos'
       follow_up: 'Post action'
       sources: 'Sources'
+      post_donate_settings: 'Follow up action settings'
+      post_donate_settings_text: 'Post donate action copy'
       extras: 'Extras'
       no_images_notice: "You haven't any photos. Drag your pics into the box below."
       ak_reports: 'ActionKit Reports:'
@@ -204,6 +208,7 @@ en:
       add_link: 'Add source'
       language_label: "Language"
       primary_image: 'Which is the main image for the page?'
+      post_action_image: 'Which is the main image for the post donate page?'
       new_variant: 'Create new share variant'
       unsaved_changes: 'You have unsaved changes.'
       user_error: "The server didn't like something you entered. Click here to see the error."

--- a/config/locales/champaign.en.yml
+++ b/config/locales/champaign.en.yml
@@ -186,7 +186,7 @@ en:
       photos: 'Photos'
       follow_up: 'Post action'
       sources: 'Sources'
-      post_donate_settings: 'Follow up action settings'
+      post_donate_settings: 'Post donate with recurring ask settings'
       post_donate_settings_text: 'Post donate action copy'
       extras: 'Extras'
       no_images_notice: "You haven't any photos. Drag your pics into the box below."

--- a/db/migrate/20220919211947_add_post_action_copy_and_image.rb
+++ b/db/migrate/20220919211947_add_post_action_copy_and_image.rb
@@ -1,0 +1,7 @@
+class AddPostActionCopyAndImage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pages, :post_action_copy, :text, default: ''
+    add_column :pages, :post_action_image_id, :integer
+    add_foreign_key :pages, :images, column: :post_action_image_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_23_114525) do
+ActiveRecord::Schema.define(version: 2022_09_19_211947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -245,6 +245,8 @@ ActiveRecord::Schema.define(version: 2022_02_23_114525) do
     t.decimal "fundraising_goal", precision: 10, scale: 2, default: "0.0"
     t.string "ak_slug", default: ""
     t.boolean "pronto", default: false
+    t.text "post_action_copy", default: ""
+    t.integer "post_action_image_id"
     t.index ["campaign_id"], name: "index_pages_on_campaign_id"
     t.index ["follow_up_liquid_layout_id"], name: "index_pages_on_follow_up_liquid_layout_id"
     t.index ["follow_up_page_id"], name: "index_pages_on_follow_up_page_id"
@@ -741,6 +743,7 @@ ActiveRecord::Schema.define(version: 2022_02_23_114525) do
   add_foreign_key "links", "pages"
   add_foreign_key "member_authentications", "members"
   add_foreign_key "pages", "campaigns"
+  add_foreign_key "pages", "images", column: "post_action_image_id"
   add_foreign_key "pages", "images", column: "primary_image_id"
   add_foreign_key "pages", "languages"
   add_foreign_key "pages", "liquid_layouts"

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -23,6 +23,7 @@
 #  meta_tags                  :string
 #  notes                      :text
 #  optimizely_status          :integer          default("optimizely_enabled"), not null
+#  post_action_copy           :text             default("")
 #  pronto                     :boolean          default(FALSE)
 #  publish_actions            :integer          default("secure"), not null
 #  publish_status             :integer          default("unpublished"), not null
@@ -37,6 +38,7 @@
 #  follow_up_page_id          :integer
 #  language_id                :integer
 #  liquid_layout_id           :integer
+#  post_action_image_id       :integer
 #  primary_image_id           :integer
 #
 # Indexes
@@ -54,6 +56,7 @@
 #  fk_rails_...  (follow_up_liquid_layout_id => liquid_layouts.id)
 #  fk_rails_...  (language_id => languages.id)
 #  fk_rails_...  (liquid_layout_id => liquid_layouts.id)
+#  fk_rails_...  (post_action_image_id => images.id)
 #  fk_rails_...  (primary_image_id => images.id)
 #
 

--- a/spec/liquid/liquid_renderer_spec.rb
+++ b/spec/liquid/liquid_renderer_spec.rb
@@ -134,6 +134,7 @@ describe LiquidRenderer do
         primary_image
         petition_target
         locale
+        post_action_image
       ]
 
       expected_keys += page.liquid_data.keys.map(&:to_s)

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -23,6 +23,7 @@
 #  meta_tags                  :string
 #  notes                      :text
 #  optimizely_status          :integer          default("optimizely_enabled"), not null
+#  post_action_copy           :text             default("")
 #  pronto                     :boolean          default(FALSE)
 #  publish_actions            :integer          default("secure"), not null
 #  publish_status             :integer          default("unpublished"), not null
@@ -37,6 +38,7 @@
 #  follow_up_page_id          :integer
 #  language_id                :integer
 #  liquid_layout_id           :integer
+#  post_action_image_id       :integer
 #  primary_image_id           :integer
 #
 # Indexes
@@ -54,6 +56,7 @@
 #  fk_rails_...  (follow_up_liquid_layout_id => liquid_layouts.id)
 #  fk_rails_...  (language_id => languages.id)
 #  fk_rails_...  (liquid_layout_id => liquid_layouts.id)
+#  fk_rails_...  (post_action_image_id => images.id)
 #  fk_rails_...  (primary_image_id => images.id)
 #
 

--- a/spec/requests/api/pages_spec.rb
+++ b/spec/requests/api/pages_spec.rb
@@ -87,6 +87,7 @@ describe 'api/pages' do
         meta_description
         template_name
         follow_up_template
+        post_action_copy
       ]
       expect(subject.keys).to match_array(expected)
       expect(subject.symbolize_keys).to include(title: 'Foo',

--- a/vendor/theme/templates/layouts/post-donate-page-with-recurring-ask.liquid
+++ b/vendor/theme/templates/layouts/post-donate-page-with-recurring-ask.liquid
@@ -7,9 +7,16 @@
 
 <div id="fa-optimisation" data-value="post-donate"></div>
 {% include 'Top Bar' %}
-<div class="cover-photo" style="background-image: url(https://storage.googleapis.com/fa-assets/sou/sou-post-donate-bg.jpg); background-position:top;">
-	<div class="cover-photo__overlay"></div>
-</div>
+{% unless post_action_image.urls.large == blank %}
+	<div class="cover-photo" style="background-image: url({{ post_action_image.urls.large }}); background-position:top;">
+		<div class="cover-photo__overlay"></div>
+	</div>
+{% endunless %}
+{% unless post_action_image.urls.large != blank %}
+	<div class="cover-photo" style="background-image: url(https://storage.googleapis.com/fa-assets/sou/sou-post-donate-bg.jpg); background-position:top;">
+		<div class="cover-photo__overlay"></div>
+	</div>
+{% endunless %}
 <div class="cover-photo__titles">
 	<div class="center-content">
 		<div class="center-content__big-column" style="float:none; margin-left:0px; width:100%; text-align:center;">
@@ -645,6 +652,11 @@ function handleLanguages(){
 
 	var language = $('html').attr('lang');
 
+	if(window.champaign?.page?.post_action_copy !== undefined && window.champaign?.page?.post_action_copy !== '') {
+		console.log('entro**********')
+		$('.en-copy').html(window.champaign.page.post_action_copy);
+	}
+
   switch (language) {
     case 'fr':
       postDonatePage = "https://actions.sumofus.org/a/soutiner-sumofus-donate-french";
@@ -658,6 +670,10 @@ function handleLanguages(){
           thankyou = "Vous êtes fantastique "+name+"!";
           secondFirstname = "Merci, "+name+", ";
       }
+
+	  if(window.champaign?.page?.post_action_copy) {
+		$('.fr-copy').html(window.champaign.page.post_action_copy);
+	  }
 
       $('.fr-copy').show();
       $('.en-copy').hide();
@@ -684,6 +700,10 @@ function handleLanguages(){
     	    secondFirstname = "Vielen Dank, ";
     	}
 
+		if(window.champaign?.page?.post_action_copy) {
+			$('.de-copy').html(window.champaign.page.post_action_copy);
+	  	}
+
       $('.de-copy').show();
       $('.fr-copy').hide();
       $('.en-copy').hide();
@@ -707,6 +727,10 @@ function handleLanguages(){
         thankyou = "¡Eres lo máximo, "+name+"!";
         secondFirstname = "Gracias, "+name+", ";
       }
+
+	  if(window.champaign?.page?.post_action_copy) {
+		$('.es-copy').html(window.champaign.page.post_action_copy);
+	  }
 
       $('.es-copy').show();
       $('.de-copy').hide();
@@ -733,6 +757,10 @@ function handleLanguages(){
         secondFirstname = "Obrigadx "+name+" ";
       }
 
+	  if(window.champaign?.page?.post_action_copy) {
+		$('.pt-copy').html(window.champaign.page.post_action_copy);
+	  }
+
       $('.pt-copy').show();
       $('.es-copy').hide();
       $('.de-copy').hide();
@@ -757,6 +785,10 @@ function handleLanguages(){
           secondFirstname = "";
       }
 
+	  if(window.champaign?.page?.post_action_copy) {
+		$('.nl-copy').html(window.champaign.page.post_action_copy);
+	  }
+
       $('.nl-copy').show();
       $('.de-copy').hide();
       $('.fr-copy').hide();
@@ -780,6 +812,10 @@ function handleLanguages(){
           thankyou = name+"، ما أروعك!";
           secondFirstname = "";
       }
+
+	  if(window.champaign?.page?.post_action_copy) {
+		$('.ar-copy').html(window.champaign.page.post_action_copy);
+	  }
 
 	  $('.ar-copy').show();
       $('.nl-copy').hide();

--- a/vendor/theme/templates/layouts/post-donate-page-with-recurring-ask.liquid
+++ b/vendor/theme/templates/layouts/post-donate-page-with-recurring-ask.liquid
@@ -653,7 +653,6 @@ function handleLanguages(){
 	var language = $('html').attr('lang');
 
 	if(window.champaign?.page?.post_action_copy !== undefined && window.champaign?.page?.post_action_copy !== '') {
-		console.log('entro**********')
 		$('.en-copy').html(window.champaign.page.post_action_copy);
 	}
 
@@ -672,7 +671,7 @@ function handleLanguages(){
       }
 
 	  if(window.champaign?.page?.post_action_copy) {
-		$('.fr-copy').html(window.champaign.page.post_action_copy);
+		 $('.fr-copy').html(window.champaign.page.post_action_copy);
 	  }
 
       $('.fr-copy').show();
@@ -701,7 +700,7 @@ function handleLanguages(){
     	}
 
 		if(window.champaign?.page?.post_action_copy) {
-			$('.de-copy').html(window.champaign.page.post_action_copy);
+			 $('.de-copy').html(window.champaign.page.post_action_copy);
 	  	}
 
       $('.de-copy').show();
@@ -729,7 +728,7 @@ function handleLanguages(){
       }
 
 	  if(window.champaign?.page?.post_action_copy) {
-		$('.es-copy').html(window.champaign.page.post_action_copy);
+		 $('.es-copy').html(window.champaign.page.post_action_copy);
 	  }
 
       $('.es-copy').show();
@@ -758,7 +757,7 @@ function handleLanguages(){
       }
 
 	  if(window.champaign?.page?.post_action_copy) {
-		$('.pt-copy').html(window.champaign.page.post_action_copy);
+		 $('.pt-copy').html(window.champaign.page.post_action_copy);
 	  }
 
       $('.pt-copy').show();
@@ -786,7 +785,7 @@ function handleLanguages(){
       }
 
 	  if(window.champaign?.page?.post_action_copy) {
-		$('.nl-copy').html(window.champaign.page.post_action_copy);
+		 $('.nl-copy').html(window.champaign.page.post_action_copy);
 	  }
 
       $('.nl-copy').show();
@@ -814,7 +813,7 @@ function handleLanguages(){
       }
 
 	  if(window.champaign?.page?.post_action_copy) {
-		$('.ar-copy').html(window.champaign.page.post_action_copy);
+		 $('.ar-copy').html(window.champaign.page.post_action_copy);
 	  }
 
 	  $('.ar-copy').show();


### PR DESCRIPTION
### Overview
* Added two new fields to the page model
    * post_action_copy: If this field has value, then we will show it as the copy of the post donate page with recurring ask instead of the default copy.
    * post_action_image_id: If an image is selected, it will replace the default image of the post donate page with a recurring ask page.
* Campaigners can modify these new fields on champaign edit page, and they will be visible only when the Post Donate Page With Recurring Ask template is selected as the follow-up action.

### Ticket
https://app.asana.com/0/1119304937718815/1202785217719163/f

### Screenshots and Videos
![Screen Shot 2022-09-20 at 12 36 01](https://user-images.githubusercontent.com/15176901/191337582-f6cc9a19-ebcc-4b72-ab0a-e750bdd23a0e.png)


https://user-images.githubusercontent.com/15176901/191337739-c1aa3474-a2ca-4ace-9916-1c8587a9c4a7.mp4

