### PR TITLE
Do not check ReCaptcha if the request is coming from cypress

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -144,7 +144,7 @@ class Api::Payment::BraintreeController < PaymentController # rubocop:disable Me
   end
 
   def authenticate_cypress_http_token
-    authenticate_or_request_with_http_token do |token, _options|
+    authenticate_with_http_token do |token, _options|
       return ActiveSupport::SecurityUtils.secure_compare(token, Settings.pronto_api_secret_key)
     end
     false

--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class Api::Payment::BraintreeController < PaymentController
+class Api::Payment::BraintreeController < PaymentController # rubocop:disable Metrics/ClassLength
   include ExceptionHandler
   protect_from_forgery with: :exception, prepend: true
   skip_before_action :verify_authenticity_token, raise: false
   before_action :check_api_key, only: [:refund]
-  before_action :verify_bot, only: [:transaction]
+  before_action :verify_bot, only: [:transaction], if: -> { authenticate_cypress_http_token == false }
 
   def token
     @merchant_account_id = unsafe_params[:merchantAccountId]
@@ -141,6 +141,13 @@ class Api::Payment::BraintreeController < PaymentController
       render json: { success: false, message: msg }, status: :unprocessable_entity
       return false
     end
+  end
+
+  def authenticate_cypress_http_token
+    authenticate_or_request_with_http_token do |token, _options|
+      return ActiveSupport::SecurityUtils.secure_compare(token, Settings.pronto_api_secret_key)
+    end
+    false
   end
 
   def member_matches_payload


### PR DESCRIPTION
### Overview
* Our cypress e2e tests are failing on pronto due to the ReCaptcha verification we enabled last week. 
    * With this PR, we are going to skip the ReCaptcha checks only when the Authorization header is present, and it is valid
        * For this, we use basic HTTP auth with a bearer token, using the pronto API secret.  

### Ticket
https://app.asana.com/0/1119304937718815/1203056138127537/f

### Example Requests

#### Request without the auth header

```console
curl --location --request POST 'http://localhost:3000/api/payment/braintree/pages/{id}/transaction' \
--header 'Content-Type: application/json' \
--header 'Cookie: _session_id=TheSessionId' \
--data-raw '{
  "action_pronto": 1,
  "amount": 1,
  "currency": "USD",
  "recurring": false,
  "store_in_vault": false,
  "user": {
    "action_pronto": 1,
    "name": "Yesi Molina",
    "email": "yesi+aksakdsks@sumofus.org",
    "postal": "31160",
    "country": "US",
    "id": 1234,
    "campaign_slug": "simple-fundraiser"
    },
  "recaptcha_token": "TheToken",
  "recaptcha_action": "recaptcha_action",
  "payment_method_nonce": "payment_method_nonce",
  "device_data": {
    "device_session_id": "device_session",
    "fraud_merchant_id": null,
    "correlation_id": "correlation_id"
    },
  "authenticationId": "authenticationId"
}'
```

Response (failing ReCaptcha):
```json
{
    "success": false,
    "message": {
        "base": [
            "Invalid request"
        ]
    }
}
```

#### Request with the auth header

```console
curl --location --request POST 'http://localhost:3000/api/payment/braintree/pages/{id}/transaction' \
--header 'Authorization: Bearer TheTokenHere' \
--header 'Content-Type: application/json' \
--header 'Cookie: _session_id=_session_id' \
--data-raw '{
  "action_pronto": 1,
  "amount": 1,
  "currency": "USD",
  "recurring": false,
  "store_in_vault": false,
  "user": {
    "action_pronto": 1,
    "name": "Yesi Molina",
    "email": "yesi@sumofus.org",
    "postal": "31160",
    "country": "US",
    "id": 123,
    "campaign_slug": "simple-fundraiser"
    },
  "recaptcha_token": "recaptcha_token",
  "recaptcha_action": "recaptcha_action",
  "payment_method_nonce": "payment_method_nonce",
  "device_data": {
    "device_session_id": "device_session_id",
    "fraud_merchant_id": null,
    "correlation_id": "correlation_id"
    },
  "authenticationId": "authenticationId"
}'
```

Response
```json
{ "success": true, "follow_up_url": "https://my-follow-up-url.org" }
```
