### PR TITLE
Post donate settings enhancements

### DIFF
--- a/app/javascript/legacy/campaigner_facing/dropzone_image_upload.js
+++ b/app/javascript/legacy/campaigner_facing/dropzone_image_upload.js
@@ -46,6 +46,9 @@ const initialize = function() {
 const addImageOption = function(file, id, html) {
   const newOption = "<option value='" + id + "'>" + file.name + '</option>';
   $('#page_primary_image_id').append(newOption);
+  if ($('#page_post_action_image_id').length) {
+    $('#page_post_action_image_id').append(newOption);
+  }
 };
 
 const removeImageOption = function(id) {

--- a/app/views/cdn/_campaigner_facing.slim
+++ b/app/views/cdn/_campaigner_facing.slim
@@ -5,3 +5,4 @@
 = render 'cdn/datatables'
 = render 'cdn/typeahead'
 = render 'cdn/speakingurl'
+= javascript_include_tag "https://cdn.tiny.cloud/1/tti67swno0y0j3mzl4zlbmk1rvv8v1lgsms0jngmpdkh6ezt/tinymce/6/tinymce.min.js", referrerpolicy: "origin"

--- a/app/views/pages/_follow_up_action_settings.slim
+++ b/app/views/pages/_follow_up_action_settings.slim
@@ -1,12 +1,28 @@
-- if page.follow_up_liquid_layout.present? && page.follow_up_liquid_layout.title == "Post Donate Page With Recurring Ask"
-  .row
-    .col-md-12
-      = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |f|
-          .form-group
-              = label_with_tooltip(f, :post_action_copy, t('pages.edit.post_donate_settings_text'), t('tooltips.post_donate_settings_text'))
-              = f.text_area :post_action_copy, class: 'form-control', 'max-length' => 140
-    .col-md-7
-      = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |form|
+.row
+  .col-md-12
+    = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |f|
         .form-group
-            = form.label :post_action_image_id, t('pages.edit.post_action_image')
-            = form.select :post_action_image_id, page.images.map{|im| [im.content_file_name, im.id] }, { include_blank: "No image" }, class: 'form-control'
+            = label_with_tooltip(f, :post_action_copy, t('pages.edit.post_donate_settings_text'), t('tooltips.post_donate_settings_text'))
+            = f.text_area :post_action_copy, class: 'tinymce'
+  .col-md-7
+    = form_for page, remote: true, html: {class: 'one-form', data: {type: "page" }} do |form|
+      .form-group
+          = form.label :post_action_image_id, t('pages.edit.post_action_image')
+          = form.select :post_action_image_id, page.images.map{|im| [im.content_file_name, im.id] }, { include_blank: "No image" }, class: 'form-control'
+javascript:
+  tinymce.init({
+    selector: ".tinymce",
+    plugins: "link image help wordcount autosave emoticons save",
+    toolbar: 'undo redo | blocks | ' +
+    'bold italic | ' +
+    'bullist numlist | ' +
+    'removeformat | help | save',
+    autosave_ask_before_unload: true,
+    autosave_interval: '10s',
+    autosave_restore_when_empty: false,
+    autosave_retention: '5m',
+    save_onsavecallback: () => {
+      //This is to avoid a form post
+      console.log('Saved');
+    }
+  });

--- a/app/views/pages/edit.slim
+++ b/app/views/pages/edit.slim
@@ -32,7 +32,7 @@ section.page-edit-step#sources data-icon='link'
   h1.page-edit-step__title = t('.sources')
   = render 'link_form', page: @page
 
-section.page-edit-step#postActionSettings data-icon='post_donate_settings'
+section.page-edit-step.hidden-irrelevant#postActionSettings data-icon='cog'
   h1.page-edit-step__title = t('.post_donate_settings')
   = render 'follow_up_action_settings', page: @page
 
@@ -55,6 +55,9 @@ javascript:
     window.ee.emit("activation:toggle");
     window.ee.emit("shares:edit");
     new PageEditBar();
+    if(#{@page.follow_up_liquid_layout.present?} && #{@page.follow_up_liquid_layout&.title == "Post Donate Page With Recurring Ask"}) {
+      $("#postActionSettings").removeClass('hidden-irrelevant');
+    }
     $(".radio-group__option").on("click", function() {
       try {
         var selectedFollowUpTemplate = $(this).find('.layout-settings__title')[0].innerText;


### PR DESCRIPTION
### Overview
* Introduced an HTML editor for the custom post-action copy to make the new feature easier and more appealing to campaigners.
    * The way it was didn't have an easy way to introduce HTML tags even tho they're supported. 
    * The editor used is the TinyMCE editor (same used by action Kit) with a very simple configuration since, for this specific field, there are a few formats that will get overwritten by the post donate page CSS (like the different alignments options).
* Fixed how the section shows/hides depending on the selected post-action template
* Fixed issue with new images not loading on the post-action settings dropdown 

### TIcket
https://app.asana.com/0/1119304937718815/1202785217719163/f

### Screenshots
![Screen Shot 2022-10-03 at 9 31 10](https://user-images.githubusercontent.com/15176901/193617190-7d0eb745-b7af-4a88-be6a-983832a44748.png)
