### PR TITLE
Checking for invalid currency

### DIFF
--- a/app/javascript/plugins/fundraiser/FundraiserView.js
+++ b/app/javascript/plugins/fundraiser/FundraiserView.js
@@ -67,15 +67,7 @@ export class FundraiserView extends Component {
     this.props.setSupportedLocalCurrency(this.supportedLocalCurrency());
     if (donationAmount && donationAmount > 0) {
       this.props.selectAmount(donationAmount);
-
-      const urlParams = new URLSearchParams(window.location.search);
-      const currencyFromUrl = urlParams.get('currency');
-      const currencyFromState = this.props.supportedCurrency(currencyFromUrl);
-      const invalidCurrency =
-        currencyFromState === 'USD' && currencyFromState !== currencyFromUrl;
-      console.log('invalidCurrency', invalidCurrency);
-      console.log('currencyFromState', currencyFromState);
-      if (invalidCurrency === false) {
+      if (this.isValidCurrency() === true) {
         this.props.changeStep(1);
       }
     }
@@ -137,6 +129,22 @@ export class FundraiserView extends Component {
   showStepTwo() {
     const { outstandingFields } = this.props.fundraiser;
     return !outstandingFields || outstandingFields.length !== 0;
+  }
+
+  isValidCurrency() {
+    const { donationBands } = this.props.fundraiser;
+    const supportedCurrencies = Object.keys(donationBands);
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const currencyFromUrl = urlParams.get('currency');
+    if (!currencyFromUrl) return true;
+    const currencyFromState =
+      supportedCurrencies.find(c => c === currencyFromUrl) ||
+      supportedCurrencies[0];
+    const invalidCurrency =
+      currencyFromState === 'USD' && currencyFromState !== currencyFromUrl;
+
+    return !invalidCurrency;
   }
 
   render() {
@@ -299,7 +307,6 @@ export const mapDispatchToProps = dispatch => ({
   setExperimentVariant: value => dispatch(setExperimentVariant(value)),
   setIsCustomAmount: (isCustomAmount, amount) =>
     dispatch(setIsCustomAmount(isCustomAmount, amount)),
-  supportedCurrency: currency => dispatch(supportedCurrency(currency)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(FundraiserView);

--- a/app/javascript/plugins/fundraiser/FundraiserView.js
+++ b/app/javascript/plugins/fundraiser/FundraiserView.js
@@ -23,6 +23,7 @@ import {
   setSupportedLocalCurrency,
   setIsCustomAmount,
 } from '../../state/fundraiser/actions';
+import { supportedCurrency } from '../../state/fundraiser/reducer';
 
 export class FundraiserView extends Component {
   constructor(props) {
@@ -66,7 +67,17 @@ export class FundraiserView extends Component {
     this.props.setSupportedLocalCurrency(this.supportedLocalCurrency());
     if (donationAmount && donationAmount > 0) {
       this.props.selectAmount(donationAmount);
-      this.props.changeStep(1);
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const currencyFromUrl = urlParams.get('currency');
+      const currencyFromState = this.props.supportedCurrency(currencyFromUrl);
+      const invalidCurrency =
+        currencyFromState === 'USD' && currencyFromState !== currencyFromUrl;
+      console.log('invalidCurrency', invalidCurrency);
+      console.log('currencyFromState', currencyFromState);
+      if (invalidCurrency === false) {
+        this.props.changeStep(1);
+      }
     }
   }
 
@@ -288,6 +299,7 @@ export const mapDispatchToProps = dispatch => ({
   setExperimentVariant: value => dispatch(setExperimentVariant(value)),
   setIsCustomAmount: (isCustomAmount, amount) =>
     dispatch(setIsCustomAmount(isCustomAmount, amount)),
+  supportedCurrency: currency => dispatch(supportedCurrency(currency)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(FundraiserView);


### PR DESCRIPTION
### Overview
* When the currency value on the query string parameters is invalid (cannot be mapped to our supported currencies), we default to USD. However, this can be problematic for our members since they expect to donate in their currency.
    * When this scenario happens, we need to land our members on the first step of the fundraiser flow to let them change the currency.

### Ticket
https://app.asana.com/0/1119304937718815/1203048398756348/f