### PR TITLE
Publish campaignUpdatedOnChampaign event

### DIFF
--- a/app/services/campaign_updater.rb
+++ b/app/services/campaign_updater.rb
@@ -19,11 +19,16 @@ class CampaignUpdater
   private
 
   def publish_event
-    ChampaignQueue.push(
-      { type: 'update_campaign',
-        name: @campaign.name,
-        campaign_id: @campaign.id },
-      { group_id: "campaign:#{@campaign.id}" }
-    )
+    detail_type = 'campaignUpdatedOnChampaign'
+    detail = {
+      name: @campaign.name,
+      id: @campaign.id
+    }
+    EventBridgeService.new
+      .call(detail: detail.to_json,
+            detail_type: detail_type)
+  rescue StandardError => e
+    puts "Error while trying to put campaignUpdatedOnChampaign event on pulpo event bus: #{e.message}."
+    {}
   end
 end

--- a/spec/requests/campaigns_spec.rb
+++ b/spec/requests/campaigns_spec.rb
@@ -65,11 +65,9 @@ describe 'Campaigns', type: :request do
       end
 
       it 'publishes the event' do
-        expect(ChampaignQueue).to receive(:push).with(
-          { type: 'update_campaign',
-            name: 'Updated Campaign',
-            campaign_id: campaign.id },
-          { group_id: /campaign:\d+/ }
+        expect(EventBridgeService).to receive_message_chain(:new, :call).with(
+          detail_type: 'campaignUpdatedOnChampaign',
+          detail: "{\"name\":\"Updated Campaign\",\"id\":#{campaign.id}}"
         )
         put "/campaigns/#{campaign.id}", params
       end


### PR DESCRIPTION
### Overview
* Once a campaign is updated on Champaign, we need to emit an event to the pulpo event bus instead of pushing a message to the AK worker queue.
    * This is to move towards a serverless, event-driven architecture.
    * The event is listened to by a lambda function that will process it and then update the campaign on action kit.

### Ticket
https://app.asana.com/0/0/1203086766414494/f