### PR TITLE
Braintree error handling

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -65,6 +65,9 @@ class Api::Payment::BraintreeController < PaymentController # rubocop:disable Me
   def one_click
     @result = client::OneClick.new(unsafe_params, cookies.signed[:payment_methods], member).run
     render status: :unprocessable_entity, errors: oneclick_payment_errors unless @result.success?
+  rescue PaymentProcessor::Exceptions::BraintreePaymentError => e
+    @result = e
+    render status: :unprocessable_entity, errors: e.message
   end
 
   private

--- a/app/javascript/components/Payment/Payment.js
+++ b/app/javascript/components/Payment/Payment.js
@@ -31,6 +31,7 @@ import {
 } from '../../state/fundraiser/actions';
 import ExpressDonation from '../ExpressDonation/ExpressDonation';
 import { isDirectDebitSupported } from '../../util/directDebitDecider';
+import { getErrorsByCode } from '../../util/getBraintreeErrorMessages';
 
 // Styles
 import './Payment.css';
@@ -38,8 +39,6 @@ import './Payment.css';
 const BRAINTREE_TOKEN_URL =
   process.env.BRAINTREE_TOKEN_URL || '/api/payment/braintree/token';
 const LOCAL_PAYMENT_PROVIDERS = ['ideal', 'giropay'];
-// TODO: Handle each code independently
-const errors = [<FormattedMessage id="fundraiser.unknown_error" />];
 
 export class Payment extends Component {
   static title = (<FormattedMessage id="payment" defaultMessage="payment" />);
@@ -64,7 +63,9 @@ export class Payment extends Component {
         paypal: true,
         card: true,
       },
-      errors: window.champaign.oneClickErrorCode?.length ? errors : [],
+      errors: window.champaign.oneClickErrorCode?.length
+        ? getErrorsByCode(window.champaign.oneClickErrorCode)
+        : [],
       waitingForGoCardless: false,
     };
   }
@@ -496,8 +497,8 @@ export class Payment extends Component {
       response.responseJSON.errors
     ) {
       errors = response.responseJSON.errors.map(function(error) {
-        if (error.declined) {
-          return <FormattedMessage id="fundraiser.card_declined" />;
+        if (error.code) {
+          return getErrorsByCode(error.code);
         } else {
           return error.message;
         }

--- a/app/javascript/util/getBraintreeErrorMessages.js
+++ b/app/javascript/util/getBraintreeErrorMessages.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+export function getErrorsByCode(code) {
+  let errors = [];
+  switch (code) {
+    case '':
+    case undefined:
+      break;
+    case '2000':
+    case '2044':
+    case '2046':
+      errors = [<FormattedMessage id="fundraiser.bank_rejected_error" />];
+      break;
+    case '2005':
+    case '2006':
+    case '2010':
+      errors = [<FormattedMessage id="fundraiser.transaction_declined" />];
+      break;
+    case '2001':
+      errors = [
+        <FormattedMessage id="fundraiser.insufficient_funds" />,
+        <FormattedMessage id="fundraiser.try_again" />,
+      ];
+      break;
+    case '2004':
+      errors = [
+        <FormattedMessage id="fundraiser.expired_card" />,
+        <FormattedMessage id="fundraiser.try_again" />,
+      ];
+      break;
+    case '2074':
+      errors = [
+        <FormattedMessage id="fundraiser.paypal_transaction_declined" />,
+      ];
+      break;
+    default:
+      errors = [<FormattedMessage id="fundraiser.unknown_error" />];
+      break;
+  }
+
+  return errors;
+}

--- a/app/views/api/payment/braintree/one_click.json.jbuilder
+++ b/app/views/api/payment/braintree/one_click.json.jbuilder
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
-json.success @result.success?
-unless @result.success?
+json.success !@result.is_a?(PaymentProcessor::Exceptions::BraintreePaymentError) && !@result.try(:success).nil? && @result.success?
+unless @result.is_a?(PaymentProcessor::Exceptions::BraintreePaymentError) && @result.try(:success).nil?
   json.params @result.params
   json.errors @result.errors
   json.message @result.message
   json.immediate_redonation @result.try(:immediate_redonation)
+end
+
+if @result.is_a?(PaymentProcessor::Exceptions::BraintreePaymentError)
+  json.errorCode @result
+  json.immediate_redonation false
 end

--- a/app/views/api/payment/braintree/one_click.json.jbuilder
+++ b/app/views/api/payment/braintree/one_click.json.jbuilder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 json.success !@result.is_a?(PaymentProcessor::Exceptions::BraintreePaymentError) && !@result.try(:success).nil? && @result.success?
-unless @result.is_a?(PaymentProcessor::Exceptions::BraintreePaymentError) && @result.try(:success).nil?
+unless @result.is_a?(PaymentProcessor::Exceptions::BraintreePaymentError) || @result.is_a?(Braintree::SuccessfulResult)
   json.params @result.params
   json.errors @result.errors
   json.message @result.message

--- a/config/locales/member_facing.ar.yml
+++ b/config/locales/member_facing.ar.yml
@@ -120,6 +120,13 @@ ar:
     thank_you_with_amount: "<strong>شكراً لتبرّعك بمبلغ %{amount}!</strong> إذا كانت لديك أيّ أسئلة، أو إذا كنت قد أتممت التبرّع بالخطأ، يُرجى مراسلتنا على العنوان donations@sumofus.org."
     recurring_thank_you_with_amount: "<strong>شكراً لتبرّعك الدوري بمبلغ %{amount}! </strong> إذا كانت لديك أيّ أسئلة، أو إذا كنت قد أتممت التبرّع بالخطأ، يُرجى مراسلتنا على العنوان donations@sumofus.org."
 
+    bank_rejected_error: "Your bank is unwilling to accept the transaction. Please contact your bank or try with a different payment method."
+    transaction_declined: "Transaction declined: please verify your information or try with a different payment method."
+    insufficient_funds: "Transaction declined: Insufficient Funds. "
+    expired_card: "Transaction declined: Expired card. "
+    paypal_transaction_declined: "Your PayPal transaction has been declined by the processor or your bank. Please try with a different payment method."
+    try_again: "Please try again with a different payment method."
+
     card_declined: تمّ رفض بطاقتك من قبل معالج الدفع. يُرجى تجربة طريقة دفع مختلفة.
     unknown_error: "تمّ إبلاغ فريقنا التقني. يُرجى التأكّد من معلوماتك أو محاولة طريقة دفعٍ أخرى. "
     fine_print: "التبرّعات لصالحنا ليست معفاة من الضرائب. لمزيد من المعلومات، الرجاء مراسلتنا عبر البريد الإلكتروني." # override this with org-specific details in your own yml file.

--- a/config/locales/member_facing.de.yml
+++ b/config/locales/member_facing.de.yml
@@ -102,6 +102,14 @@ de:
     thank_you: Vielen Dank!
     thank_you_with_amount: "<strong>Vielen Dank für Ihre Spende in Höhe von %{amount}!</strong> Sie haben Fragen oder versehentlich gespendet? Dann schreiben Sie uns an  hallo@sumofus.org."
     recurring_thank_you_with_amount: "<strong> Vielen Dank für Ihre regelmäßige Spende in Höhe von %{amount}!</strong> Falls Sie eine Frage an uns haben oder diese Spende unabsichtlich getätigt haben, schreiben Sie uns gern eine Nachricht an hallo@sumofus.org."
+    
+    bank_rejected_error: "Ihre Bank akzeptiert die Transaktion nicht. Bitte kontaktieren Sie Ihre Bank oder versuchen Sie es mit einer anderen Zahlungsmethode."
+    transaction_declined: "Transaktion abgelehnt: Bitte überprüfen Sie Ihre Angaben oder versuchen Sie es mit einer anderen Zahlungsmethode."
+    insufficient_funds: "Transaktion abgelehnt: Unzureichende Kontodeckung. "
+    expired_card: "Transaktion abgelehnt: Abgelaufene Karte. "
+    paypal_transaction_declined: "Ihre PayPal-Transaktion wurde vom Prozessor oder Ihrer Bank abgelehnt. Bitte versuchen Sie es mit einer anderen Zahlungsmethode."
+    try_again: "Bitte versuchen Sie es erneut mit einer anderen Zahlungsmethode."
+
     card_declined: Der Zahlungsdienst hat Ihre Kreditkarte nicht akzeptiert. Bitte wählen Sie eine andere Zahlungsmethode.
     unknown_error: Unbekannter Fehler. Unser Team wurde benachrichtigt. Bitte überprüfen Sie Ihre Eingaben oder wählen Sie eine andere Zahlungsmethode.
     fine_print: "Donations are not tax deductable. For more information please email us."

--- a/config/locales/member_facing.en.yml
+++ b/config/locales/member_facing.en.yml
@@ -116,6 +116,13 @@ en:
     thank_you_with_amount: "<strong>Thank you for your donation of %{amount}!</strong> If you have any questions or made this donation in error, please email donations@sumofus.org."
     recurring_thank_you_with_amount: "<strong>Thank you for your recurring donation of %{amount}!</strong> If you have any questions or made this donation in error, please email donations@sumofus.org."
 
+    bank_rejected_error: "Your bank is unwilling to accept the transaction. Please contact your bank or try with a different payment method."
+    transaction_declined: "Transaction declined: please verify your information or try with a different payment method."
+    insufficient_funds: "Transaction declined: Insufficient Funds. "
+    expired_card: "Transaction declined: Expired card. "
+    paypal_transaction_declined: "Your PayPal transaction has been declined by the processor or your bank. Please try with a different payment method."
+    try_again: "Please try again with a different payment method."
+
     card_declined: Your card was declined by the payment processor. Please try a different payment method.
     unknown_error: Our technical team has been notified. Please double check your info or try a different payment method.
     fine_print: "Donations are not tax deductable. For more information please email us." # override this with org-specific details in your own yml file.

--- a/config/locales/member_facing.es.yml
+++ b/config/locales/member_facing.es.yml
@@ -112,6 +112,13 @@ es:
     thank_you_with_amount: "<strong> Gracias por tu donación de %{amount}!</strong> Si tienes alguna duda o realizaste esta donación por error, contáctanos vía correo electrónico a donations@sumofus.org."
     recurring_thank_you_with_amount: "<strong>Thank you for your recurring donation of %{amount}!</strong> If you have any questions or made this donation in error, please email donations@sumofus.org."
 
+    bank_rejected_error: "Su banco no está dispuesto a aceptar la transacción. Póngase en contacto con su banco o intente con otro método de pago."
+    transaction_declined: "Transacción rechazada: verifique su información o intente con otro método de pago."
+    insufficient_funds: "Transacción rechazada: fondos insuficientes. "
+    expired_card: "Transacción rechazada: tarjeta vencida. "
+    paypal_transaction_declined: "Su transacción de PayPal ha sido rechazada por el procesador o su banco. Intente con otro método de pago."
+    try_again: "Por favor vuelva a intentarlo con otro método de pago."
+
     card_declined: 'Tu tarjeta ha sido rechazada por el procesador de pagos. Intenta utilizar un medio de pago distinto.'
     unknown_error: Nuestro equipo técnico ha sido notificado. Por favor revise su información o pruebe con un método de pago diferente.
     fine_print: "Donations are not tax deductable. For more information please email us." # override this with org-specific details in your own yml file.

--- a/config/locales/member_facing.fr.yml
+++ b/config/locales/member_facing.fr.yml
@@ -98,6 +98,14 @@ fr:
     thank_you: Nous vous remercions pour votre don !
     thank_you_with_amount: "<strong>Merci pour votre don de %{amount} !</strong> si vous avez la moindre question ou si vous avez fait ce don par erreur, veuillez nous contacter via donations@sumofus.org."
     recurring_thank_you_with_amount: "<strong>Merci pour votre don régulier de %{amount} !</strong> Si vous avez la moindre question ou si vous avez fait ce don par erreur, veuillez nous contacter via donations@sumofus.org."
+    
+    bank_rejected_error: "Votre banque a refusé de valider la transaction. Veuillez contacter votre banque ou essayer avec un autre mode de paiement."
+    transaction_declined: "Transaction refusée : veuillez vérifier vos informations ou essayer avec une autre méthode de paiement."
+    insufficient_funds: "Transaction refusée : Fonds insuffisants. "
+    expired_card: "Transaction refusée : Carte bancaire expirée. "
+    paypal_transaction_declined: "Votre transaction PayPal a été refusée par le processeur ou par votre banque. Veuillez essayer avec un autre mode de paiement."
+    try_again: "Veuillez réessayer avec un autre mode de paiement s'il vous plaît."
+    
     card_declined: Votre carte a été refusée par le service de paiement. Veuillez choisir une autre méthode de paiement.
     unknown_error: Notre équipe technique a été notifiée de ce problème. Veuillez revérifier vos informations ou choisir une autre méthode de paiement.
     fine_print: "Les dons ne sont pas déductibles de vos impôts. Pour plus d’information, contactez-nous."

--- a/config/locales/member_facing.nl.yml
+++ b/config/locales/member_facing.nl.yml
@@ -112,6 +112,14 @@ nl: # translated 22 July 2021
     thank_you: Bedankt voor je donatie!
     thank_you_with_amount: "<strong>Bedankt voor je donatie van %{amount}!</strong> Als je vragen hebt of deze donatie per vergissing hebt gedaan, stuur dan een e-mail naar donations@sumofus.org. "
     recurring_thank_you_with_amount: "<strong>Bedankt voor je terugkerende donatie van  %{amount}!</strong> Als je vragen hebt of deze donatie per vergissing hebt gedaan, stuur dan een e-mail naar donations@sumofus.org."
+    
+    bank_rejected_error: "Your bank is unwilling to accept the transaction. Please contact your bank or try with a different payment method."
+    transaction_declined: "Transaction declined: please verify your information or try with a different payment method."
+    insufficient_funds: "Transaction declined: Insufficient Funds. "
+    expired_card: "Transaction declined: Expired card. "
+    paypal_transaction_declined: "Your PayPal transaction has been declined by the processor or your bank. Please try with a different payment method."
+    try_again: "Please try again with a different payment method."
+    
     card_declined: Je kaart werd geweigerd door de betalingsverwerker. Gelieve een andere betaalmethode te proberen.
     unknown_error: Ons technisch team is op de hoogte gebracht. Gelieve nogmaals je gegevens te controleren of een andere betaalmethode te proberen.
     fine_print: "Donaties zijn niet belastingaftrekbaar. Voor meer informatie kun je ons mailen. " # override this with org-specific details in your own yml file.

--- a/config/locales/member_facing.pt.yml
+++ b/config/locales/member_facing.pt.yml
@@ -116,6 +116,13 @@ pt:
     thank_you_with_amount: "<strong>Agradecemos a sua doação de %{amount}!</strong> Se tiver qualquer dúvida ou se fez essa doação por engano, por favor, envie um e-mail para donations@sumofus.org."
     recurring_thank_you_with_amount: "<strong>Agradecemos a sua doação recorrente de %{amount}!</strong> Se tiver qualquer dúvida ou se fez essa doação por engano, por favor, envie um e-mail para donations@sumofus.org."
 
+    bank_rejected_error: "Your bank is unwilling to accept the transaction. Please contact your bank or try with a different payment method."
+    transaction_declined: "Transaction declined: please verify your information or try with a different payment method."
+    insufficient_funds: "Transaction declined: Insufficient Funds. "
+    expired_card: "Transaction declined: Expired card. "
+    paypal_transaction_declined: "Your PayPal transaction has been declined by the processor or your bank. Please try with a different payment method."
+    try_again: "Please try again with a different payment method."
+
     card_declined: Seu cartão foi recusado pelo processador do pagamento. Por favor, tente novamente com um método de pagamento diferente.
     unknown_error: Nossa equipe técnica foi notificada. Por favor, verifique suas informações novamente ou tente um método de pagamento diferente.
     fine_print: "As doações não são dedutíveis de impostos. Para obter maiores informações, nos envie um e-mail." # override this with org-specific details in your own yml file.


### PR DESCRIPTION
### Overview
* We don't currently provide insightful error messages when there is an error making a transaction on Braintree.
    * Added better messaging for members based on the most common errors we get from Braintree (taken from the analysis we did for August to November).
        * For declined transactions, we are showing a less generic error message but not saying when a transaction failed due to failed 3ds, bad CVV, or any other security-related error code to avoid saying too much for bad actors. 

### Ticket
https://app.asana.com/0/1119304937718815/1203423804221590/f

### Screenshots
<details>
  <summary>Regular flow</summary>

![Screen Shot 2022-11-28 at 16 42 22](https://user-images.githubusercontent.com/15176901/204396420-878b08d3-3377-4ab9-8404-8a6f3386a2f0.png)

![Screen Shot 2022-11-28 at 16 41 52](https://user-images.githubusercontent.com/15176901/204396430-4aad2e90-f966-4737-8ded-6281a05ef9d2.png)

</details> 

<details>
  <summary>One click (From URL)</summary>

![Screen Shot 2022-11-28 at 16 22 36](https://user-images.githubusercontent.com/15176901/204395339-8de5ad6f-72b5-41de-abbb-95cc194477a7.png)

![Screen Shot 2022-11-28 at 16 22 49](https://user-images.githubusercontent.com/15176901/204395395-591522aa-fe83-4d4d-9d31-c9f48ecccf27.png)

![Screen Shot 2022-11-28 at 16 23 09](https://user-images.githubusercontent.com/15176901/204395404-13a9068b-4014-49f4-b2d4-8cf3e2b3485f.png)


</details> 


<details>
  <summary>Express Donation</summary>

![Screen Shot 2022-11-28 at 16 23 37](https://user-images.githubusercontent.com/15176901/204395481-1f7410f0-1747-4483-8e40-0e8dfd34b5ec.png)

![Screen Shot 2022-11-28 at 16 23 54](https://user-images.githubusercontent.com/15176901/204395498-6f924bd7-d59e-43d4-9fba-22d734e63277.png)

</details> 

<details>
  <summary>Other languages</summary>

![Screen Shot 2022-11-28 at 16 26 24](https://user-images.githubusercontent.com/15176901/204395757-c6c1090e-c3cc-48b0-aa58-cdce8bd4376d.png)

![Screen Shot 2022-11-28 at 16 25 30](https://user-images.githubusercontent.com/15176901/204395741-4c3be8bb-4600-4146-8ffd-f465d1e34559.png)

![Screen Shot 2022-11-28 at 16 26 44](https://user-images.githubusercontent.com/15176901/204395745-785ae06e-5e7f-430f-a6fe-d18530c7be46.png)

</details> 


