### PR TITLE
Patch 3ds blank popup after transaction error

### DIFF
--- a/app/javascript/components/Braintree/BraintreeCardFields.js
+++ b/app/javascript/components/Braintree/BraintreeCardFields.js
@@ -210,9 +210,8 @@ class BraintreeCardFields extends Component {
               });
           } else {
             resolve(data);
+            this.teardown();
           }
-
-          this.teardown();
         }
       );
     });


### PR DESCRIPTION
### Overview
* Yasmin found an edge case while testing #2075. The issue happens when you try to donate with a 3DS verification and the donation fails for any reason, like canceling the 3ds verification, an expired card, or anything else. Then you try to resubmit the transaction (either changing anything on the form or not) in the second attempt; the 3DS iframe will show an error; however, on the third attempt, it will work.
    * I researched, and it is because the teardown of the hosted fields was happening even though the transaction wasn't successful. This only happens when the 3DS verification is triggered.
        * Moved the teardown call to the right place. 

### Demo

https://user-images.githubusercontent.com/15176901/206266638-0cbe61d1-6984-4fbc-bc4e-8f9409348a89.mp4

