### PR TITLE
Revert sending events to pulpo until pages services are done

### DIFF
--- a/app/services/campaign_creator.rb
+++ b/app/services/campaign_creator.rb
@@ -18,16 +18,11 @@ class CampaignCreator
   private
 
   def publish_event
-    detail_type = 'campaignCreatedOnChampaign'
-    detail = {
-      name: @campaign.name,
-      id: @campaign.id
-    }
-    EventBridgeService.new
-      .call(detail: detail.to_json,
-            detail_type: detail_type)
-  rescue StandardError => e
-    puts "Error while trying to put campaignCreatedOnChampaign event on pulpo event bus: #{e.message}."
-    {}
+    ChampaignQueue.push(
+      { type: 'create_campaign',
+        name: @campaign.name,
+        campaign_id: @campaign.id },
+      { group_id: "campaign:#{@campaign.id}" }
+    )
   end
 end

--- a/app/services/campaign_updater.rb
+++ b/app/services/campaign_updater.rb
@@ -19,16 +19,11 @@ class CampaignUpdater
   private
 
   def publish_event
-    detail_type = 'campaignUpdatedOnChampaign'
-    detail = {
-      name: @campaign.name,
-      id: @campaign.id
-    }
-    EventBridgeService.new
-      .call(detail: detail.to_json,
-            detail_type: detail_type)
-  rescue StandardError => e
-    puts "Error while trying to put campaignUpdatedOnChampaign event on pulpo event bus: #{e.message}."
-    {}
+    ChampaignQueue.push(
+      { type: 'update_campaign',
+        name: @campaign.name,
+        campaign_id: @campaign.id },
+      { group_id: "campaign:#{@campaign.id}" }
+    )
   end
 end

--- a/spec/requests/campaigns_spec.rb
+++ b/spec/requests/campaigns_spec.rb
@@ -25,7 +25,12 @@ describe 'Campaigns', type: :request do
       end
 
       it 'publishes the event' do
-        expect(EventBridgeService).to receive_message_chain(:new, :call)
+        expect(ChampaignQueue).to receive(:push).with(
+          { name: 'Super Campaign',
+            type: 'create_campaign',
+            campaign_id: be_a(Integer) },
+          { group_id: /campaign:\d+/ }
+        )
         post '/campaigns', params
       end
     end
@@ -65,9 +70,11 @@ describe 'Campaigns', type: :request do
       end
 
       it 'publishes the event' do
-        expect(EventBridgeService).to receive_message_chain(:new, :call).with(
-          detail_type: 'campaignUpdatedOnChampaign',
-          detail: "{\"name\":\"Updated Campaign\",\"id\":#{campaign.id}}"
+        expect(ChampaignQueue).to receive(:push).with(
+          { type: 'update_campaign',
+            name: 'Updated Campaign',
+            campaign_id: campaign.id },
+          { group_id: /campaign:\d+/ }
         )
         put "/campaigns/#{campaign.id}", params
       end


### PR DESCRIPTION
### Overview
* I didn't notice an issue dependency between the pages and campaigns; when a campaign is created on Champaign, that campaign is now added to a dynamo table, and all subsequent updates are done in pulpo; that's great. However, this raises an issue when we assign a campaign to a page; since that is still happening on the worker, the campaign doesn't get assigned to the page (only on Champaigns DB but not on action Kit) because the campaign information does not exist on redis.
    * The consequences of this could be that when the campaigners want to get all the action count for a campaign, they won't get the correct results of all the sum of the pages tied to a campaign.
    * I updated the pages using pulpo's campaigns on AK (there were only 9 campaigns so far)

### Next Steps
* Revert this PR once the next [milestone](https://app.asana.com/0/1202246621543866/1202807663308199/f) for the serverless project is done.
* Inform Simona about this issue.
