### PR TITLE
Temporarily disabling pronto

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,6 @@ module Champaign
 
     config.i18n.available_locales = %i[en fr de es pt nl ar]
     config.i18n.enforce_available_locales = true
-    config.middleware.use Pronto
   end
 end
 


### PR DESCRIPTION
### Overview
* We will stop redirects to pronto temporarily while we regroup and perform a bug bash, fix all the outstanding issues and experiment again.
