### PR TITLE
Adding new fb pixel event

### DIFF
--- a/vendor/theme/templates/layouts/Default:-petition-and-scroll-to-donate-greenpeace.liquid
+++ b/vendor/theme/templates/layouts/Default:-petition-and-scroll-to-donate-greenpeace.liquid
@@ -142,6 +142,9 @@
     window.ee.on('action:submitted_success', function () {
       var formData = window.champaign.myActionForm.formData();
       $('.inject-name').text(formData.name.split(' ')[0]);
+      if (typeof window.fbq === 'function') {
+        window.fbq('track', 'ActionSubmitted');
+      }
     });
 
     var interval = setInterval(function() {

--- a/vendor/theme/templates/layouts/Default:-petition-and-scroll-to-share-greenpeace.liquid
+++ b/vendor/theme/templates/layouts/Default:-petition-and-scroll-to-share-greenpeace.liquid
@@ -184,6 +184,9 @@ endcomment %} {% comment %} Primary layout: true {% endcomment %}
     window.ee.on('action:submitted_success', function () {
       var formData = window.champaign.myActionForm.formData();
       $('.inject-name').text(formData.name.split(' ')[0]);
+      if (typeof window.fbq === 'function') {
+        window.fbq('track', 'ActionSubmitted');
+      }
     });
     window.addEventListener(
       "share",

--- a/vendor/theme/templates/layouts/end-of-year-scroll-to-share-2020.liquid
+++ b/vendor/theme/templates/layouts/end-of-year-scroll-to-share-2020.liquid
@@ -231,6 +231,9 @@
       console.log("Action submitted, inject name");
       var formData = window.champaign.myActionForm.formData();
       $('.inject-name').text(formData.name.split(' ')[0]);
+      if (typeof window.fbq === 'function') {
+        window.fbq('track', 'ActionSubmitted');
+      }
     });
     window.addEventListener(
       "share",


### PR DESCRIPTION
### Overview
We're currently using the `CompleteRegistration` event on the FaceBook Ads manager to track conversions; however, that event can trigger more than once per action.
This PR will add a new event that only fires on successful action submissions.