### PR TITLE
Added fundraiser plugin to templates

### DIFF
--- a/vendor/theme/templates/layouts/petition-with-large-image.liquid
+++ b/vendor/theme/templates/layouts/petition-with-large-image.liquid
@@ -15,7 +15,9 @@
     'stuck-right not-sticky gdpr consent-variant-togglable-buttons'  %}
   </div>
 </div>
-
+<div class="hidden-irrelevant">
+  {% include'Fundraiser', freestanding: true, fundraiser_title: fundraiser_title %}
+</div>
 {% include 'Petition Mobile Footer' %}
 {% include 'Simple Footer' %}
 

--- a/vendor/theme/templates/layouts/petition-without-image.liquid
+++ b/vendor/theme/templates/layouts/petition-without-image.liquid
@@ -42,7 +42,9 @@
     </div>
   </div>
 </div>
-
+<div class="hidden-irrelevant">
+  {% include'Fundraiser', freestanding: true, fundraiser_title: fundraiser_title %}
+</div>
 {% include 'Petition Mobile Footer' %}
 {% include 'Small Image Footer' %}
 

--- a/vendor/theme/templates/partials/_petition_with_small_image.liquid
+++ b/vendor/theme/templates/partials/_petition_with_small_image.liquid
@@ -29,6 +29,8 @@
 
   </div>
 </div>
-
+<div class="hidden-irrelevant">
+  {% include'Fundraiser', freestanding: true, fundraiser_title: fundraiser_title %}
+</div>
 {% include 'Petition Mobile Footer' %}
 {% include 'Small Image Footer' %}


### PR DESCRIPTION
### Overview
* This is a patch for #2063. I discovered that some petition templates didn't have the fundraiser plugin. Therefore we cannot force a petition that has it on them because we will not have the information to render the page correctly.
    * I added the fundraiser plugin to those templates as a hidden div, so if we don't force any template on them, the page will render correctly without showing the donation form (as it was first designed).

### Ticket

https://app.asana.com/0/1119304937718815/1203050335588363/f