### PR TITLE
One click error handling

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -30,6 +30,8 @@ class Api::Payment::BraintreeController < PaymentController # rubocop:disable Me
         member: recognized_member,
         cookied_payment_methods: params.to_unsafe_hash['payment_method_ids']
       ).process
+    rescue PaymentProcessor::Exceptions::BraintreePaymentError => e
+      render json: { error: e.message, success: false }, status: 500
     rescue ArgumentError => e
       @status = 400
       @status = 404 if e.to_s == 'PaymentProcessor::Exceptions::CustomerNotFound'

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,6 +13,7 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
   before_action :localize, only: %i[show follow_up double_opt_in_notice]
   before_action :record_tracking, only: %i[show]
 
+  attr_reader :error_code
   def index
     @pages = Search::PageSearcher.search(search_params)
   end
@@ -99,7 +100,9 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
     end
   end
 
-  attr_writer :error_code
+  def set_error_code(code)
+    @error_code = code
+  end
 
   def double_opt_in_notice
     @rendered = renderer.render_custom_without_cache('Double Opt In Follow Up',
@@ -200,7 +203,7 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
       cookied_payment_methods: cookies.signed[:payment_methods]
     ).process
   rescue PaymentProcessor::Exceptions::BraintreePaymentError => e
-    error_code(e.message)
+    set_error_code(e.message)
     @process_one_click = false
   rescue StandardError
     @process_one_click = false

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -91,10 +91,7 @@ class PagesController < ApplicationController # rubocop:disable Metrics/ClassLen
     else
       @rendered = renderer.render
       @data = renderer.personalization_data
-      @error = {
-        declined: true,
-        code: error_code
-      }
+      @error = error_code
       render :show, layout: 'member_facing', error: @error
       return
     end

--- a/app/javascript/components/Payment/Payment.js
+++ b/app/javascript/components/Payment/Payment.js
@@ -64,9 +64,7 @@ export class Payment extends Component {
         paypal: true,
         card: true,
       },
-      errors: window.champaign.personalization.braintreeErrorCode.length
-        ? errors
-        : [],
+      errors: window.champaign.oneClickErrorCode?.length ? errors : [],
       waitingForGoCardless: false,
     };
   }

--- a/app/javascript/components/Payment/Payment.js
+++ b/app/javascript/components/Payment/Payment.js
@@ -38,6 +38,8 @@ import './Payment.css';
 const BRAINTREE_TOKEN_URL =
   process.env.BRAINTREE_TOKEN_URL || '/api/payment/braintree/token';
 const LOCAL_PAYMENT_PROVIDERS = ['ideal', 'giropay'];
+// TODO: Handle each code independently
+const errors = [<FormattedMessage id="fundraiser.unknown_error" />];
 
 export class Payment extends Component {
   static title = (<FormattedMessage id="payment" defaultMessage="payment" />);
@@ -62,7 +64,9 @@ export class Payment extends Component {
         paypal: true,
         card: true,
       },
-      errors: [],
+      errors: window.champaign.personalization.braintreeErrorCode.length
+        ? errors
+        : [],
       waitingForGoCardless: false,
     };
   }

--- a/app/lib/payment_processor/braintree/one_click.rb
+++ b/app/lib/payment_processor/braintree/one_click.rb
@@ -22,7 +22,11 @@ module PaymentProcessor::Braintree
         action = create_action(extra_fields(sale))
         store_locally(sale, action)
       else
-        raise "Error while making a sale transaction on BrainTree: #{sale}" unless sale.success?
+        error_code = sale.transaction.processor_response_code
+        Rails.logger.error(
+          "Error while making a sale transaction on BrainTree: #{sale.message} code: #{error_code}"
+        )
+        raise PaymentProcessor::Exceptions::BraintreePaymentError, sale.transaction.processor_response_code.to_s
       end
 
       sale

--- a/app/lib/payment_processor/exceptions.rb
+++ b/app/lib/payment_processor/exceptions.rb
@@ -5,5 +5,6 @@ module PaymentProcessor
     class InvalidCurrency < ArgumentError; end
     class PaymentMethodNotFound < ArgumentError; end
     class CustomerNotFound < ArgumentError; end
+    class BraintreePaymentError < StandardError; end
   end
 end

--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -31,7 +31,7 @@ html lang="#{@page.language.try(:code).try(:downcase)}" dir=("#{@page.language.t
     = render partial: "layouts/mixpanel" if Settings.mixpanel_token
     = render partial: "shared/js_locale"
     = render partial: "shared/champaign_object"
-    = render "pages/personalization", data: @data
+    = render "pages/personalization", data: @data, error: @error
 
     = stylesheet_link_tag "member-facing"
     = stylesheet_packs_with_chunks_tag "globals", "member_facing", "plugins"

--- a/app/views/layouts/member_facing.slim
+++ b/app/views/layouts/member_facing.slim
@@ -30,8 +30,8 @@ html lang="#{@page.language.try(:code).try(:downcase)}" dir=("#{@page.language.t
 
     = render partial: "layouts/mixpanel" if Settings.mixpanel_token
     = render partial: "shared/js_locale"
-    = render partial: "shared/champaign_object"
-    = render "pages/personalization", data: @data, error: @error
+    = render partial: "shared/champaign_object", error: @error
+    = render "pages/personalization", data: @data
 
     = stylesheet_link_tag "member-facing"
     = stylesheet_packs_with_chunks_tag "globals", "member_facing", "plugins"

--- a/app/views/pages/_personalization.slim
+++ b/app/views/pages/_personalization.slim
@@ -15,6 +15,5 @@ javascript:
     location: #{ serialize(data, 'location') },
     member: #{serialize(data, 'member') },
     id_mismatch: #{serialize(data, 'id_mismatch') },
-    forcedDonateLayout: #{serialize(data, 'forced_donate_layout') },
-    braintreeErrorCode: #{serialize(error, 'code') }
+    forcedDonateLayout: #{serialize(data, 'forced_donate_layout') }
   }

--- a/app/views/pages/_personalization.slim
+++ b/app/views/pages/_personalization.slim
@@ -16,4 +16,5 @@ javascript:
     member: #{serialize(data, 'member') },
     id_mismatch: #{serialize(data, 'id_mismatch') },
     forcedDonateLayout: #{serialize(data, 'forced_donate_layout') },
+    braintreeErrorCode: #{serialize(error, 'code') }
   }

--- a/app/views/shared/_champaign_object.slim
+++ b/app/views/shared/_champaign_object.slim
@@ -3,4 +3,5 @@ javascript:
     configuration: #{global_config.to_json.html_safe},
     page: #{page_object(@page).to_json.html_safe},
     plugins: #{plugins_config(@page).to_json.html_safe},
+    oneClickErrorCode: #{@error.to_json.html_safe}
   };


### PR DESCRIPTION
### Overview
* If there is a failure on express donations (a member has saved payment methods and clicked on a one-click link from a fundraiser), we don't currently show any error message on the UI.
    * This PR passes the error code back to the front end, where we can show a generic error message.
        * The follow-up for this will be handling each error code independently to show better error messages for the members, however, there is a separate [task](https://app.asana.com/0/1119304937718815/1203423804221590/f) to do it, but we are waiting for translations. **This ticket will only show an error message on the UI**. 
    * Return the error code on the express_donation and one_click endpoints, too, as pronto is using them, and we need to handle the errors there as well. 
    * Improved the logging as we logged the error without details such as the error code and specific error message returned by Braintree.
        * Before: `RuntimeError (Error while making a sale transaction on BrainTree: #<Braintree::ErrorResult:0x0000564358120060>):`
        * After: `Error while making a sale transaction on BrainTree: Declined - Call Issuer code: 2044` 

### Ticket
https://app.asana.com/0/1119304937718815/1203423804221592/f

### Video

https://user-images.githubusercontent.com/15176901/204346799-fd6206c0-1108-4148-ac84-328a48aed26b.mp4

