### PR TITLE
 Emit campaignCreated event from Champaign

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,3 +106,5 @@ group :test do
 end
 
 gem "aws-sdk-secretsmanager", "~> 1.21"
+
+gem "aws-sdk-eventbridge", "~> 1.38"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,16 +90,19 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.4.10)
       execjs
-    aws-eventstream (1.0.1)
-    aws-partitions (1.142.0)
-    aws-sdk-core (3.42.0)
-      aws-eventstream (~> 1.0)
-      aws-partitions (~> 1.0)
-      aws-sigv4 (~> 1.0)
-      jmespath (~> 1.0)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.639.0)
+    aws-sdk-core (3.157.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.525.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1, >= 1.6.1)
     aws-sdk-dynamodb (1.21.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
+    aws-sdk-eventbridge (1.38.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-kms (1.13.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
@@ -122,7 +125,8 @@ GEM
     aws-sdk-sqs (1.10.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sigv4 (1.0.3)
+    aws-sigv4 (1.5.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
@@ -266,7 +270,7 @@ GEM
     jbuilder (2.6.4)
       activesupport (>= 3.0.0)
       multi_json (>= 1.2)
-    jmespath (1.4.0)
+    jmespath (1.6.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -584,6 +588,7 @@ DEPENDENCIES
   annotate
   aws-sdk-core (~> 3)
   aws-sdk-dynamodb (~> 1.21)
+  aws-sdk-eventbridge (~> 1.38)
   aws-sdk-rails
   aws-sdk-s3 (~> 1.30)
   aws-sdk-secretsmanager (~> 1.21)
@@ -671,4 +676,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   2.3.16
+   2.3.15

--- a/app/services/campaign_creator.rb
+++ b/app/services/campaign_creator.rb
@@ -18,11 +18,16 @@ class CampaignCreator
   private
 
   def publish_event
-    ChampaignQueue.push(
-      { type: 'create_campaign',
-        name: @campaign.name,
-        campaign_id: @campaign.id },
-      { group_id: "campaign:#{@campaign.id}" }
-    )
+    detail_type = 'campaignCreatedOnChampaign'
+    detail = {
+      name: @campaign.name,
+      id: @campaign.id
+    }
+    EventBridgeService.new
+      .call(detail: detail.to_json,
+            detail_type: detail_type)
+  rescue StandardError => e
+    puts "Error while trying to put campaignCreatedOnChampaign event on pulpo event bus: #{e.message}."
+    {}
   end
 end

--- a/app/services/event_bridge_service.rb
+++ b/app/services/event_bridge_service.rb
@@ -1,0 +1,57 @@
+class EventBridgeService
+  attr_reader :options
+
+  def initialize(options: default_options)
+    @options = options
+    @client = Aws::EventBridge::Client.new(
+      region: @options[:region]
+    )
+  end
+
+  def call(detail:, detail_type:)
+    event_payload = define_event_hash(detail, detail_type)
+    resp = client.put_events(entries: [event_payload])
+    { events: resp.data.entries } if resp.data.failed_entry_count.zero?
+
+    check_errors(resp.data.entries)
+  end
+
+  def check_errors(eventbridge_events)
+    event_arr = []
+
+    eventbridge_events.each do |entry|
+      if entry.error_code.nil?
+        event_arr << entry
+        next
+      end
+      error_msg = "AWS events error code: #{entry.error_code}, message: #{entry.error_message}"
+      Rails.logger.error(error_msg)
+      event_arr << entry
+    end
+
+    { events: event_arr }
+  end
+
+  def define_event_hash(detail, detail_type)
+    {
+      time: Time.zone.now.to_s,
+      source: options[:source],
+      resources: [''],
+      event_bus_name: options[:event_bus_name],
+      detail: detail,
+      detail_type: detail_type
+    }
+  end
+
+  private
+
+  attr_reader :client
+
+  def default_options
+    {
+      region: 'us-east-1',
+      event_bus_name: "PulpoEventBus-#{Settings.aws_secrets_manager_prefix}",
+      source: 'sumofus.org/champaign'
+    }
+  end
+end

--- a/app/services/event_bridge_service.rb
+++ b/app/services/event_bridge_service.rb
@@ -4,7 +4,7 @@ class EventBridgeService
   def initialize(options: default_options)
     @options = options
     @client = Aws::EventBridge::Client.new(
-      region: @options[:region]
+      region: @options[:region], stub_responses: Rails.env.test?
     )
   end
 

--- a/spec/requests/campaigns_spec.rb
+++ b/spec/requests/campaigns_spec.rb
@@ -25,12 +25,7 @@ describe 'Campaigns', type: :request do
       end
 
       it 'publishes the event' do
-        expect(ChampaignQueue).to receive(:push).with(
-          { name: 'Super Campaign',
-            type: 'create_campaign',
-            campaign_id: be_a(Integer) },
-          { group_id: /campaign:\d+/ }
-        )
+        expect(EventBridgeService).to receive_message_chain(:new, :call)
         post '/campaigns', params
       end
     end


### PR DESCRIPTION
### Overview
* The last piece of the serverless project's first milestone is creating campaigns without executing any code from the AK worker. This PR is that last piece.
    * Added the event bridge service to put events on pulpo's bus.
    * Replaced the champaign SQS push with the event bridge service call.

### Ticket
https://app.asana.com/0/1119304937718815/1202737927486106/f

### Demo