### PR TITLE
Skip Braintree 3DS verification if BT throws unsupported_card error

### DIFF
--- a/app/controllers/api/payment/braintree_controller.rb
+++ b/app/controllers/api/payment/braintree_controller.rb
@@ -97,6 +97,7 @@ class Api::Payment::BraintreeController < PaymentController # rubocop:disable Me
       page_id: params.require(:page_id),
       store_in_vault: store_in_vault?
     }.to_hash.tap do |options|
+      options[:three_d_secure] = three_d_secure? unless recurring?
       options[:device_data] = unsafe_params[:device_data].to_json unless unsafe_params[:device_data].nil?
 
       options[:extra_params] = unsafe_params[:extra_action_fields] if unsafe_params[:extra_action_fields].present?

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -123,6 +123,10 @@ class PaymentController < ApplicationController
     (ActiveRecord::Type::Boolean.new.cast(params[:store_in_vault]) || false) && provider_not_gc
   end
 
+  def three_d_secure?
+    (ActiveRecord::Type::Boolean.new.cast(params[:three_d_secure]) || false) && provider_not_gc
+  end
+
   def provider_not_gc
     params[:provider] != 'GC'
   end

--- a/app/javascript/components/Braintree/BraintreeCardFields.js
+++ b/app/javascript/components/Braintree/BraintreeCardFields.js
@@ -192,6 +192,7 @@ class BraintreeCardFields extends Component {
                 nonce: data.nonce,
                 bin: data.details.bin,
                 amount: donationAmount,
+                challengeRequested: true,
               })
               .then(function(response) {
                 if (

--- a/app/javascript/components/Payment/Payment.js
+++ b/app/javascript/components/Payment/Payment.js
@@ -393,6 +393,10 @@ export class Payment extends Component {
       recaptcha_action,
       ...(data.threeDSecureInfo?.threeDSecureAuthenticationId && {
         authenticationId: data.threeDSecureInfo.threeDSecureAuthenticationId,
+        ...(data.threeDSecureInfo.status != 'unsupported_card' &&
+          data.threeDSecureInfo.liabilityShiftPossible && {
+            three_d_secure: true,
+          }),
       }),
     };
 

--- a/app/lib/payment_processor/braintree/transaction.rb
+++ b/app/lib/payment_processor/braintree/transaction.rb
@@ -23,7 +23,7 @@ module PaymentProcessor
 
       # rubocop:disable Metrics/ParameterLists
       def self.make_transaction(nonce:, amount:, currency:, user:, page_id:,
-                                three_d_secure:, store_in_vault: false, device_data: {}, extra_params: {})
+                                store_in_vault: false, device_data: {}, extra_params: {}, three_d_secure: false)
         builder = new(nonce, amount, currency, user, page_id, store_in_vault, device_data, extra_params, three_d_secure)
         builder.transact
         builder
@@ -31,7 +31,7 @@ module PaymentProcessor
 
       # Long parameter list is doing my head in - let's replace with a parameter object
       def initialize(nonce, amount, currency, user, page_id,
-                     three_d_secure, store_in_vault = false, device_data = {}, extra_params = {})
+                     store_in_vault = false, device_data = {}, extra_params = {}, three_d_secure = false)
         @amount = amount
         @nonce = nonce
         @user = user

--- a/config/locales/member_facing.nl.yml
+++ b/config/locales/member_facing.nl.yml
@@ -113,12 +113,12 @@ nl: # translated 22 July 2021
     thank_you_with_amount: "<strong>Bedankt voor je donatie van %{amount}!</strong> Als je vragen hebt of deze donatie per vergissing hebt gedaan, stuur dan een e-mail naar donations@sumofus.org. "
     recurring_thank_you_with_amount: "<strong>Bedankt voor je terugkerende donatie van  %{amount}!</strong> Als je vragen hebt of deze donatie per vergissing hebt gedaan, stuur dan een e-mail naar donations@sumofus.org."
     
-    bank_rejected_error: "Your bank is unwilling to accept the transaction. Please contact your bank or try with a different payment method."
+    bank_rejected_error: "Je bank is niet bereid de transactie te accepteren. Neem contact op met je bank of probeer het met een andere betaalmethode."
     transaction_declined: "Transaction declined: please verify your information or try with a different payment method."
-    insufficient_funds: "Transaction declined: Insufficient Funds. "
-    expired_card: "Transaction declined: Expired card. "
-    paypal_transaction_declined: "Your PayPal transaction has been declined by the processor or your bank. Please try with a different payment method."
-    try_again: "Please try again with a different payment method."
+    insufficient_funds: "Transactie geweigerd: onvoldoende saldo. "
+    expired_card: "Transactie geweigerd: kaart verlopen. "
+    paypal_transaction_declined: "Je PayPal-transactie is geweigerd door de processor van je bank. Probeer het opnieuw met een andere betaalmethode."
+    try_again: "Probeer het opnieuw met een andere betaalmethode."
     
     card_declined: Je kaart werd geweigerd door de betalingsverwerker. Gelieve een andere betaalmethode te proberen.
     unknown_error: Ons technisch team is op de hoogte gebracht. Gelieve nogmaals je gegevens te controleren of een andere betaalmethode te proberen.

--- a/config/locales/member_facing.pt.yml
+++ b/config/locales/member_facing.pt.yml
@@ -116,12 +116,12 @@ pt:
     thank_you_with_amount: "<strong>Agradecemos a sua doação de %{amount}!</strong> Se tiver qualquer dúvida ou se fez essa doação por engano, por favor, envie um e-mail para donations@sumofus.org."
     recurring_thank_you_with_amount: "<strong>Agradecemos a sua doação recorrente de %{amount}!</strong> Se tiver qualquer dúvida ou se fez essa doação por engano, por favor, envie um e-mail para donations@sumofus.org."
 
-    bank_rejected_error: "Your bank is unwilling to accept the transaction. Please contact your bank or try with a different payment method."
-    transaction_declined: "Transaction declined: please verify your information or try with a different payment method."
-    insufficient_funds: "Transaction declined: Insufficient Funds. "
-    expired_card: "Transaction declined: Expired card. "
-    paypal_transaction_declined: "Your PayPal transaction has been declined by the processor or your bank. Please try with a different payment method."
-    try_again: "Please try again with a different payment method."
+    bank_rejected_error: "Seu banco recusou esta operação. Por favor, entre em contato com seu banco, ou tente outro método de pagamento."
+    transaction_declined: "Transação declinada:  por favor verifique seus dados ou tente outro método de pagamento. "
+    insufficient_funds: "Transação declinada: Fundos insuficientes. "
+    expired_card: "Transação declinada:  Cartão de crédito vencido. "
+    paypal_transaction_declined: "Sua transação do PayPal foi declinada pelo operador ou pelo seu banco. Por favor, tente outro método de pagamento."
+    try_again: "Por favor, tente novamente com outro método de pagamento."
 
     card_declined: Seu cartão foi recusado pelo processador do pagamento. Por favor, tente novamente com um método de pagamento diferente.
     unknown_error: Nossa equipe técnica foi notificada. Por favor, verifique suas informações novamente ou tente um método de pagamento diferente.

--- a/spec/controllers/api/payment/braintree_controller_spec.rb
+++ b/spec/controllers/api/payment/braintree_controller_spec.rb
@@ -61,7 +61,8 @@ describe Api::Payment::BraintreeController do
         user: params[:user],
         currency: params[:currency],
         page_id: params[:page_id],
-        store_in_vault: false
+        store_in_vault: false,
+        three_d_secure: false
       }
     end
 

--- a/spec/controllers/api/payment/braintree_controller_spec.rb
+++ b/spec/controllers/api/payment/braintree_controller_spec.rb
@@ -61,8 +61,7 @@ describe Api::Payment::BraintreeController do
         user: params[:user],
         currency: params[:currency],
         page_id: params[:page_id],
-        store_in_vault: false,
-        three_d_secure: false
+        store_in_vault: false
       }
     end
 
@@ -102,6 +101,7 @@ describe Api::Payment::BraintreeController do
         before :each do
           allow(client::Transaction).to receive(:make_transaction).and_return(builder)
           payment_options[:store_in_vault] = false
+          payment_options[:three_d_secure] = false
           post :transaction, params: params
         end
 
@@ -167,7 +167,7 @@ describe Api::Payment::BraintreeController do
         before :each do
           allow(client::Transaction).to receive(:make_transaction).and_return(builder)
           post :transaction, params: params
-          payment_options.merge!(store_in_vault: false)
+          payment_options.merge!(store_in_vault: false, three_d_secure: false)
         end
 
         it 'calls Transaction.make_transaction' do

--- a/spec/lib/payment_processor/braintree/subscription_spec.rb
+++ b/spec/lib/payment_processor/braintree/subscription_spec.rb
@@ -17,7 +17,8 @@ module PaymentProcessor
               email: 'test@example.com',
               name: 'Bob Loblaw',
               country: 'AU'
-            }
+            },
+            three_d_secure: true
           }
         end
         let(:member) { create(:member, email: 'test@example.com') }

--- a/spec/lib/payment_processor/braintree/subscription_spec.rb
+++ b/spec/lib/payment_processor/braintree/subscription_spec.rb
@@ -17,8 +17,7 @@ module PaymentProcessor
               email: 'test@example.com',
               name: 'Bob Loblaw',
               country: 'AU'
-            },
-            three_d_secure: true
+            }
           }
         end
         let(:member) { create(:member, email: 'test@example.com') }

--- a/spec/lib/payment_processor/braintree/transaction_spec.rb
+++ b/spec/lib/payment_processor/braintree/transaction_spec.rb
@@ -26,7 +26,8 @@ module PaymentProcessor
             currency: 'USD',
             user: { email: 'test@example.com', name: 'Bob' },
             page_id: 1,
-            device_data: { foo: 'bar' }
+            device_data: { foo: 'bar' },
+            three_d_secure: true
           }
         end
 
@@ -49,7 +50,8 @@ module PaymentProcessor
             device_data: { foo: 'bar' },
             options: {
               submit_for_settlement: true,
-              store_in_vault_on_success: false
+              store_in_vault_on_success: false,
+              three_d_secure: { required: true }
             },
             customer: {
               first_name: 'Bob',

--- a/spec/lib/payment_processor/braintree/transaction_spec.rb
+++ b/spec/lib/payment_processor/braintree/transaction_spec.rb
@@ -27,7 +27,7 @@ module PaymentProcessor
             user: { email: 'test@example.com', name: 'Bob' },
             page_id: 1,
             device_data: { foo: 'bar' },
-            three_d_secure: true
+            three_d_secure: false
           }
         end
 
@@ -51,7 +51,7 @@ module PaymentProcessor
             options: {
               submit_for_settlement: true,
               store_in_vault_on_success: false,
-              three_d_secure: { required: true }
+              three_d_secure: { required: false }
             },
             customer: {
               first_name: 'Bob',

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -668,7 +668,7 @@ describe 'Braintree API' do
                                                                             options: {
                                                                               submit_for_settlement: true,
                                                                               store_in_vault_on_success: true,
-                                                                              three_d_secure: { required: false }
+                                                                              three_d_secure: { required: true }
                                                                             },
                                                                             customer: {
                                                                               first_name: 'Bernie',

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -667,7 +667,8 @@ describe 'Braintree API' do
                                                                             device_data: {},
                                                                             options: {
                                                                               submit_for_settlement: true,
-                                                                              store_in_vault_on_success: true
+                                                                              store_in_vault_on_success: true,
+                                                                              three_d_secure: { required: false }
                                                                             },
                                                                             customer: {
                                                                               first_name: 'Bernie',
@@ -877,7 +878,8 @@ describe 'Braintree API' do
                                                                             device_data: {},
                                                                             options: {
                                                                               submit_for_settlement: true,
-                                                                              store_in_vault_on_success: true
+                                                                              store_in_vault_on_success: true,
+                                                                              three_d_secure: { required: false }
                                                                             },
                                                                             customer: {
                                                                               first_name: 'Bernie',

--- a/spec/requests/api/braintree/braintree_spec.rb
+++ b/spec/requests/api/braintree/braintree_spec.rb
@@ -668,7 +668,7 @@ describe 'Braintree API' do
                                                                             options: {
                                                                               submit_for_settlement: true,
                                                                               store_in_vault_on_success: true,
-                                                                              three_d_secure: { required: true }
+                                                                              three_d_secure: { required: false }
                                                                             },
                                                                             customer: {
                                                                               first_name: 'Bernie',


### PR DESCRIPTION
### Overview
* Braintree does not support 3DS for all the card types, and it might return an error when calling the `verifyCard` method with a `status = unsupported_card`
    * This can happen for some Maestro and Discover cards or even some Amex cards.
        * In production, we do not have 3DS verification for USD currency. However, this PR will prevent errors when Braintree enrolls us for 3DS on the USD merchant account.
* This error was discovered while investigating a failed sandbox discover card on prosecco. 
* I also included, as part of this work, the addition of `challengeRequested: true` on the `verifyCard` method to prevent saving payment methods and/or creating subscriptions without 3DS verification and then getting soft declines for subsequent payments. 
    * https://developer.paypal.com/braintree/docs/guides/3d-secure/migration/javascript/v3#recurring-transactions 

### References
https://github.com/braintree/braintree-web-drop-in/issues/813

### Ticket
https://app.asana.com/0/1119304937718815/1203493022913236/f